### PR TITLE
fix(swift): reduce subclient initializer access level to internal

### DIFF
--- a/generators/swift/base/src/asIs/HTTPClient.swift
+++ b/generators/swift/base/src/asIs/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/generators/swift/base/src/asIs/RequestOptions.swift
+++ b/generators/swift/base/src/asIs/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/generators/swift/sdk/src/generators/client/SubClientGenerator.ts
+++ b/generators/swift/sdk/src/generators/client/SubClientGenerator.ts
@@ -52,7 +52,6 @@ export class SubClientGenerator {
 
     private generateInitializer(): swift.Initializer {
         return swift.initializer({
-            accessLevel: swift.AccessLevel.Public,
             parameters: [
                 swift.functionParameter({
                     argumentLabel: "config",

--- a/generators/swift/sdk/versions.yml
+++ b/generators/swift/sdk/versions.yml
@@ -4,7 +4,7 @@
   changelogEntry:
     - type: fix
       summary: |
-        Reduce subclient class initializer access level to internal.
+        Reduced subclient class initializer access level to internal.
   createdAt: "2025-10-04"
   irVersion: 59
 
@@ -12,7 +12,7 @@
   changelogEntry:
     - type: fix
       summary: |
-        Upgrade generator-cli dependency to fix local generation handling of .fernignore files.
+        Upgraded generator-cli dependency to fix local generation handling of .fernignore files.
   createdAt: "2025-09-30"
   irVersion: 60
 
@@ -36,7 +36,7 @@
   changelogEntry:
     - type: feat
       summary: |
-        Add support for custom sections in the README.md via `customSections` config option.
+        Added support for custom sections in the README.md via `customSections` config option.
   createdAt: "2025-09-18"
   irVersion: 59
 

--- a/generators/swift/sdk/versions.yml
+++ b/generators/swift/sdk/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.17.3
+  changelogEntry:
+    - type: fix
+      summary: |
+        Reduce subclient class initializer access level to internal.
+  createdAt: "2025-10-04"
+  irVersion: 59
+
 - version: 0.17.2
   changelogEntry:
     - type: fix

--- a/seed/swift-sdk/accept-header/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/accept-header/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/accept-header/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/accept-header/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/accept-header/Sources/Resources/Service/ServiceClient.swift
+++ b/seed/swift-sdk/accept-header/Sources/Resources/Service/ServiceClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ServiceClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/alias-extends/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/alias-extends/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/alias-extends/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/alias-extends/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/alias/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/alias/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/alias/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/alias/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/any-auth/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/any-auth/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/any-auth/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/any-auth/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/any-auth/Sources/Resources/Auth/AuthClient.swift
+++ b/seed/swift-sdk/any-auth/Sources/Resources/Auth/AuthClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class AuthClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/any-auth/Sources/Resources/User/UserClient.swift
+++ b/seed/swift-sdk/any-auth/Sources/Resources/User/UserClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class UserClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/api-wide-base-path/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/api-wide-base-path/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/api-wide-base-path/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/api-wide-base-path/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/api-wide-base-path/Sources/Resources/Service/ServiceClient.swift
+++ b/seed/swift-sdk/api-wide-base-path/Sources/Resources/Service/ServiceClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ServiceClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/audiences/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/audiences/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/audiences/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/audiences/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/audiences/Sources/Resources/Commons/CommonsClient.swift
+++ b/seed/swift-sdk/audiences/Sources/Resources/Commons/CommonsClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class CommonsClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 }

--- a/seed/swift-sdk/audiences/Sources/Resources/FolderA/FolderAClient.swift
+++ b/seed/swift-sdk/audiences/Sources/Resources/FolderA/FolderAClient.swift
@@ -4,7 +4,7 @@ public final class FolderAClient: Sendable {
     public let service: ServiceClient
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.service = ServiceClient(config: config)
         self.httpClient = HTTPClient(config: config)
     }

--- a/seed/swift-sdk/audiences/Sources/Resources/FolderA/Service/ServiceClient.swift
+++ b/seed/swift-sdk/audiences/Sources/Resources/FolderA/Service/ServiceClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ServiceClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/audiences/Sources/Resources/FolderB/Common/CommonClient.swift
+++ b/seed/swift-sdk/audiences/Sources/Resources/FolderB/Common/CommonClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class CommonClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 }

--- a/seed/swift-sdk/audiences/Sources/Resources/FolderB/FolderBClient.swift
+++ b/seed/swift-sdk/audiences/Sources/Resources/FolderB/FolderBClient.swift
@@ -4,7 +4,7 @@ public final class FolderBClient: Sendable {
     public let common: CommonClient
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.common = CommonClient(config: config)
         self.httpClient = HTTPClient(config: config)
     }

--- a/seed/swift-sdk/audiences/Sources/Resources/FolderC/Common/FolderCCommonClient.swift
+++ b/seed/swift-sdk/audiences/Sources/Resources/FolderC/Common/FolderCCommonClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class FolderCCommonClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 }

--- a/seed/swift-sdk/audiences/Sources/Resources/FolderC/FolderCClient.swift
+++ b/seed/swift-sdk/audiences/Sources/Resources/FolderC/FolderCClient.swift
@@ -4,7 +4,7 @@ public final class FolderCClient: Sendable {
     public let common: FolderCCommonClient
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.common = FolderCCommonClient(config: config)
         self.httpClient = HTTPClient(config: config)
     }

--- a/seed/swift-sdk/audiences/Sources/Resources/FolderD/FolderDClient.swift
+++ b/seed/swift-sdk/audiences/Sources/Resources/FolderD/FolderDClient.swift
@@ -4,7 +4,7 @@ public final class FolderDClient: Sendable {
     public let service: FolderDServiceClient
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.service = FolderDServiceClient(config: config)
         self.httpClient = HTTPClient(config: config)
     }

--- a/seed/swift-sdk/audiences/Sources/Resources/FolderD/Service/FolderDServiceClient.swift
+++ b/seed/swift-sdk/audiences/Sources/Resources/FolderD/Service/FolderDServiceClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class FolderDServiceClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/audiences/Sources/Resources/Foo/FooClient.swift
+++ b/seed/swift-sdk/audiences/Sources/Resources/Foo/FooClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class FooClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/auth-environment-variables/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/auth-environment-variables/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/auth-environment-variables/Sources/Resources/Service/ServiceClient.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/Resources/Service/ServiceClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ServiceClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/Resources/BasicAuth/BasicAuthClient.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/Resources/BasicAuth/BasicAuthClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class BasicAuthClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/Resources/Errors/ErrorsClient.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/Resources/Errors/ErrorsClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ErrorsClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 }

--- a/seed/swift-sdk/basic-auth/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/basic-auth/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/basic-auth/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/basic-auth/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/basic-auth/Sources/Resources/BasicAuth/BasicAuthClient_.swift
+++ b/seed/swift-sdk/basic-auth/Sources/Resources/BasicAuth/BasicAuthClient_.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class BasicAuthClient_: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/basic-auth/Sources/Resources/Errors/ErrorsClient.swift
+++ b/seed/swift-sdk/basic-auth/Sources/Resources/Errors/ErrorsClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ErrorsClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 }

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/Resources/Service/ServiceClient.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/Resources/Service/ServiceClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ServiceClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/bytes-download/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/bytes-download/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/bytes-download/Sources/Resources/Service/ServiceClient.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Resources/Service/ServiceClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ServiceClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/bytes-upload/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/bytes-upload/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/bytes-upload/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/bytes-upload/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/bytes-upload/Sources/Resources/Service/ServiceClient.swift
+++ b/seed/swift-sdk/bytes-upload/Sources/Resources/Service/ServiceClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ServiceClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/circular-references-advanced/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/circular-references-advanced/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/circular-references-advanced/Sources/Resources/A/AClient.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Resources/A/AClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class AClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 }

--- a/seed/swift-sdk/circular-references-advanced/Sources/Resources/Ast/AstClient.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Resources/Ast/AstClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class AstClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 }

