### PR TITLE
fix(java, cli): Only run spotlessApply if gradlew file exists.

### DIFF
--- a/generators/java-v2/base/src/project/JavaProject.ts
+++ b/generators/java-v2/base/src/project/JavaProject.ts
@@ -1,5 +1,5 @@
 import { AbstractProject, File } from "@fern-api/base-generator";
-import { AbsoluteFilePath } from "@fern-api/fs-utils";
+import { AbsoluteFilePath, join, RelativeFilePath, doesPathExist} from "@fern-api/fs-utils";
 import { BaseJavaCustomConfigSchema } from "@fern-api/java-ast";
 import { loggingExeca } from "@fern-api/logging-execa";
 import { mkdir } from "fs/promises";
@@ -27,13 +27,20 @@ export class JavaProject extends AbstractProject<AbstractJavaGeneratorContext<Ba
         });
         await this.writeRawFiles();
         this.context.logger.debug(`Successfully wrote java files to ${this.absolutePathToOutputDirectory}`);
-
-        this.context.logger.debug(`JavaProject: Running spotlessApply`);
-        await loggingExeca(this.context.logger, "./gradlew", [":spotlessApply"], {
-            doNotPipeOutput: false,
-            cwd: this.absolutePathToOutputDirectory
-        });
-        this.context.logger.debug(`JavaProject: Successfully ran spotlessApply`);
+        const gradlewPath = join(
+            this.absolutePathToOutputDirectory,
+            RelativeFilePath.of("gradlew")
+        )
+        const gradlewExists = await doesPathExist(gradlewPath, "file");
+        if (gradlewExists) {
+            this.context.logger.debug(`JavaProject: Running spotlessApply`);
+            await loggingExeca(this.context.logger, "./gradlew", [":spotlessApply"], {
+                doNotPipeOutput: false,
+                cwd: this.absolutePathToOutputDirectory
+            });
+            this.context.logger.debug(`JavaProject: Successfully ran spotlessApply`);
+        }
+        
     }
 
     private async writeJavaFiles({

--- a/generators/java-v2/base/src/project/JavaProject.ts
+++ b/generators/java-v2/base/src/project/JavaProject.ts
@@ -1,5 +1,5 @@
 import { AbstractProject, File } from "@fern-api/base-generator";
-import { AbsoluteFilePath, join, RelativeFilePath, doesPathExist} from "@fern-api/fs-utils";
+import { AbsoluteFilePath, doesPathExist, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { BaseJavaCustomConfigSchema } from "@fern-api/java-ast";
 import { loggingExeca } from "@fern-api/logging-execa";
 import { mkdir } from "fs/promises";
@@ -27,10 +27,7 @@ export class JavaProject extends AbstractProject<AbstractJavaGeneratorContext<Ba
         });
         await this.writeRawFiles();
         this.context.logger.debug(`Successfully wrote java files to ${this.absolutePathToOutputDirectory}`);
-        const gradlewPath = join(
-            this.absolutePathToOutputDirectory,
-            RelativeFilePath.of("gradlew")
-        )
+        const gradlewPath = join(this.absolutePathToOutputDirectory, RelativeFilePath.of("gradlew"));
         const gradlewExists = await doesPathExist(gradlewPath, "file");
         if (gradlewExists) {
             this.context.logger.debug(`JavaProject: Running spotlessApply`);
@@ -40,7 +37,6 @@ export class JavaProject extends AbstractProject<AbstractJavaGeneratorContext<Ba
             });
             this.context.logger.debug(`JavaProject: Successfully ran spotlessApply`);
         }
-        
     }
 
     private async writeJavaFiles({

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,3 +1,11 @@
+- version: 3.8.8
+  changelogEntry:
+    - summary: |
+        Fix: Don't run spotlessApply if gradlew doesn't exist.
+      type: fix
+  createdAt: "2025-10-05"
+  irVersion: 60
+
 - version: 3.8.7
   changelogEntry:
     - summary: |

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Fix: Don't run spotlessApply if gradlew doesn't exist.
+      type: fix
+  createdAt: "2025-10-05"
+  irVersion: 60
+  version: 0.84.9
+
+- changelogEntry:
+    - summary: |
         Fixed spotlessCheck in Java Dynamic Snippets Tests.
       type: fix
   createdAt: "2025-10-04"

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/dynamic-snippets/java/DynamicSnippetsJavaTestGenerator.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/dynamic-snippets/java/DynamicSnippetsJavaTestGenerator.ts
@@ -1,5 +1,5 @@
 import { Style } from "@fern-api/browser-compatible-base-generator";
-import { AbsoluteFilePath, join, RelativeFilePath } from "@fern-api/fs-utils";
+import { AbsoluteFilePath, doesPathExist, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { dynamic } from "@fern-api/ir-sdk";
 import { Config, DynamicSnippetsGenerator } from "@fern-api/java-dynamic-snippets";
 import { loggingExeca } from "@fern-api/logging-execa";
@@ -70,15 +70,19 @@ export class DynamicSnippetsJavaTestGenerator {
             }
         }
         this.context.logger.debug("Dynamic snippets test files generated, running spotlessApply...");
-        try {
-            await loggingExeca(this.context.logger, "./gradlew", [":spotlessApply"], {
-                doNotPipeOutput: false,
-                cwd: outputDir
-            });
-        } catch (e) {
-            this.context.failAndThrow("Failed to run spotlessApply", e);
+        const gradlewPath = join(outputDir, RelativeFilePath.of("gradlew"));
+        const gradlewExists = await doesPathExist(gradlewPath, "file");
+        if (gradlewExists) {
+            try {
+                await loggingExeca(this.context.logger, "./gradlew", [":spotlessApply"], {
+                    doNotPipeOutput: false,
+                    cwd: outputDir
+                });
+                this.context.logger.debug("Successfully ran spotlessApply");
+            } catch (e) {
+                this.context.failAndThrow("Failed to run spotlessApply", e);
+            }
         }
-        this.context.logger.debug("Successfully ran spotlessApply");
         this.context.logger.debug("Done generating dynamic snippet tests");
     }
 


### PR DESCRIPTION
## Description
Fix an issue where the Java generator would fail when attempting to run `spotlessApply` in projects that don't have a `gradlew` file. This occurred in Java V2 generator and dynamic snippets test generation when local-file-system was the output location

## Changes Made
- Added existence check for `gradlew` file before attempting to run `spotlessApply` in [JavaProject.ts](generators/java-v2/base/src/project/JavaProject.ts#L30-L42)
- Added existence check for `gradlew` file before attempting to run `spotlessApply` in [DynamicSnippetsJavaTestGenerator.ts](packages/cli/generation/local-generation/local-workspace-runner/src/dynamic-snippets/java/DynamicSnippetsJavaTestGenerator.ts#L73-L85)
- Updated version to 3.8.8 for Java SDK generator with fix changelog entry
- Updated CLI version to 0.84.9 with fix changelog entry

## Testing
- [x] Manually tested local file system output with new generator