### PR TITLE
chore(rust): Add new readme config fields to ReadmeConfigBuilder

### DIFF
--- a/generators/rust/sdk/src/readme/ReadmeConfigBuilder.ts
+++ b/generators/rust/sdk/src/readme/ReadmeConfigBuilder.ts
@@ -45,6 +45,10 @@ export class ReadmeConfigBuilder {
             apiReferenceLink: context.ir.readmeConfig?.apiReferenceLink,
             bannerLink: context.ir.readmeConfig?.bannerLink,
             introduction: context.ir.readmeConfig?.introduction,
+            referenceMarkdownPath: "./reference.md",
+            apiName: context.ir.readmeConfig?.apiName,
+            disabledFeatures: context.ir.readmeConfig?.disabledFeatures,
+            whiteLabel: context.ir.readmeConfig?.whiteLabel,
             customSections: getCustomSections(context),
             features
         };

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -1,5 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.5.5
+  createdAt: "2025-10-07"
+  changelogEntry:
+    - type: chore
+      summary: Add new readme config fields to ReadmeConfigBuilder
+  irVersion: 59
+
 - version: 0.5.4
   createdAt: "2025-10-03"
   changelogEntry:

--- a/seed/rust-sdk/accept-header/README.md
+++ b/seed/rust-sdk/accept-header/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_accept
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/alias-extends/README.md
+++ b/seed/rust-sdk/alias-extends/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_alias_extends
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/alias/README.md
+++ b/seed/rust-sdk/alias/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_alias
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/any-auth/README.md
+++ b/seed/rust-sdk/any-auth/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_any_auth
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/api-wide-base-path/README.md
+++ b/seed/rust-sdk/api-wide-base-path/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_api_wide_base_path
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/audiences/README.md
+++ b/seed/rust-sdk/audiences/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_audiences
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/auth-environment-variables/README.md
+++ b/seed/rust-sdk/auth-environment-variables/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_auth_environment_variables
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/basic-auth-environment-variables/README.md
+++ b/seed/rust-sdk/basic-auth-environment-variables/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_basic_auth_environment_variables
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/basic-auth/README.md
+++ b/seed/rust-sdk/basic-auth/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_basic_auth
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/bearer-token-environment-variable/README.md
+++ b/seed/rust-sdk/bearer-token-environment-variable/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_bearer_token_environment_variable
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/bytes-upload/README.md
+++ b/seed/rust-sdk/bytes-upload/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_bytes_upload
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/client-side-params/README.md
+++ b/seed/rust-sdk/client-side-params/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_client_side_params
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/content-type/README.md
+++ b/seed/rust-sdk/content-type/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_content_types
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/cross-package-type-names/README.md
+++ b/seed/rust-sdk/cross-package-type-names/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_cross_package_type_names
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/custom-auth/README.md
+++ b/seed/rust-sdk/custom-auth/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_custom_auth
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/enum/README.md
+++ b/seed/rust-sdk/enum/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_enum
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/error-property/README.md
+++ b/seed/rust-sdk/error-property/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_error_property
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/errors/README.md
+++ b/seed/rust-sdk/errors/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_errors
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/examples/no-custom-config/README.md
+++ b/seed/rust-sdk/examples/no-custom-config/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_examples
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/examples/readme-config/README.md
+++ b/seed/rust-sdk/examples/readme-config/README.md
@@ -1,11 +1,11 @@
-# Seed Rust Library
+# CustomName Rust Library
 
 ![](https://www.fernapi.com)
 
 [![fern shield](https://img.shields.io/badge/%F0%9F%8C%BF-Built%20with%20Fern-brightgreen)](https://buildwithfern.com?utm_source=github&utm_medium=github&utm_campaign=readme&utm_source=Seed%2FRust)
 [![crates.io shield](https://img.shields.io/crates/v/seed_examples)](https://crates.io/crates/seed_examples)
 
-The Seed Rust library provides convenient access to the Seed APIs from Rust.
+The CustomName Rust library provides convenient access to the CustomName APIs from Rust.
 
 ## Documentation
 
@@ -25,6 +25,10 @@ Or install via cargo:
 ```sh
 cargo add seed_examples
 ```
+
+## Reference
+
+A full reference for this library is available [here](./reference.md).
 
 ## Base Readme Custom Section
 

--- a/seed/rust-sdk/exhaustive/README.md
+++ b/seed/rust-sdk/exhaustive/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_exhaustive
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/extends/README.md
+++ b/seed/rust-sdk/extends/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_extends
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/extra-properties/README.md
+++ b/seed/rust-sdk/extra-properties/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_extra_properties
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/file-download/README.md
+++ b/seed/rust-sdk/file-download/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_file_download
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/file-upload/README.md
+++ b/seed/rust-sdk/file-upload/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_file_upload
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/folders/README.md
+++ b/seed/rust-sdk/folders/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_api
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/http-head/README.md
+++ b/seed/rust-sdk/http-head/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_http_head
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/idempotency-headers/README.md
+++ b/seed/rust-sdk/idempotency-headers/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_idempotency_headers
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/imdb/imdb-custom-config/README.md
+++ b/seed/rust-sdk/imdb/imdb-custom-config/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add custom_imdb_sdk
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/imdb/imdb/README.md
+++ b/seed/rust-sdk/imdb/imdb/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_api
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/inferred-auth-explicit/README.md
+++ b/seed/rust-sdk/inferred-auth-explicit/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_inferred_auth_explicit
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/inferred-auth-implicit-no-expiry/README.md
+++ b/seed/rust-sdk/inferred-auth-implicit-no-expiry/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_inferred_auth_implicit_no_expiry
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/inferred-auth-implicit/README.md
+++ b/seed/rust-sdk/inferred-auth-implicit/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_inferred_auth_implicit
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/license/README.md
+++ b/seed/rust-sdk/license/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_license
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/literal/README.md
+++ b/seed/rust-sdk/literal/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_literal
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/mixed-case/README.md
+++ b/seed/rust-sdk/mixed-case/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_mixed_case
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/mixed-file-directory/README.md
+++ b/seed/rust-sdk/mixed-file-directory/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_mixed_file_directory
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/multi-line-docs/README.md
+++ b/seed/rust-sdk/multi-line-docs/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_multi_line_docs
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/multi-url-environment-no-default/README.md
+++ b/seed/rust-sdk/multi-url-environment-no-default/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_multi_url_environment_no_default
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/multi-url-environment/README.md
+++ b/seed/rust-sdk/multi-url-environment/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_multi_url_environment
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/multiple-request-bodies/README.md
+++ b/seed/rust-sdk/multiple-request-bodies/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_api
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/no-environment/README.md
+++ b/seed/rust-sdk/no-environment/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_no_environment
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/nullable-optional/README.md
+++ b/seed/rust-sdk/nullable-optional/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_nullable_optional
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/nullable/README.md
+++ b/seed/rust-sdk/nullable/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_nullable
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/oauth-client-credentials-custom/README.md
+++ b/seed/rust-sdk/oauth-client-credentials-custom/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_oauth_client_credentials
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/oauth-client-credentials-default/README.md
+++ b/seed/rust-sdk/oauth-client-credentials-default/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_oauth_client_credentials_default
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/oauth-client-credentials-environment-variables/README.md
+++ b/seed/rust-sdk/oauth-client-credentials-environment-variables/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_oauth_client_credentials_environment_variables
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/oauth-client-credentials-nested-root/README.md
+++ b/seed/rust-sdk/oauth-client-credentials-nested-root/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_oauth_client_credentials
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/oauth-client-credentials-with-variables/README.md
+++ b/seed/rust-sdk/oauth-client-credentials-with-variables/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_oauth_client_credentials_with_variables
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/oauth-client-credentials/README.md
+++ b/seed/rust-sdk/oauth-client-credentials/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_oauth_client_credentials
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/optional/README.md
+++ b/seed/rust-sdk/optional/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_objects_with_imports
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/package-yml/README.md
+++ b/seed/rust-sdk/package-yml/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_package_yml
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/pagination-custom/README.md
+++ b/seed/rust-sdk/pagination-custom/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_pagination
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/pagination/README.md
+++ b/seed/rust-sdk/pagination/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_pagination
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/path-parameters/README.md
+++ b/seed/rust-sdk/path-parameters/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_path_parameters
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/plain-text/README.md
+++ b/seed/rust-sdk/plain-text/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_plain_text
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/property-access/README.md
+++ b/seed/rust-sdk/property-access/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_property_access
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/query-parameters-openapi-as-objects/README.md
+++ b/seed/rust-sdk/query-parameters-openapi-as-objects/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_api
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/query-parameters-openapi/README.md
+++ b/seed/rust-sdk/query-parameters-openapi/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_api
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/query-parameters/README.md
+++ b/seed/rust-sdk/query-parameters/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_query_parameters
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/request-parameters/README.md
+++ b/seed/rust-sdk/request-parameters/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_request_parameters
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/required-nullable/README.md
+++ b/seed/rust-sdk/required-nullable/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_api
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/reserved-keywords/README.md
+++ b/seed/rust-sdk/reserved-keywords/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_nursery_api
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/response-property/README.md
+++ b/seed/rust-sdk/response-property/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_response_property
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/server-sent-event-examples/README.md
+++ b/seed/rust-sdk/server-sent-event-examples/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_server_sent_events
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/server-sent-events/README.md
+++ b/seed/rust-sdk/server-sent-events/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_server_sent_events
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/simple-api/README.md
+++ b/seed/rust-sdk/simple-api/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_simple_api
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/simple-fhir/README.md
+++ b/seed/rust-sdk/simple-fhir/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_api
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/single-url-environment-default/basic/README.md
+++ b/seed/rust-sdk/single-url-environment-default/basic/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_single_url_environment_default
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/single-url-environment-default/custom-environment/README.md
+++ b/seed/rust-sdk/single-url-environment-default/custom-environment/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add environment_test_sdk
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/single-url-environment-default/full-custom/README.md
+++ b/seed/rust-sdk/single-url-environment-default/full-custom/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add full_custom_sdk
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Custom Installation
 
 Add this line to your Cargo.toml:

--- a/seed/rust-sdk/single-url-environment-no-default/README.md
+++ b/seed/rust-sdk/single-url-environment-no-default/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_single_url_environment_no_default
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/streaming-parameter/README.md
+++ b/seed/rust-sdk/streaming-parameter/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_streaming
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/streaming/README.md
+++ b/seed/rust-sdk/streaming/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_streaming
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/trace/README.md
+++ b/seed/rust-sdk/trace/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_trace
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/undiscriminated-unions/README.md
+++ b/seed/rust-sdk/undiscriminated-unions/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_undiscriminated_unions
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/unions/README.md
+++ b/seed/rust-sdk/unions/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_unions
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/unknown/README.md
+++ b/seed/rust-sdk/unknown/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_unknown_as_any
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/validation/README.md
+++ b/seed/rust-sdk/validation/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_validation
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/variables/README.md
+++ b/seed/rust-sdk/variables/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_variables
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/version-no-default/README.md
+++ b/seed/rust-sdk/version-no-default/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_version
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/version/README.md
+++ b/seed/rust-sdk/version/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_version
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:

--- a/seed/rust-sdk/websocket-inferred-auth/README.md
+++ b/seed/rust-sdk/websocket-inferred-auth/README.md
@@ -20,6 +20,10 @@ Or install via cargo:
 cargo add seed_websocket_auth
 ```
 
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
 ## Usage
 
 Instantiate and use the client with the following:


### PR DESCRIPTION
Linear ticket:
- https://linear.app/buildwithfern/issue/FER-7099/rust-sdk-update-readmeconfigbuilder

## Description

Added support for referenceMarkdownPath, apiName, disabledFeatures, and whiteLabel fields in the ReadmeConfigBuilder output. This allows for more flexible and customizable readme generation based on the input configuration.