--- a/seed/swift-sdk/circular-references/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/circular-references/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/circular-references/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/circular-references/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/circular-references/Sources/Resources/A/AClient.swift
+++ b/seed/swift-sdk/circular-references/Sources/Resources/A/AClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class AClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 }

--- a/seed/swift-sdk/circular-references/Sources/Resources/Ast/AstClient.swift
+++ b/seed/swift-sdk/circular-references/Sources/Resources/Ast/AstClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class AstClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 }

--- a/seed/swift-sdk/client-side-params/no-custom-config/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/client-side-params/no-custom-config/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/client-side-params/no-custom-config/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/client-side-params/no-custom-config/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/client-side-params/no-custom-config/Sources/Resources/Service/ServiceClient.swift
+++ b/seed/swift-sdk/client-side-params/no-custom-config/Sources/Resources/Service/ServiceClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ServiceClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/client-side-params/no-custom-config/Sources/Resources/Types/TypesClient.swift
+++ b/seed/swift-sdk/client-side-params/no-custom-config/Sources/Resources/Types/TypesClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class TypesClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 }

--- a/seed/swift-sdk/client-side-params/with-custom-config/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/client-side-params/with-custom-config/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/client-side-params/with-custom-config/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/client-side-params/with-custom-config/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/client-side-params/with-custom-config/Sources/Resources/Service/ServiceClient.swift
+++ b/seed/swift-sdk/client-side-params/with-custom-config/Sources/Resources/Service/ServiceClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ServiceClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/client-side-params/with-custom-config/Sources/Resources/Types/TypesClient.swift
+++ b/seed/swift-sdk/client-side-params/with-custom-config/Sources/Resources/Types/TypesClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class TypesClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 }

--- a/seed/swift-sdk/content-type/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/content-type/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/content-type/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/content-type/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/content-type/Sources/Resources/Service/ServiceClient.swift
+++ b/seed/swift-sdk/content-type/Sources/Resources/Service/ServiceClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ServiceClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/cross-package-type-names/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/cross-package-type-names/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/cross-package-type-names/Sources/Resources/Commons/CommonsClient.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Resources/Commons/CommonsClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class CommonsClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 }

--- a/seed/swift-sdk/cross-package-type-names/Sources/Resources/FolderA/FolderAClient.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Resources/FolderA/FolderAClient.swift
@@ -4,7 +4,7 @@ public final class FolderAClient: Sendable {
     public let service: ServiceClient
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.service = ServiceClient(config: config)
         self.httpClient = HTTPClient(config: config)
     }

--- a/seed/swift-sdk/cross-package-type-names/Sources/Resources/FolderA/Service/ServiceClient.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Resources/FolderA/Service/ServiceClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ServiceClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/cross-package-type-names/Sources/Resources/FolderB/Common/CommonClient.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Resources/FolderB/Common/CommonClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class CommonClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 }

--- a/seed/swift-sdk/cross-package-type-names/Sources/Resources/FolderB/FolderBClient.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Resources/FolderB/FolderBClient.swift
@@ -4,7 +4,7 @@ public final class FolderBClient: Sendable {
     public let common: CommonClient
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.common = CommonClient(config: config)
         self.httpClient = HTTPClient(config: config)
     }

--- a/seed/swift-sdk/cross-package-type-names/Sources/Resources/FolderC/Common/FolderCCommonClient.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Resources/FolderC/Common/FolderCCommonClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class FolderCCommonClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 }

--- a/seed/swift-sdk/cross-package-type-names/Sources/Resources/FolderC/FolderCClient.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Resources/FolderC/FolderCClient.swift
@@ -4,7 +4,7 @@ public final class FolderCClient: Sendable {
     public let common: FolderCCommonClient
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.common = FolderCCommonClient(config: config)
         self.httpClient = HTTPClient(config: config)
     }

--- a/seed/swift-sdk/cross-package-type-names/Sources/Resources/FolderD/FolderDClient.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Resources/FolderD/FolderDClient.swift
@@ -4,7 +4,7 @@ public final class FolderDClient: Sendable {
     public let service: FolderDServiceClient
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.service = FolderDServiceClient(config: config)
         self.httpClient = HTTPClient(config: config)
     }

--- a/seed/swift-sdk/cross-package-type-names/Sources/Resources/FolderD/Service/FolderDServiceClient.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Resources/FolderD/Service/FolderDServiceClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class FolderDServiceClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/cross-package-type-names/Sources/Resources/Foo/FooClient.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Resources/Foo/FooClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class FooClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/custom-auth/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/custom-auth/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/custom-auth/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/custom-auth/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/custom-auth/Sources/Resources/CustomAuth/CustomAuthClient_.swift
+++ b/seed/swift-sdk/custom-auth/Sources/Resources/CustomAuth/CustomAuthClient_.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class CustomAuthClient_: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/custom-auth/Sources/Resources/Errors/ErrorsClient.swift
+++ b/seed/swift-sdk/custom-auth/Sources/Resources/Errors/ErrorsClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ErrorsClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 }

--- a/seed/swift-sdk/empty-clients/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/empty-clients/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/empty-clients/Sources/Resources/Level1/Level1Client.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Resources/Level1/Level1Client.swift
@@ -5,7 +5,7 @@ public final class Level1Client: Sendable {
     public let types: Level1TypesClient
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.level2 = Level2Client(config: config)
         self.types = Level1TypesClient(config: config)
         self.httpClient = HTTPClient(config: config)

--- a/seed/swift-sdk/empty-clients/Sources/Resources/Level1/Level2/Level2Client.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Resources/Level1/Level2/Level2Client.swift
@@ -4,7 +4,7 @@ public final class Level2Client: Sendable {
     public let types: TypesClient
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.types = TypesClient(config: config)
         self.httpClient = HTTPClient(config: config)
     }

--- a/seed/swift-sdk/empty-clients/Sources/Resources/Level1/Level2/Types/TypesClient.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Resources/Level1/Level2/Types/TypesClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class TypesClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 }

--- a/seed/swift-sdk/empty-clients/Sources/Resources/Level1/Types/Level1TypesClient.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Resources/Level1/Types/Level1TypesClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class Level1TypesClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 }

--- a/seed/swift-sdk/enum/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/enum/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/enum/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/enum/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/enum/Sources/Resources/Headers/HeadersClient.swift
+++ b/seed/swift-sdk/enum/Sources/Resources/Headers/HeadersClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class HeadersClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/enum/Sources/Resources/InlinedRequest/InlinedRequestClient.swift
+++ b/seed/swift-sdk/enum/Sources/Resources/InlinedRequest/InlinedRequestClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class InlinedRequestClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/enum/Sources/Resources/PathParam/PathParamClient.swift
+++ b/seed/swift-sdk/enum/Sources/Resources/PathParam/PathParamClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class PathParamClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/enum/Sources/Resources/QueryParam/QueryParamClient.swift
+++ b/seed/swift-sdk/enum/Sources/Resources/QueryParam/QueryParamClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class QueryParamClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/enum/Sources/Resources/Unknown/UnknownClient.swift
+++ b/seed/swift-sdk/enum/Sources/Resources/Unknown/UnknownClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class UnknownClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 }

