### PR TITLE
fix(swift): add missing container declaration in encode method

### DIFF
--- a/generators/swift/model/src/helpers/struct-generator/StructGenerator.ts
+++ b/generators/swift/model/src/helpers/struct-generator/StructGenerator.ts
@@ -72,7 +72,7 @@ export class StructGenerator {
             properties,
             initializers: this.generateInitializers(dataProperties),
             methods: this.generateMethods(constantProperties, dataProperties),
-            nestedTypes: this.generateNestedTypes(dataProperties),
+            nestedTypes: this.generateNestedTypes(constantProperties, dataProperties),
             docs: this.docsContent ? swift.docComment({ summary: this.docsContent }) : undefined
         });
     }
@@ -261,7 +261,7 @@ export class StructGenerator {
     private generateEncodeMethod(constantProperties: swift.Property[], dataProperties: swift.Property[]) {
         const bodyStatements: swift.Statement[] = [];
 
-        if (dataProperties.length > 0) {
+        if (constantProperties.length > 0 || dataProperties.length > 0) {
             bodyStatements.push(
                 swift.Statement.variableDeclaration({
                     unsafeName: "container",
@@ -345,12 +345,12 @@ export class StructGenerator {
         });
     }
 
-    private generateNestedTypes(dataProperties: swift.Property[]) {
+    private generateNestedTypes(constantProperties: swift.Property[], dataProperties: swift.Property[]) {
         const nestedTypes: (swift.Struct | swift.EnumWithRawValues)[] = [];
         this.localContext.stringLiteralEnums.forEach((enum_) => {
             nestedTypes.push(enum_);
         });
-        if (dataProperties.length > 0) {
+        if (constantProperties.length > 0 || dataProperties.length > 0) {
             nestedTypes.push(this.generateCodingKeysEnum());
         }
         return nestedTypes;

--- a/generators/swift/sdk/versions.yml
+++ b/generators/swift/sdk/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.17.5
+  changelogEntry:
+    - type: fix
+      summary: |
+        Fixed a bug where some discriminated union variants were missing the container declaration statement in their `encode(to:)` method body.
+  createdAt: "2025-10-04"
+  irVersion: 59
+
 - version: 0.17.4
   changelogEntry:
     - type: fix

--- a/seed/swift-sdk/circular-references-advanced/Sources/Schemas/FieldValue.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Schemas/FieldValue.swift
@@ -86,8 +86,14 @@ public enum FieldValue: Codable, Hashable, Sendable {
         }
 
         public func encode(to encoder: Encoder) throws -> Void {
+            var container = encoder.container(keyedBy: CodingKeys.self)
             try encoder.encodeAdditionalProperties(self.additionalProperties)
             try container.encode(self.type, forKey: .type)
+        }
+
+        /// Keys for encoding/decoding struct properties.
+        enum CodingKeys: String, CodingKey, CaseIterable {
+            case type
         }
     }
 

--- a/seed/swift-sdk/circular-references/Sources/Schemas/FieldValue.swift
+++ b/seed/swift-sdk/circular-references/Sources/Schemas/FieldValue.swift
@@ -86,8 +86,14 @@ public enum FieldValue: Codable, Hashable, Sendable {
         }
 
         public func encode(to encoder: Encoder) throws -> Void {
+            var container = encoder.container(keyedBy: CodingKeys.self)
             try encoder.encodeAdditionalProperties(self.additionalProperties)
             try container.encode(self.type, forKey: .type)
+        }
+
+        /// Keys for encoding/decoding struct properties.
+        enum CodingKeys: String, CodingKey, CaseIterable {
+            case type
         }
     }
 

--- a/seed/swift-sdk/trace/Sources/Schemas/SubmissionResponse.swift
+++ b/seed/swift-sdk/trace/Sources/Schemas/SubmissionResponse.swift
@@ -219,8 +219,14 @@ public enum SubmissionResponse: Codable, Hashable, Sendable {
         }
 
         public func encode(to encoder: Encoder) throws -> Void {
+            var container = encoder.container(keyedBy: CodingKeys.self)
             try encoder.encodeAdditionalProperties(self.additionalProperties)
             try container.encode(self.type, forKey: .type)
+        }
+
+        /// Keys for encoding/decoding struct properties.
+        enum CodingKeys: String, CodingKey, CaseIterable {
+            case type
         }
     }
 


### PR DESCRIPTION
## Description
Linear ticket: [FER-7055](https://linear.app/buildwithfern/issue/FER-7055/fix-missing-container-declaration-in-discriminated-union-variant)
<!-- Provide a clear and concise description of the changes made in this PR -->
Fixes a bug where discriminated union variants with no properties other than the discriminant would have a missing statement in their encode method body.

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Updated `StructGenerator` to check constant properties for container declaration and coding keys enum

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated
- [x] Manual testing completed
