### PR TITLE
chore(rust): Bump Rust SDK version to 0.5.5

### DIFF
--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
-- version: 0.5.4
-  createdAt: "2025-10-03"
+- version: 0.5.5
+  createdAt: "2025-10-06"
   changelogEntry:
     - type: chore
       summary: Disable doctests and export root client in generator


### PR DESCRIPTION
## Description

Updated the Rust SDK version in versions.yml to 0.5.5 with a new release date. The changelog entry remains unchanged.