--- a/seed/swift-sdk/error-property/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/error-property/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/error-property/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/error-property/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/error-property/Sources/Resources/Errors/ErrorsClient.swift
+++ b/seed/swift-sdk/error-property/Sources/Resources/Errors/ErrorsClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ErrorsClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 }

--- a/seed/swift-sdk/error-property/Sources/Resources/PropertyBasedError/PropertyBasedErrorClient.swift
+++ b/seed/swift-sdk/error-property/Sources/Resources/PropertyBasedError/PropertyBasedErrorClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class PropertyBasedErrorClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/errors/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/errors/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/errors/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/errors/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/errors/Sources/Resources/Commons/CommonsClient.swift
+++ b/seed/swift-sdk/errors/Sources/Resources/Commons/CommonsClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class CommonsClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 }

--- a/seed/swift-sdk/errors/Sources/Resources/Simple/SimpleClient.swift
+++ b/seed/swift-sdk/errors/Sources/Resources/Simple/SimpleClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class SimpleClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/examples/no-custom-config/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/examples/no-custom-config/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/examples/no-custom-config/Sources/Resources/Commons/CommonsClient.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Sources/Resources/Commons/CommonsClient.swift
@@ -4,7 +4,7 @@ public final class CommonsClient: Sendable {
     public let types: TypesClient
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.types = TypesClient(config: config)
         self.httpClient = HTTPClient(config: config)
     }

--- a/seed/swift-sdk/examples/no-custom-config/Sources/Resources/Commons/Types/TypesClient.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Sources/Resources/Commons/Types/TypesClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class TypesClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 }

--- a/seed/swift-sdk/examples/no-custom-config/Sources/Resources/File/FileClient.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Sources/Resources/File/FileClient.swift
@@ -5,7 +5,7 @@ public final class FileClient: Sendable {
     public let service: FileServiceClient
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.notification = NotificationClient(config: config)
         self.service = FileServiceClient(config: config)
         self.httpClient = HTTPClient(config: config)

--- a/seed/swift-sdk/examples/no-custom-config/Sources/Resources/File/Notification/NotificationClient.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Sources/Resources/File/Notification/NotificationClient.swift
@@ -4,7 +4,7 @@ public final class NotificationClient: Sendable {
     public let service: ServiceClient
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.service = ServiceClient(config: config)
         self.httpClient = HTTPClient(config: config)
     }

--- a/seed/swift-sdk/examples/no-custom-config/Sources/Resources/File/Notification/Service/ServiceClient.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Sources/Resources/File/Notification/Service/ServiceClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ServiceClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/examples/no-custom-config/Sources/Resources/File/Service/FileServiceClient.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Sources/Resources/File/Service/FileServiceClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class FileServiceClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/examples/no-custom-config/Sources/Resources/Health/HealthClient.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Sources/Resources/Health/HealthClient.swift
@@ -4,7 +4,7 @@ public final class HealthClient: Sendable {
     public let service: HealthServiceClient
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.service = HealthServiceClient(config: config)
         self.httpClient = HTTPClient(config: config)
     }

--- a/seed/swift-sdk/examples/no-custom-config/Sources/Resources/Health/Service/HealthServiceClient.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Sources/Resources/Health/Service/HealthServiceClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class HealthServiceClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/examples/no-custom-config/Sources/Resources/Service/ServiceClient_.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Sources/Resources/Service/ServiceClient_.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ServiceClient_: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/examples/no-custom-config/Sources/Resources/Types/TypesClient_.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Sources/Resources/Types/TypesClient_.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class TypesClient_: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 }

--- a/seed/swift-sdk/examples/readme-config/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/examples/readme-config/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/examples/readme-config/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/examples/readme-config/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/examples/readme-config/Sources/Resources/Commons/CommonsClient.swift
+++ b/seed/swift-sdk/examples/readme-config/Sources/Resources/Commons/CommonsClient.swift
@@ -4,7 +4,7 @@ public final class CommonsClient: Sendable {
     public let types: TypesClient
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.types = TypesClient(config: config)
         self.httpClient = HTTPClient(config: config)
     }

--- a/seed/swift-sdk/examples/readme-config/Sources/Resources/Commons/Types/TypesClient.swift
+++ b/seed/swift-sdk/examples/readme-config/Sources/Resources/Commons/Types/TypesClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class TypesClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 }

--- a/seed/swift-sdk/examples/readme-config/Sources/Resources/File/FileClient.swift
+++ b/seed/swift-sdk/examples/readme-config/Sources/Resources/File/FileClient.swift
@@ -5,7 +5,7 @@ public final class FileClient: Sendable {
     public let service: FileServiceClient
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.notification = NotificationClient(config: config)
         self.service = FileServiceClient(config: config)
         self.httpClient = HTTPClient(config: config)

--- a/seed/swift-sdk/examples/readme-config/Sources/Resources/File/Notification/NotificationClient.swift
+++ b/seed/swift-sdk/examples/readme-config/Sources/Resources/File/Notification/NotificationClient.swift
@@ -4,7 +4,7 @@ public final class NotificationClient: Sendable {
     public let service: ServiceClient
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.service = ServiceClient(config: config)
         self.httpClient = HTTPClient(config: config)
     }

--- a/seed/swift-sdk/examples/readme-config/Sources/Resources/File/Notification/Service/ServiceClient.swift
+++ b/seed/swift-sdk/examples/readme-config/Sources/Resources/File/Notification/Service/ServiceClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ServiceClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/examples/readme-config/Sources/Resources/File/Service/FileServiceClient.swift
+++ b/seed/swift-sdk/examples/readme-config/Sources/Resources/File/Service/FileServiceClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class FileServiceClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/examples/readme-config/Sources/Resources/Health/HealthClient.swift
+++ b/seed/swift-sdk/examples/readme-config/Sources/Resources/Health/HealthClient.swift
@@ -4,7 +4,7 @@ public final class HealthClient: Sendable {
     public let service: HealthServiceClient
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.service = HealthServiceClient(config: config)
         self.httpClient = HTTPClient(config: config)
     }

--- a/seed/swift-sdk/examples/readme-config/Sources/Resources/Health/Service/HealthServiceClient.swift
+++ b/seed/swift-sdk/examples/readme-config/Sources/Resources/Health/Service/HealthServiceClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class HealthServiceClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/examples/readme-config/Sources/Resources/Service/ServiceClient_.swift
+++ b/seed/swift-sdk/examples/readme-config/Sources/Resources/Service/ServiceClient_.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ServiceClient_: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/examples/readme-config/Sources/Resources/Types/TypesClient_.swift
+++ b/seed/swift-sdk/examples/readme-config/Sources/Resources/Types/TypesClient_.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class TypesClient_: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 }

