### PR TITLE
fix(ci): remove need for Auto Seed Update

### DIFF
--- a/.github/actions/cached-seed/action.yaml
+++ b/.github/actions/cached-seed/action.yaml
@@ -96,40 +96,6 @@ runs:
           ${{ inputs.skip-scripts == 'true' && '--skip-scripts' || '' }} \
           ${{ inputs.allow-unexpected-failures == 'true' && '--allow-unexpected-failures' || '' }}
 
-    - name: Validate results
-      if: inputs.validate-git-diff == 'true'
-      id: validate
-      shell: bash
-      run: |
-        # Validate results
-        # Split the input string into an array
-        IFS=',' read -ra FOLDERS <<< "${{ inputs.validation-exclude-paths }}"
-
-        # Build the exclude string
-        EXCLUDE_STRING=""
-        for folder in "${FOLDERS[@]}"; do
-          # Trim whitespace
-          folder=$(echo "$folder" | xargs)
-          if [ -n "$folder" ]; then
-            EXCLUDE_STRING="$EXCLUDE_STRING\":(exclude)$folder\" "
-          fi
-        done
-
-        # Remove trailing space
-        EXCLUDE_STRING=$(echo "$EXCLUDE_STRING" | sed 's/[[:space:]]*$//')
-
-        echo "exclude_string=$EXCLUDE_STRING" >> $GITHUB_OUTPUT
-        echo "Built git diff exclude string as: "
-        echo "$EXCLUDE_STRING"
-
-        if git --no-pager diff --exit-code -- $EXCLUDE_STRING; then
-          echo "Results are valid, saving to cache if not already."
-          echo "valid=true" >> $GITHUB_OUTPUT
-        else
-          echo "Changes detected in git-tracked files."
-          exit 1
-        fi
-
     - name: Save cache
       if: steps.cache.outputs.cache-hit != 'true' && inputs.cache-disabled != 'true'
       uses: actions/cache/save@v4

--- a/.github/actions/cached-seed/action.yaml
+++ b/.github/actions/cached-seed/action.yaml
@@ -12,10 +12,6 @@ inputs:
     description: Specific fixtures to run. If not supplied, will run all fixtures. Note - for multiple fixtures at once, separate by space, not comma.
     required: false
     default: ""
-  validate-git-diff:
-    description: Whether to validate that no git-tracked files were changed
-    required: false
-    default: "true"
   skip-scripts:
     description: Whether to skip running scripts during seed generation
     required: false

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -13,10 +13,6 @@ on:
       - "test-definitions-openapi/**"
       - "generators/**"
       - "seed/**"
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-    branches:
-      - main
   workflow_dispatch:
 
 # Cancel previous workflows on previous push


### PR DESCRIPTION
## Summary
1. In order to require all seed tests we needed to pass the `git diff` check ensuring that we have committed all seed changes in our PR
2. The quick fix to address this was to run "Auto Seed Update" to commit the changes to the PR immediately. But this has the unintended consequence of rerunning the original seed test from scratch that it was intended to fix - essentially doubling our time-to-first-signal from seed tests and slowing our developer velocity.
3. Since we still have the jobs to update seed after a PR is merged we can rely on that to keep the repo in sync (for now but we'll look for better alternatives long-term) and don't need to require these changes to be included in PR's at all. All we need is that the seed tests are fast and accurate