### PR TITLE
fix(swift): use real github repo url and version in readme

### DIFF
--- a/generators/swift/sdk/versions.yml
+++ b/generators/swift/sdk/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.17.4
+  changelogEntry:
+    - type: fix
+      summary: |
+        Fixed missing `gitUrl` and `minVersion` values in SPM installation instructions in README.
+  createdAt: "2025-10-04"
+  irVersion: 59
+
 - version: 0.17.3
   changelogEntry:
     - type: fix

--- a/seed/swift-sdk/accept-header/README.md
+++ b/seed/swift-sdk/accept-header/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/accept-header/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/alias-extends/README.md
+++ b/seed/swift-sdk/alias-extends/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/alias-extends/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/alias/README.md
+++ b/seed/swift-sdk/alias/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/alias/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/any-auth/README.md
+++ b/seed/swift-sdk/any-auth/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/any-auth/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/api-wide-base-path/README.md
+++ b/seed/swift-sdk/api-wide-base-path/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/api-wide-base-path/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/audiences/README.md
+++ b/seed/swift-sdk/audiences/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/audiences/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/auth-environment-variables/README.md
+++ b/seed/swift-sdk/auth-environment-variables/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/auth-environment-variables/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/basic-auth-environment-variables/README.md
+++ b/seed/swift-sdk/basic-auth-environment-variables/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/basic-auth-environment-variables/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/basic-auth/README.md
+++ b/seed/swift-sdk/basic-auth/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/basic-auth/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/bearer-token-environment-variable/README.md
+++ b/seed/swift-sdk/bearer-token-environment-variable/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/bearer-token-environment-variable/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/bytes-upload/README.md
+++ b/seed/swift-sdk/bytes-upload/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/bytes-upload/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/client-side-params/no-custom-config/README.md
+++ b/seed/swift-sdk/client-side-params/no-custom-config/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/client-side-params/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/client-side-params/with-custom-config/README.md
+++ b/seed/swift-sdk/client-side-params/with-custom-config/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/client-side-params/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/content-type/README.md
+++ b/seed/swift-sdk/content-type/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/content-type/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/cross-package-type-names/README.md
+++ b/seed/swift-sdk/cross-package-type-names/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/cross-package-type-names/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/custom-auth/README.md
+++ b/seed/swift-sdk/custom-auth/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/custom-auth/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/enum/README.md
+++ b/seed/swift-sdk/enum/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/enum/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/error-property/README.md
+++ b/seed/swift-sdk/error-property/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/error-property/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/errors/README.md
+++ b/seed/swift-sdk/errors/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/errors/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/examples/no-custom-config/README.md
+++ b/seed/swift-sdk/examples/no-custom-config/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/examples/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/examples/readme-config/README.md
+++ b/seed/swift-sdk/examples/readme-config/README.md
@@ -26,7 +26,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/examples/fern", from: "0.0.1"),
 ]
 ```
 
@@ -36,7 +36,7 @@ A full reference for this library is available [here](./reference.md).
 
 ## Base Readme Custom Section
 
-Base Readme Custom Content for <git-url>:0.1.0
+Base Readme Custom Content for https://github.com/examples/fern:0.0.1
 
 ## Override Section
 
@@ -44,7 +44,7 @@ Override Content
 
 ## Generator Invocation Custom Section
 
-Generator Invocation Custom Content for <git-url>:0.1.0
+Generator Invocation Custom Content for https://github.com/examples/fern:0.0.1
 
 ## Usage
 

--- a/seed/swift-sdk/exhaustive/README.md
+++ b/seed/swift-sdk/exhaustive/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/exhaustive/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/extends/README.md
+++ b/seed/swift-sdk/extends/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/extends/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/extra-properties/README.md
+++ b/seed/swift-sdk/extra-properties/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/extra-properties/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/file-download/README.md
+++ b/seed/swift-sdk/file-download/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/file-download/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/file-upload/README.md
+++ b/seed/swift-sdk/file-upload/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/file-upload/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/folders/README.md
+++ b/seed/swift-sdk/folders/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/folders/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/http-head/README.md
+++ b/seed/swift-sdk/http-head/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/http-head/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/idempotency-headers/README.md
+++ b/seed/swift-sdk/idempotency-headers/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/idempotency-headers/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/imdb/README.md
+++ b/seed/swift-sdk/imdb/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/imdb/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/inferred-auth-explicit/README.md
+++ b/seed/swift-sdk/inferred-auth-explicit/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/inferred-auth-explicit/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/README.md
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/inferred-auth-implicit-no-expiry/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/inferred-auth-implicit/README.md
+++ b/seed/swift-sdk/inferred-auth-implicit/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/inferred-auth-implicit/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/license/README.md
+++ b/seed/swift-sdk/license/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/license/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/literal/README.md
+++ b/seed/swift-sdk/literal/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/literal/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/mixed-case/README.md
+++ b/seed/swift-sdk/mixed-case/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/mixed-case/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/mixed-file-directory/README.md
+++ b/seed/swift-sdk/mixed-file-directory/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/mixed-file-directory/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/multi-line-docs/README.md
+++ b/seed/swift-sdk/multi-line-docs/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/multi-line-docs/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/multi-url-environment-no-default/README.md
+++ b/seed/swift-sdk/multi-url-environment-no-default/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/multi-url-environment-no-default/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/multi-url-environment/README.md
+++ b/seed/swift-sdk/multi-url-environment/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/multi-url-environment/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/multiple-request-bodies/README.md
+++ b/seed/swift-sdk/multiple-request-bodies/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/multiple-request-bodies/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/no-environment/README.md
+++ b/seed/swift-sdk/no-environment/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/no-environment/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/nullable-optional/README.md
+++ b/seed/swift-sdk/nullable-optional/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/nullable-optional/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/nullable/README.md
+++ b/seed/swift-sdk/nullable/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/nullable/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/oauth-client-credentials-custom/README.md
+++ b/seed/swift-sdk/oauth-client-credentials-custom/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/oauth-client-credentials-custom/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/oauth-client-credentials-default/README.md
+++ b/seed/swift-sdk/oauth-client-credentials-default/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/oauth-client-credentials-default/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/README.md
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/oauth-client-credentials-environment-variables/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/README.md
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/oauth-client-credentials-nested-root/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/README.md
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/oauth-client-credentials-with-variables/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/oauth-client-credentials/README.md
+++ b/seed/swift-sdk/oauth-client-credentials/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/oauth-client-credentials/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/optional/README.md
+++ b/seed/swift-sdk/optional/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/optional/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/package-yml/README.md
+++ b/seed/swift-sdk/package-yml/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/package-yml/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/pagination-custom/README.md
+++ b/seed/swift-sdk/pagination-custom/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/pagination-custom/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/README.md
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/pagination/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/pagination/custom-pager/README.md
+++ b/seed/swift-sdk/pagination/custom-pager/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/pagination/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/pagination/no-custom-config/README.md
+++ b/seed/swift-sdk/pagination/no-custom-config/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/pagination/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/path-parameters/README.md
+++ b/seed/swift-sdk/path-parameters/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/path-parameters/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/plain-text/README.md
+++ b/seed/swift-sdk/plain-text/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/plain-text/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/property-access/README.md
+++ b/seed/swift-sdk/property-access/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/property-access/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/README.md
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/query-parameters-openapi-as-objects/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/query-parameters-openapi/README.md
+++ b/seed/swift-sdk/query-parameters-openapi/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/query-parameters-openapi/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/query-parameters/README.md
+++ b/seed/swift-sdk/query-parameters/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/query-parameters/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/request-parameters/README.md
+++ b/seed/swift-sdk/request-parameters/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/request-parameters/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/required-nullable/README.md
+++ b/seed/swift-sdk/required-nullable/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/required-nullable/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/reserved-keywords/README.md
+++ b/seed/swift-sdk/reserved-keywords/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/reserved-keywords/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/response-property/README.md
+++ b/seed/swift-sdk/response-property/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/response-property/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/server-sent-event-examples/README.md
+++ b/seed/swift-sdk/server-sent-event-examples/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/server-sent-event-examples/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/server-sent-events/README.md
+++ b/seed/swift-sdk/server-sent-events/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/server-sent-events/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/simple-api/README.md
+++ b/seed/swift-sdk/simple-api/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/simple-api/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/simple-fhir/README.md
+++ b/seed/swift-sdk/simple-fhir/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/simple-fhir/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/single-url-environment-default/no-custom-config/README.md
+++ b/seed/swift-sdk/single-url-environment-default/no-custom-config/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/single-url-environment-default/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/single-url-environment-default/with-custom-config/README.md
+++ b/seed/swift-sdk/single-url-environment-default/with-custom-config/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/single-url-environment-default/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/single-url-environment-no-default/README.md
+++ b/seed/swift-sdk/single-url-environment-no-default/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/single-url-environment-no-default/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/streaming-parameter/README.md
+++ b/seed/swift-sdk/streaming-parameter/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/streaming-parameter/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/streaming/README.md
+++ b/seed/swift-sdk/streaming/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/streaming/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/trace/README.md
+++ b/seed/swift-sdk/trace/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/trace/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/undiscriminated-unions/README.md
+++ b/seed/swift-sdk/undiscriminated-unions/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/undiscriminated-unions/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/unions/README.md
+++ b/seed/swift-sdk/unions/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/unions/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/unknown/README.md
+++ b/seed/swift-sdk/unknown/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/unknown/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/validation/README.md
+++ b/seed/swift-sdk/validation/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/validation/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/variables/README.md
+++ b/seed/swift-sdk/variables/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/variables/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/version-no-default/README.md
+++ b/seed/swift-sdk/version-no-default/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/version-no-default/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/version/README.md
+++ b/seed/swift-sdk/version/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/version/fern", from: "0.0.1"),
 ]
 ```
 

--- a/seed/swift-sdk/websocket-inferred-auth/README.md
+++ b/seed/swift-sdk/websocket-inferred-auth/README.md
@@ -20,7 +20,7 @@ With Swift Package Manager (SPM), add the following to the top-level `dependenci
 
 ```swift
 dependencies: [
-    .package(url: "<git-url>", from: "0.1.0"),
+    .package(url: "https://github.com/websocket-inferred-auth/fern", from: "0.0.1"),
 ]
 ```
 


### PR DESCRIPTION
## Description
Linear ticket: [FER-6550](https://linear.app/buildwithfern/issue/FER-6550/github-repo-url-and-version-not-propagating-to-installation-section-in)
<!-- Provide a clear and concise description of the changes made in this PR -->
Readme installation section currently always falls back to `<git-url>` and `0.1.0`. With this PR we should start pulling the real values when possible. 

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Updated `SdkGeneratorContext .getSPMDetails()` to pull version and repo url grom generator config

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated
- [ ] Manual testing completed