--- a/seed/swift-sdk/exhaustive/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/exhaustive/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/exhaustive/Sources/Resources/Endpoints/Container/ContainerClient.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Resources/Endpoints/Container/ContainerClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ContainerClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/exhaustive/Sources/Resources/Endpoints/ContentType/ContentTypeClient.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Resources/Endpoints/ContentType/ContentTypeClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ContentTypeClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/exhaustive/Sources/Resources/Endpoints/EndpointsClient.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Resources/Endpoints/EndpointsClient.swift
@@ -13,7 +13,7 @@ public final class EndpointsClient: Sendable {
     public let urls: UrlsClient
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.container = ContainerClient(config: config)
         self.contentType = ContentTypeClient(config: config)
         self.enum = EnumClient(config: config)

--- a/seed/swift-sdk/exhaustive/Sources/Resources/Endpoints/Enum/EnumClient.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Resources/Endpoints/Enum/EnumClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class EnumClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/exhaustive/Sources/Resources/Endpoints/HttpMethods/HttpMethodsClient.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Resources/Endpoints/HttpMethods/HttpMethodsClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class HttpMethodsClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/exhaustive/Sources/Resources/Endpoints/Object/ObjectClient.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Resources/Endpoints/Object/ObjectClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ObjectClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/exhaustive/Sources/Resources/Endpoints/Params/ParamsClient.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Resources/Endpoints/Params/ParamsClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ParamsClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/exhaustive/Sources/Resources/Endpoints/Primitive/PrimitiveClient.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Resources/Endpoints/Primitive/PrimitiveClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class PrimitiveClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/exhaustive/Sources/Resources/Endpoints/Put/PutClient.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Resources/Endpoints/Put/PutClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class PutClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/exhaustive/Sources/Resources/Endpoints/Union/UnionClient.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Resources/Endpoints/Union/UnionClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class UnionClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/exhaustive/Sources/Resources/Endpoints/Urls/UrlsClient.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Resources/Endpoints/Urls/UrlsClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class UrlsClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/exhaustive/Sources/Resources/GeneralErrors/GeneralErrorsClient.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Resources/GeneralErrors/GeneralErrorsClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class GeneralErrorsClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 }

--- a/seed/swift-sdk/exhaustive/Sources/Resources/InlinedRequests/InlinedRequestsClient.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Resources/InlinedRequests/InlinedRequestsClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class InlinedRequestsClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/exhaustive/Sources/Resources/NoAuth/NoAuthClient.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Resources/NoAuth/NoAuthClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class NoAuthClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/exhaustive/Sources/Resources/NoReqBody/NoReqBodyClient.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Resources/NoReqBody/NoReqBodyClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class NoReqBodyClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/exhaustive/Sources/Resources/ReqWithHeaders/ReqWithHeadersClient.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Resources/ReqWithHeaders/ReqWithHeadersClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ReqWithHeadersClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/exhaustive/Sources/Resources/Types/Docs/DocsClient.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Resources/Types/Docs/DocsClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class DocsClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 }

--- a/seed/swift-sdk/exhaustive/Sources/Resources/Types/Enum/TypesEnumClient.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Resources/Types/Enum/TypesEnumClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class TypesEnumClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 }

--- a/seed/swift-sdk/exhaustive/Sources/Resources/Types/Object/TypesObjectClient.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Resources/Types/Object/TypesObjectClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class TypesObjectClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 }

--- a/seed/swift-sdk/exhaustive/Sources/Resources/Types/TypesClient.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Resources/Types/TypesClient.swift
@@ -7,7 +7,7 @@ public final class TypesClient: Sendable {
     public let union: TypesUnionClient
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.docs = DocsClient(config: config)
         self.enum = TypesEnumClient(config: config)
         self.object = TypesObjectClient(config: config)

--- a/seed/swift-sdk/exhaustive/Sources/Resources/Types/Union/TypesUnionClient.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Resources/Types/Union/TypesUnionClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class TypesUnionClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 }

--- a/seed/swift-sdk/extends/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/extends/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/extends/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/extends/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/extra-properties/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/extra-properties/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/extra-properties/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/extra-properties/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/extra-properties/Sources/Resources/User/UserClient.swift
+++ b/seed/swift-sdk/extra-properties/Sources/Resources/User/UserClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class UserClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/file-download/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/file-download/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/file-download/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/file-download/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/file-download/Sources/Resources/Service/ServiceClient.swift
+++ b/seed/swift-sdk/file-download/Sources/Resources/Service/ServiceClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ServiceClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/file-upload/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/file-upload/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/file-upload/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/file-upload/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/file-upload/Sources/Resources/Service/ServiceClient.swift
+++ b/seed/swift-sdk/file-upload/Sources/Resources/Service/ServiceClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ServiceClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/folders/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/folders/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/folders/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/folders/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/folders/Sources/Resources/A/AClient.swift
+++ b/seed/swift-sdk/folders/Sources/Resources/A/AClient.swift
@@ -6,7 +6,7 @@ public final class AClient: Sendable {
     public let d: DClient
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.b = BClient(config: config)
         self.c = CClient(config: config)
         self.d = DClient(config: config)

--- a/seed/swift-sdk/folders/Sources/Resources/A/B/BClient.swift
+++ b/seed/swift-sdk/folders/Sources/Resources/A/B/BClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class BClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/folders/Sources/Resources/A/C/CClient.swift
+++ b/seed/swift-sdk/folders/Sources/Resources/A/C/CClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class CClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/folders/Sources/Resources/A/D/DClient.swift
+++ b/seed/swift-sdk/folders/Sources/Resources/A/D/DClient.swift
@@ -4,7 +4,7 @@ public final class DClient: Sendable {
     public let types: TypesClient
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.types = TypesClient(config: config)
         self.httpClient = HTTPClient(config: config)
     }

--- a/seed/swift-sdk/folders/Sources/Resources/A/D/Types/TypesClient.swift
+++ b/seed/swift-sdk/folders/Sources/Resources/A/D/Types/TypesClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class TypesClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 }

--- a/seed/swift-sdk/folders/Sources/Resources/Folder/FolderClient.swift
+++ b/seed/swift-sdk/folders/Sources/Resources/Folder/FolderClient.swift
@@ -4,7 +4,7 @@ public final class FolderClient: Sendable {
     public let service: ServiceClient
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.service = ServiceClient(config: config)
         self.httpClient = HTTPClient(config: config)
     }

--- a/seed/swift-sdk/folders/Sources/Resources/Folder/Service/ServiceClient.swift
+++ b/seed/swift-sdk/folders/Sources/Resources/Folder/Service/ServiceClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ServiceClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/http-head/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/http-head/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/http-head/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/http-head/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/http-head/Sources/Resources/User/UserClient.swift
+++ b/seed/swift-sdk/http-head/Sources/Resources/User/UserClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class UserClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/idempotency-headers/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/idempotency-headers/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/idempotency-headers/Sources/Resources/Payment/PaymentClient.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/Resources/Payment/PaymentClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class PaymentClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/imdb/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/imdb/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/imdb/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/imdb/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/imdb/Sources/Resources/Imdb/ImdbClient.swift
+++ b/seed/swift-sdk/imdb/Sources/Resources/Imdb/ImdbClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ImdbClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/inferred-auth-explicit/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/inferred-auth-explicit/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/inferred-auth-explicit/Sources/Resources/Auth/AuthClient.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Sources/Resources/Auth/AuthClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class AuthClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/inferred-auth-explicit/Sources/Resources/Nested/Api/NestedApiClient.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Sources/Resources/Nested/Api/NestedApiClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class NestedApiClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/inferred-auth-explicit/Sources/Resources/Nested/NestedClient.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Sources/Resources/Nested/NestedClient.swift
@@ -4,7 +4,7 @@ public final class NestedClient: Sendable {
     public let api: NestedApiClient
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.api = NestedApiClient(config: config)
         self.httpClient = HTTPClient(config: config)
     }

--- a/seed/swift-sdk/inferred-auth-explicit/Sources/Resources/NestedNoAuth/Api/ApiClient.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Sources/Resources/NestedNoAuth/Api/ApiClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ApiClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/inferred-auth-explicit/Sources/Resources/NestedNoAuth/NestedNoAuthClient.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Sources/Resources/NestedNoAuth/NestedNoAuthClient.swift
@@ -4,7 +4,7 @@ public final class NestedNoAuthClient: Sendable {
     public let api: ApiClient
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.api = ApiClient(config: config)
         self.httpClient = HTTPClient(config: config)
     }

--- a/seed/swift-sdk/inferred-auth-explicit/Sources/Resources/Simple/SimpleClient.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Sources/Resources/Simple/SimpleClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class SimpleClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Resources/Auth/AuthClient.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Resources/Auth/AuthClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class AuthClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Resources/Nested/Api/NestedApiClient.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Resources/Nested/Api/NestedApiClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class NestedApiClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Resources/Nested/NestedClient.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Resources/Nested/NestedClient.swift
@@ -4,7 +4,7 @@ public final class NestedClient: Sendable {
     public let api: NestedApiClient
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.api = NestedApiClient(config: config)
         self.httpClient = HTTPClient(config: config)
     }

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Resources/NestedNoAuth/Api/ApiClient.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Resources/NestedNoAuth/Api/ApiClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ApiClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Resources/NestedNoAuth/NestedNoAuthClient.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Resources/NestedNoAuth/NestedNoAuthClient.swift
@@ -4,7 +4,7 @@ public final class NestedNoAuthClient: Sendable {
     public let api: ApiClient
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.api = ApiClient(config: config)
         self.httpClient = HTTPClient(config: config)
     }

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Resources/Simple/SimpleClient.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Resources/Simple/SimpleClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class SimpleClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/inferred-auth-implicit/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/inferred-auth-implicit/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/inferred-auth-implicit/Sources/Resources/Auth/AuthClient.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Sources/Resources/Auth/AuthClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class AuthClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/inferred-auth-implicit/Sources/Resources/Nested/Api/NestedApiClient.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Sources/Resources/Nested/Api/NestedApiClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class NestedApiClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/inferred-auth-implicit/Sources/Resources/Nested/NestedClient.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Sources/Resources/Nested/NestedClient.swift
@@ -4,7 +4,7 @@ public final class NestedClient: Sendable {
     public let api: NestedApiClient
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.api = NestedApiClient(config: config)
         self.httpClient = HTTPClient(config: config)
     }

--- a/seed/swift-sdk/inferred-auth-implicit/Sources/Resources/NestedNoAuth/Api/ApiClient.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Sources/Resources/NestedNoAuth/Api/ApiClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ApiClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/inferred-auth-implicit/Sources/Resources/NestedNoAuth/NestedNoAuthClient.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Sources/Resources/NestedNoAuth/NestedNoAuthClient.swift
@@ -4,7 +4,7 @@ public final class NestedNoAuthClient: Sendable {
     public let api: ApiClient
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.api = ApiClient(config: config)
         self.httpClient = HTTPClient(config: config)
     }

--- a/seed/swift-sdk/inferred-auth-implicit/Sources/Resources/Simple/SimpleClient.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Sources/Resources/Simple/SimpleClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class SimpleClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/license/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/license/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/license/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/license/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/literal/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/literal/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/literal/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/literal/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/literal/Sources/Resources/Headers/HeadersClient.swift
+++ b/seed/swift-sdk/literal/Sources/Resources/Headers/HeadersClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class HeadersClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/literal/Sources/Resources/Inlined/InlinedClient.swift
+++ b/seed/swift-sdk/literal/Sources/Resources/Inlined/InlinedClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class InlinedClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/literal/Sources/Resources/Path/PathClient.swift
+++ b/seed/swift-sdk/literal/Sources/Resources/Path/PathClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class PathClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/literal/Sources/Resources/Query/QueryClient.swift
+++ b/seed/swift-sdk/literal/Sources/Resources/Query/QueryClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class QueryClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/literal/Sources/Resources/Reference/ReferenceClient.swift
+++ b/seed/swift-sdk/literal/Sources/Resources/Reference/ReferenceClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ReferenceClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/literals-unions/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/literals-unions/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/literals-unions/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/literals-unions/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/literals-unions/Sources/Resources/Literals/LiteralsClient.swift
+++ b/seed/swift-sdk/literals-unions/Sources/Resources/Literals/LiteralsClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class LiteralsClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 }

--- a/seed/swift-sdk/mixed-case/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/mixed-case/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/mixed-case/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/mixed-case/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/mixed-case/Sources/Resources/Service/ServiceClient.swift
+++ b/seed/swift-sdk/mixed-case/Sources/Resources/Service/ServiceClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ServiceClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/mixed-file-directory/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/mixed-file-directory/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/mixed-file-directory/Sources/Resources/Organization/OrganizationClient.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/Resources/Organization/OrganizationClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class OrganizationClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/mixed-file-directory/Sources/Resources/User/Events/EventsClient.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/Resources/User/Events/EventsClient.swift
@@ -4,7 +4,7 @@ public final class EventsClient: Sendable {
     public let metadata: MetadataClient
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.metadata = MetadataClient(config: config)
         self.httpClient = HTTPClient(config: config)
     }

--- a/seed/swift-sdk/mixed-file-directory/Sources/Resources/User/Events/Metadata/MetadataClient.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/Resources/User/Events/Metadata/MetadataClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class MetadataClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/mixed-file-directory/Sources/Resources/User/UserClient.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/Resources/User/UserClient.swift
@@ -4,7 +4,7 @@ public final class UserClient: Sendable {
     public let events: EventsClient
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.events = EventsClient(config: config)
         self.httpClient = HTTPClient(config: config)
     }

--- a/seed/swift-sdk/multi-line-docs/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/multi-line-docs/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/multi-line-docs/Sources/Resources/User/UserClient.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/Resources/User/UserClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class UserClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/Resources/Ec2/Ec2Client.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/Resources/Ec2/Ec2Client.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class Ec2Client: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/Resources/S3/S3Client.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/Resources/S3/S3Client.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class S3Client: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/multi-url-environment/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/multi-url-environment/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/multi-url-environment/Sources/Resources/Ec2/Ec2Client.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/Resources/Ec2/Ec2Client.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class Ec2Client: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/multi-url-environment/Sources/Resources/S3/S3Client.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/Resources/S3/S3Client.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class S3Client: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/no-environment/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/no-environment/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/no-environment/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/no-environment/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/no-environment/Sources/Resources/Dummy/DummyClient.swift
+++ b/seed/swift-sdk/no-environment/Sources/Resources/Dummy/DummyClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class DummyClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/nullable-optional/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/nullable-optional/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/nullable-optional/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/nullable-optional/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/nullable-optional/Sources/Resources/NullableOptional/NullableOptionalClient_.swift
+++ b/seed/swift-sdk/nullable-optional/Sources/Resources/NullableOptional/NullableOptionalClient_.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class NullableOptionalClient_: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/nullable/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/nullable/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/nullable/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/nullable/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/nullable/Sources/Resources/Nullable/NullableClient_.swift
+++ b/seed/swift-sdk/nullable/Sources/Resources/Nullable/NullableClient_.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class NullableClient_: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Resources/Auth/AuthClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Resources/Auth/AuthClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class AuthClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Resources/Nested/Api/NestedApiClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Resources/Nested/Api/NestedApiClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class NestedApiClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Resources/Nested/NestedClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Resources/Nested/NestedClient.swift
@@ -4,7 +4,7 @@ public final class NestedClient: Sendable {
     public let api: NestedApiClient
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.api = NestedApiClient(config: config)
         self.httpClient = HTTPClient(config: config)
     }

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Resources/NestedNoAuth/Api/ApiClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Resources/NestedNoAuth/Api/ApiClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ApiClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Resources/NestedNoAuth/NestedNoAuthClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Resources/NestedNoAuth/NestedNoAuthClient.swift
@@ -4,7 +4,7 @@ public final class NestedNoAuthClient: Sendable {
     public let api: ApiClient
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.api = ApiClient(config: config)
         self.httpClient = HTTPClient(config: config)
     }

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Resources/Simple/SimpleClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Resources/Simple/SimpleClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class SimpleClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Resources/Auth/AuthClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Resources/Auth/AuthClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class AuthClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Resources/Nested/Api/NestedApiClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Resources/Nested/Api/NestedApiClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class NestedApiClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Resources/Nested/NestedClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Resources/Nested/NestedClient.swift
@@ -4,7 +4,7 @@ public final class NestedClient: Sendable {
     public let api: NestedApiClient
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.api = NestedApiClient(config: config)
         self.httpClient = HTTPClient(config: config)
     }

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Resources/NestedNoAuth/Api/ApiClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Resources/NestedNoAuth/Api/ApiClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ApiClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Resources/NestedNoAuth/NestedNoAuthClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Resources/NestedNoAuth/NestedNoAuthClient.swift
@@ -4,7 +4,7 @@ public final class NestedNoAuthClient: Sendable {
     public let api: ApiClient
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.api = ApiClient(config: config)
         self.httpClient = HTTPClient(config: config)
     }

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Resources/Simple/SimpleClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Resources/Simple/SimpleClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class SimpleClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Resources/Auth/AuthClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Resources/Auth/AuthClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class AuthClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Resources/Nested/Api/NestedApiClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Resources/Nested/Api/NestedApiClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class NestedApiClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Resources/Nested/NestedClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Resources/Nested/NestedClient.swift
@@ -4,7 +4,7 @@ public final class NestedClient: Sendable {
     public let api: NestedApiClient
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.api = NestedApiClient(config: config)
         self.httpClient = HTTPClient(config: config)
     }

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Resources/NestedNoAuth/Api/ApiClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Resources/NestedNoAuth/Api/ApiClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ApiClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Resources/NestedNoAuth/NestedNoAuthClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Resources/NestedNoAuth/NestedNoAuthClient.swift
@@ -4,7 +4,7 @@ public final class NestedNoAuthClient: Sendable {
     public let api: ApiClient
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.api = ApiClient(config: config)
         self.httpClient = HTTPClient(config: config)
     }

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Resources/Simple/SimpleClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Resources/Simple/SimpleClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class SimpleClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Resources/Auth/AuthClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Resources/Auth/AuthClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class AuthClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Resources/Nested/Api/NestedApiClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Resources/Nested/Api/NestedApiClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class NestedApiClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Resources/Nested/NestedClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Resources/Nested/NestedClient.swift
@@ -4,7 +4,7 @@ public final class NestedClient: Sendable {
     public let api: NestedApiClient
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.api = NestedApiClient(config: config)
         self.httpClient = HTTPClient(config: config)
     }

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Resources/NestedNoAuth/Api/ApiClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Resources/NestedNoAuth/Api/ApiClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ApiClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Resources/NestedNoAuth/NestedNoAuthClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Resources/NestedNoAuth/NestedNoAuthClient.swift
@@ -4,7 +4,7 @@ public final class NestedNoAuthClient: Sendable {
     public let api: ApiClient
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.api = ApiClient(config: config)
         self.httpClient = HTTPClient(config: config)
     }

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Resources/Simple/SimpleClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Resources/Simple/SimpleClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class SimpleClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Resources/Auth/AuthClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Resources/Auth/AuthClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class AuthClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Resources/Nested/Api/NestedApiClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Resources/Nested/Api/NestedApiClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class NestedApiClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Resources/Nested/NestedClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Resources/Nested/NestedClient.swift
@@ -4,7 +4,7 @@ public final class NestedClient: Sendable {
     public let api: NestedApiClient
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.api = NestedApiClient(config: config)
         self.httpClient = HTTPClient(config: config)
     }

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Resources/NestedNoAuth/Api/ApiClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Resources/NestedNoAuth/Api/ApiClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ApiClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Resources/NestedNoAuth/NestedNoAuthClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Resources/NestedNoAuth/NestedNoAuthClient.swift
@@ -4,7 +4,7 @@ public final class NestedNoAuthClient: Sendable {
     public let api: ApiClient
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.api = ApiClient(config: config)
         self.httpClient = HTTPClient(config: config)
     }

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Resources/Service/ServiceClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Resources/Service/ServiceClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ServiceClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Resources/Simple/SimpleClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Resources/Simple/SimpleClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class SimpleClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Resources/Auth/AuthClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Resources/Auth/AuthClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class AuthClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Resources/Nested/Api/NestedApiClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Resources/Nested/Api/NestedApiClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class NestedApiClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Resources/Nested/NestedClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Resources/Nested/NestedClient.swift
@@ -4,7 +4,7 @@ public final class NestedClient: Sendable {
     public let api: NestedApiClient
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.api = NestedApiClient(config: config)
         self.httpClient = HTTPClient(config: config)
     }

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Resources/NestedNoAuth/Api/ApiClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Resources/NestedNoAuth/Api/ApiClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ApiClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Resources/NestedNoAuth/NestedNoAuthClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Resources/NestedNoAuth/NestedNoAuthClient.swift
@@ -4,7 +4,7 @@ public final class NestedNoAuthClient: Sendable {
     public let api: ApiClient
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.api = ApiClient(config: config)
         self.httpClient = HTTPClient(config: config)
     }

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Resources/Simple/SimpleClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Resources/Simple/SimpleClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class SimpleClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/object/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/object/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/object/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/object/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/objects-with-imports/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/objects-with-imports/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/objects-with-imports/Sources/Resources/Commons/CommonsClient.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Resources/Commons/CommonsClient.swift
@@ -4,7 +4,7 @@ public final class CommonsClient: Sendable {
     public let metadata: MetadataClient
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.metadata = MetadataClient(config: config)
         self.httpClient = HTTPClient(config: config)
     }

--- a/seed/swift-sdk/objects-with-imports/Sources/Resources/Commons/Metadata/MetadataClient.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Resources/Commons/Metadata/MetadataClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class MetadataClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 }

--- a/seed/swift-sdk/objects-with-imports/Sources/Resources/File/Directory/DirectoryClient.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Resources/File/Directory/DirectoryClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class DirectoryClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 }

--- a/seed/swift-sdk/objects-with-imports/Sources/Resources/File/FileClient.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Resources/File/FileClient.swift
@@ -4,7 +4,7 @@ public final class FileClient: Sendable {
     public let directory: DirectoryClient
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.directory = DirectoryClient(config: config)
         self.httpClient = HTTPClient(config: config)
     }

--- a/seed/swift-sdk/optional/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/optional/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/optional/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/optional/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/optional/Sources/Resources/Optional/OptionalClient.swift
+++ b/seed/swift-sdk/optional/Sources/Resources/Optional/OptionalClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class OptionalClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/package-yml/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/package-yml/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/package-yml/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/package-yml/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/package-yml/Sources/Resources/Service/ServiceClient.swift
+++ b/seed/swift-sdk/package-yml/Sources/Resources/Service/ServiceClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ServiceClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/pagination-custom/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/pagination-custom/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/pagination-custom/Sources/Resources/Users/UsersClient.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/Resources/Users/UsersClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class UsersClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Resources/Complex/ComplexClient.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Resources/Complex/ComplexClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ComplexClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Resources/InlineUsers/InlineUsers/InlineUsersInlineUsersClient.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Resources/InlineUsers/InlineUsers/InlineUsersInlineUsersClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class InlineUsersInlineUsersClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Resources/InlineUsers/InlineUsersClient.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Resources/InlineUsers/InlineUsersClient.swift
@@ -4,7 +4,7 @@ public final class InlineUsersClient: Sendable {
     public let inlineUsers: InlineUsersInlineUsersClient
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.inlineUsers = InlineUsersInlineUsersClient(config: config)
         self.httpClient = HTTPClient(config: config)
     }

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Resources/Users/UsersClient.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Resources/Users/UsersClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class UsersClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Resources/Complex/ComplexClient.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Resources/Complex/ComplexClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ComplexClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Resources/InlineUsers/InlineUsers/InlineUsersInlineUsersClient.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Resources/InlineUsers/InlineUsers/InlineUsersInlineUsersClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class InlineUsersInlineUsersClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Resources/InlineUsers/InlineUsersClient.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Resources/InlineUsers/InlineUsersClient.swift
@@ -4,7 +4,7 @@ public final class InlineUsersClient: Sendable {
     public let inlineUsers: InlineUsersInlineUsersClient
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.inlineUsers = InlineUsersInlineUsersClient(config: config)
         self.httpClient = HTTPClient(config: config)
     }

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Resources/Users/UsersClient.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Resources/Users/UsersClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class UsersClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Resources/Complex/ComplexClient.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Resources/Complex/ComplexClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ComplexClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Resources/InlineUsers/InlineUsers/InlineUsersInlineUsersClient.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Resources/InlineUsers/InlineUsers/InlineUsersInlineUsersClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class InlineUsersInlineUsersClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Resources/InlineUsers/InlineUsersClient.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Resources/InlineUsers/InlineUsersClient.swift
@@ -4,7 +4,7 @@ public final class InlineUsersClient: Sendable {
     public let inlineUsers: InlineUsersInlineUsersClient
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.inlineUsers = InlineUsersInlineUsersClient(config: config)
         self.httpClient = HTTPClient(config: config)
     }

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Resources/Users/UsersClient.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Resources/Users/UsersClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class UsersClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/path-parameters/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/path-parameters/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/path-parameters/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/path-parameters/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/path-parameters/Sources/Resources/Organizations/OrganizationsClient.swift
+++ b/seed/swift-sdk/path-parameters/Sources/Resources/Organizations/OrganizationsClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class OrganizationsClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/path-parameters/Sources/Resources/User/UserClient.swift
+++ b/seed/swift-sdk/path-parameters/Sources/Resources/User/UserClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class UserClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/plain-text/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/plain-text/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/plain-text/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/plain-text/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/plain-text/Sources/Resources/Service/ServiceClient.swift
+++ b/seed/swift-sdk/plain-text/Sources/Resources/Service/ServiceClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ServiceClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/property-access/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/property-access/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/property-access/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/property-access/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/public-object/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/public-object/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/public-object/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/public-object/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/public-object/Sources/Resources/Service/ServiceClient.swift
+++ b/seed/swift-sdk/public-object/Sources/Resources/Service/ServiceClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ServiceClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/query-parameters-openapi/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/query-parameters-openapi/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/query-parameters/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/query-parameters/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/query-parameters/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/query-parameters/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/query-parameters/Sources/Resources/User/UserClient.swift
+++ b/seed/swift-sdk/query-parameters/Sources/Resources/User/UserClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class UserClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/request-parameters/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/request-parameters/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/request-parameters/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/request-parameters/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/request-parameters/Sources/Resources/User/UserClient.swift
+++ b/seed/swift-sdk/request-parameters/Sources/Resources/User/UserClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class UserClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/required-nullable/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/required-nullable/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/required-nullable/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/required-nullable/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/reserved-keywords/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/reserved-keywords/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/reserved-keywords/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/reserved-keywords/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/reserved-keywords/Sources/Resources/Package/PackageClient.swift
+++ b/seed/swift-sdk/reserved-keywords/Sources/Resources/Package/PackageClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class PackageClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/response-property/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/response-property/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/response-property/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/response-property/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/response-property/Sources/Resources/Service/ServiceClient.swift
+++ b/seed/swift-sdk/response-property/Sources/Resources/Service/ServiceClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ServiceClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/seed.yml
+++ b/seed/swift-sdk/seed.yml
@@ -122,6 +122,7 @@ allowedFailures:
   - query-parameters-openapi
   - query-parameters-openapi-as-objects
   - request-parameters
+  - required-nullable
   - reserved-keywords
   - simple-fhir
   - streaming

--- a/seed/swift-sdk/server-sent-event-examples/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/server-sent-event-examples/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/server-sent-event-examples/Sources/Resources/Completions/CompletionsClient.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/Resources/Completions/CompletionsClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class CompletionsClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/server-sent-events/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/server-sent-events/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/server-sent-events/Sources/Resources/Completions/CompletionsClient.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/Resources/Completions/CompletionsClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class CompletionsClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/simple-api/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/simple-api/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/simple-api/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/simple-api/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/simple-api/Sources/Resources/User/UserClient.swift
+++ b/seed/swift-sdk/simple-api/Sources/Resources/User/UserClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class UserClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/simple-fhir/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/simple-fhir/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Resources/Dummy/DummyClient.swift
+++ b/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Resources/Dummy/DummyClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class DummyClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Resources/Dummy/DummyClient.swift
+++ b/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Resources/Dummy/DummyClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class DummyClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/Resources/Dummy/DummyClient.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/Resources/Dummy/DummyClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class DummyClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/streaming-parameter/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/streaming-parameter/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/streaming-parameter/Sources/Resources/Dummy/DummyClient.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/Resources/Dummy/DummyClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class DummyClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/streaming/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/streaming/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/streaming/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/streaming/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/streaming/Sources/Resources/Dummy/DummyClient.swift
+++ b/seed/swift-sdk/streaming/Sources/Resources/Dummy/DummyClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class DummyClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/trace/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/trace/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/trace/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/trace/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/trace/Sources/Resources/Admin/AdminClient.swift
+++ b/seed/swift-sdk/trace/Sources/Resources/Admin/AdminClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class AdminClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/trace/Sources/Resources/Commons/CommonsClient.swift
+++ b/seed/swift-sdk/trace/Sources/Resources/Commons/CommonsClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class CommonsClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 }

--- a/seed/swift-sdk/trace/Sources/Resources/Homepage/HomepageClient.swift
+++ b/seed/swift-sdk/trace/Sources/Resources/Homepage/HomepageClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class HomepageClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/trace/Sources/Resources/LangServer/LangServerClient.swift
+++ b/seed/swift-sdk/trace/Sources/Resources/LangServer/LangServerClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class LangServerClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 }

--- a/seed/swift-sdk/trace/Sources/Resources/Migration/MigrationClient.swift
+++ b/seed/swift-sdk/trace/Sources/Resources/Migration/MigrationClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class MigrationClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/trace/Sources/Resources/Playlist/PlaylistClient.swift
+++ b/seed/swift-sdk/trace/Sources/Resources/Playlist/PlaylistClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class PlaylistClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/trace/Sources/Resources/Problem/ProblemClient.swift
+++ b/seed/swift-sdk/trace/Sources/Resources/Problem/ProblemClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ProblemClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/trace/Sources/Resources/Submission/SubmissionClient.swift
+++ b/seed/swift-sdk/trace/Sources/Resources/Submission/SubmissionClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class SubmissionClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/trace/Sources/Resources/Sysprop/SyspropClient.swift
+++ b/seed/swift-sdk/trace/Sources/Resources/Sysprop/SyspropClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class SyspropClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/trace/Sources/Resources/V2/Problem/V2ProblemClient.swift
+++ b/seed/swift-sdk/trace/Sources/Resources/V2/Problem/V2ProblemClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class V2ProblemClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/trace/Sources/Resources/V2/V2Client.swift
+++ b/seed/swift-sdk/trace/Sources/Resources/V2/V2Client.swift
@@ -5,7 +5,7 @@ public final class V2Client: Sendable {
     public let v3: V3Client
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.problem = V2ProblemClient(config: config)
         self.v3 = V3Client(config: config)
         self.httpClient = HTTPClient(config: config)

--- a/seed/swift-sdk/trace/Sources/Resources/V2/V3/Problem/V3ProblemClient.swift
+++ b/seed/swift-sdk/trace/Sources/Resources/V2/V3/Problem/V3ProblemClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class V3ProblemClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/trace/Sources/Resources/V2/V3/V3Client.swift
+++ b/seed/swift-sdk/trace/Sources/Resources/V2/V3/V3Client.swift
@@ -4,7 +4,7 @@ public final class V3Client: Sendable {
     public let problem: V3ProblemClient
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.problem = V3ProblemClient(config: config)
         self.httpClient = HTTPClient(config: config)
     }

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Resources/Union/UnionClient.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Resources/Union/UnionClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class UnionClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/unions/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/unions/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/unions/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/unions/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/unions/Sources/Resources/Bigunion/BigunionClient.swift
+++ b/seed/swift-sdk/unions/Sources/Resources/Bigunion/BigunionClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class BigunionClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/unions/Sources/Resources/Types/TypesClient.swift
+++ b/seed/swift-sdk/unions/Sources/Resources/Types/TypesClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class TypesClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 }

--- a/seed/swift-sdk/unions/Sources/Resources/Union/UnionClient.swift
+++ b/seed/swift-sdk/unions/Sources/Resources/Union/UnionClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class UnionClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/unknown/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/unknown/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/unknown/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/unknown/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/unknown/Sources/Resources/Unknown/UnknownClient.swift
+++ b/seed/swift-sdk/unknown/Sources/Resources/Unknown/UnknownClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class UnknownClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/validation/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/validation/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/validation/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/validation/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/variables/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/variables/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/variables/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/variables/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/variables/Sources/Resources/Service/ServiceClient.swift
+++ b/seed/swift-sdk/variables/Sources/Resources/Service/ServiceClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ServiceClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/version-no-default/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/version-no-default/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/version-no-default/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/version-no-default/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/version-no-default/Sources/Resources/User/UserClient.swift
+++ b/seed/swift-sdk/version-no-default/Sources/Resources/User/UserClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class UserClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/version/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/version/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/version/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/version/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/version/Sources/Resources/User/UserClient.swift
+++ b/seed/swift-sdk/version/Sources/Resources/User/UserClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class UserClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/websocket-bearer-auth/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/websocket-bearer-auth/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/websocket-bearer-auth/Sources/Resources/Realtime/RealtimeClient.swift
+++ b/seed/swift-sdk/websocket-bearer-auth/Sources/Resources/Realtime/RealtimeClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class RealtimeClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 }

--- a/seed/swift-sdk/websocket-inferred-auth/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/websocket-inferred-auth/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/websocket-inferred-auth/Sources/Resources/Auth/AuthClient.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Sources/Resources/Auth/AuthClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class AuthClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 

--- a/seed/swift-sdk/websocket-inferred-auth/Sources/Resources/Realtime/RealtimeClient.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Sources/Resources/Realtime/RealtimeClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class RealtimeClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 }

--- a/seed/swift-sdk/websocket/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/websocket/Sources/Core/Networking/HTTPClient.swift
@@ -105,7 +105,6 @@ final class HTTPClient: Sendable {
         var request = URLRequest(url: url)
 
         // Set timeout
-        // TODO(kafkas): URLSession already has a timeout setting; find out if this is the right way to override it at the request level
         if let timeout = requestOptions?.timeout {
             request.timeoutInterval = TimeInterval(timeout)
         }
@@ -232,7 +231,6 @@ final class HTTPClient: Sendable {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {
-                // TODO(kafkas): Merge requestOptions.additionalBodyParameters into this
                 return try jsonEncoder.encode(encodableBody)
             } catch {
                 preconditionFailure(
@@ -250,7 +248,6 @@ final class HTTPClient: Sendable {
         _ request: URLRequest
     ) async throws -> (Data, String?) {
         do {
-            // TODO(kafkas): Handle retries
             let (data, response) = try await clientConfig.urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/seed/swift-sdk/websocket/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/websocket/Sources/Public/RequestOptions.swift
@@ -22,7 +22,6 @@ public struct RequestOptions {
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
     let additionalQueryParameters: [String: String]?
 
-    // TODO(kafkas): Omit for file uploads
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
     let additionalBodyParameters: [String: String]?
 

--- a/seed/swift-sdk/websocket/Sources/Resources/Realtime/RealtimeClient.swift
+++ b/seed/swift-sdk/websocket/Sources/Resources/Realtime/RealtimeClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class RealtimeClient: Sendable {
     private let httpClient: HTTPClient
 
-    public init(config: ClientConfig) {
+    init(config: ClientConfig) {
         self.httpClient = HTTPClient(config: config)
     }
 }


### PR DESCRIPTION
## Description
Linear ticket: [FER-6933](https://linear.app/buildwithfern/issue/FER-6933/reduce-subclient-class-initializer-access-level-to-internal)
<!-- Provide a clear and concise description of the changes made in this PR -->
Reduces the access level of subclient initializers to internal (the default) to prevent the end user from consuming them directly. Also removes the `TODO(kafkas)` comments from "as is" files.

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Removes `TODO(kafkas)` from `HTTPClient` and `RequestOptions`
- Updates `SubClientGenerator` to remove public access level for the initializer

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated
- [x] Manual testing completed
