### PR TITLE
fix(ci): Update settings for manually triggering update-seed workflow

### DIFF
--- a/.github/actions/check-for-changed-files/action.yaml
+++ b/.github/actions/check-for-changed-files/action.yaml
@@ -6,6 +6,10 @@ inputs:
     description: The depth to fetch the repository, helps to speed up process to have sufficient history
     required: false
     default: "30"
+  base_sha:
+    description: The base SHA to compare against
+    required: false
+    default: ""
   files:
     description: File paths to check for changes (e.g., generators/java-sdk/**, .github/actions/cached-seed/action.yaml)
     required: true
@@ -38,4 +42,5 @@ runs:
       uses: tj-actions/changed-files@v46
       with:
         fetch_depth: ${{ inputs.fetch_depth }}
+        base_sha: ${{ inputs.base_sha }}
         files: ${{ inputs.files }}

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -143,7 +143,7 @@ jobs:
         id: setup-info
         run: |
           FETCH_DEPTH=0
-          MERGE_BASE=""
+          BASE_SHA=""
 
           if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.ref }}" != "refs/heads/main" ]]; then
             git fetch origin main
@@ -162,7 +162,6 @@ jobs:
           fi
 
           echo "fetch_depth=$FETCH_DEPTH" >> $GITHUB_OUTPUT
-          echo "sha=$SHA" >> $GITHUB_OUTPUT
           echo "base_sha=$BASE_SHA" >> $GITHUB_OUTPUT
 
       - name: Get generator changes for ${{ matrix.generator-name }}

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -6,6 +6,7 @@ on:
       - main
   workflow_dispatch:
 
+# CHRISM - move concurrency to job level not at workflow level
 # Cancel previous workflows on previous push
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -38,7 +39,6 @@ jobs:
             echo "update-by-push=true" >> $GITHUB_OUTPUT
             echo "update-by-pr=false" >> $GITHUB_OUTPUT
           else
-            # CHRISM - why skip scripts here?
             echo "skip-scripts=false" >> $GITHUB_OUTPUT
             echo "update-by-push=false" >> $GITHUB_OUTPUT
             echo "update-by-pr=true" >> $GITHUB_OUTPUT
@@ -53,10 +53,6 @@ jobs:
         generator-name: [seed, ruby, ruby-v2, openapi, python, postman, java, typescript, go, csharp, php, swift, rust]
         include:
           - files: |
-              .github/actions/cached-seed/action.yaml
-              .github/actions/check-for-changed-files/action.yaml
-              .github/actions/install/action.yaml
-              .github/workflows/seed.yml
               packages/seed/
               packages/ir-sdk/fern/apis/
               packages/cli/generation/ir-generator/
@@ -154,6 +150,8 @@ jobs:
           FETCH_DEPTH=0
           BASE_SHA=""
 
+          # For workflow_dispatch events that aren't on main, find the last commit from the main branch and compare against that
+          # For workflows involving the main branch, compare to the last commit
           if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.ref }}" != "refs/heads/main" ]]; then
             git fetch origin main
             MERGE_BASE=$(git merge-base HEAD origin/main)
@@ -161,10 +159,13 @@ jobs:
 
             FETCH_DEPTH=0
             BASE_SHA=$MERGE_BASE
-          elif [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.ref }}" == "refs/heads/main" ]]; then
+          elif [[ ("${{ github.event_name }}" == "workflow_dispatch" && "${{ github.ref }}" == "refs/heads/main") || \
+                  ("${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main") ]]; then            
+            PREVIOUS_MAIN_COMMIT=$(git rev-parse origin/main^)
+            echo "Previous commit on main: $PREVIOUS_MAIN_COMMIT"
+
             FETCH_DEPTH=200
-          elif [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]; then
-            FETCH_DEPTH=200
+            BASE_SHA=$PREVIOUS_MAIN_COMMIT
           else
             echo "Unexpected event and branch combination. Event: ${{ github.event_name }}, Branch: ${{ github.ref }}"
             exit 1

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -1440,25 +1440,3 @@ jobs:
           approver-gh-token: ${{ secrets.PR_BOT_GH_PAT }}
           pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
 
-  # Use always() to ensure this runs even if stages from needs are skipped.
-  # Add check back to make sure it doesn't run for failures or cancellations.
-  # Only trigger if there are no new patches (seed is up to date) and workflow
-  # is adding changes by commit (not by PR)
-  trigger-seed-snapshot-tests:
-    needs: [commit-seed-changes-by-push, changes, setup]
-    if: >-
-      ${{ 
-        always() && needs.setup.outputs.update-by-push == 'true' &&
-        needs.commit-seed-changes-by-push.outputs.has-patches == 'false' &&
-        !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
-      }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      # Note: this will trigger to the default branch of the repo, not the PR branch
-      - name: Trigger seed tests
-        uses: peter-evans/repository-dispatch@v2
-        with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
-          event-type: seed-tests
-          client-payload: '{"ref": "${{ github.ref }}"}'

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -6,7 +6,6 @@ on:
       - main
   workflow_dispatch:
 
-# CHRISM - move concurrency to job level not at workflow level
 # Cancel previous workflows on previous push
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -144,10 +143,9 @@ jobs:
             ${{ matrix.files }}
             .github/
 
-      - name: Setup Info
-        id: setup-info
+      - name: Setup Base SHA
+        id: setup-base-sha
         run: |
-          FETCH_DEPTH=0
           BASE_SHA=""
 
           # For workflow_dispatch events that aren't on main, find the last commit from the main branch and compare against that
@@ -157,28 +155,25 @@ jobs:
             MERGE_BASE=$(git merge-base HEAD origin/main)
             echo "Merge base commit: $MERGE_BASE"
 
-            FETCH_DEPTH=0
             BASE_SHA=$MERGE_BASE
           elif [[ ("${{ github.event_name }}" == "workflow_dispatch" && "${{ github.ref }}" == "refs/heads/main") || \
                   ("${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main") ]]; then            
             PREVIOUS_MAIN_COMMIT=$(git rev-parse origin/main^)
             echo "Previous commit on main: $PREVIOUS_MAIN_COMMIT"
 
-            FETCH_DEPTH=200
             BASE_SHA=$PREVIOUS_MAIN_COMMIT
           else
             echo "Unexpected event and branch combination. Event: ${{ github.event_name }}, Branch: ${{ github.ref }}"
             exit 1
           fi
 
-          echo "fetch_depth=$FETCH_DEPTH" >> $GITHUB_OUTPUT
           echo "base_sha=$BASE_SHA" >> $GITHUB_OUTPUT
 
       - name: Get generator changes for ${{ matrix.generator-name }}
         id: get-generator-changes
         uses: ./.github/actions/check-for-changed-files
         with:
-          base_sha: ${{ steps.setup-info.outputs.base_sha }}
+          base_sha: ${{ steps.setup-base-sha.outputs.base_sha }}
           files: ${{ matrix.files }}
 
       - name: Set output

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -152,9 +152,9 @@ jobs:
 
             FETCH_DEPTH=0
             BASE_SHA=$MERGE_BASE
-          else if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.ref }}" == "refs/heads/main" ]]; then
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.ref }}" == "refs/heads/main" ]]; then
             FETCH_DEPTH=200
-          else if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]; then
+          elif [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]; then
             FETCH_DEPTH=200
           else
             echo "Unexpected event and branch combination. Event: ${{ github.event_name }}, Branch: ${{ github.ref }}"

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -139,6 +139,15 @@ jobs:
       rust: ${{ steps.set-output.outputs.rust-changes }}
 
     steps:
+      - name: Checkout Files
+        uses: actions/checkout@v4
+        with:
+          # Get sufficient history to check for changes
+          fetch-depth: 0
+          sparse-checkout: |
+            ${{ matrix.files }}
+            .github/
+
       - name: Setup Info
         id: setup-info
         run: |

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -4,20 +4,11 @@ on:
   push:
     branches:
       - main
-    paths:
-      - ".github/workflows/update-seed.yml"
-      - "packages/seed/**"
-      - "packages/ir-sdk/fern/apis/**"
-      - "packages/cli/generation/ir-generator/**"
-      - "test-definitions/**"
-      - "test-definitions-openapi/**"
-      - "generators/**"
-      - "seed/**"
   workflow_dispatch:
 
 # Cancel previous workflows on previous push
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -37,20 +28,22 @@ jobs:
       update-by-push: ${{ steps.set-update-options.outputs.update-by-push }}
       update-by-pr: ${{ steps.set-update-options.outputs.update-by-pr }}
     steps:
-      # Apply by direct push for PRs to main, apply by PR for push to main or workflow_dispatch
+      # Apply by direct push for workflow_dispatches that aren't on main, apply by PR if running against main
       - name: Set update options
         id: set-update-options
         shell: bash
         run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.ref }}" != "refs/heads/main" ]]; then
             echo "skip-scripts=true" >> $GITHUB_OUTPUT
             echo "update-by-push=true" >> $GITHUB_OUTPUT
             echo "update-by-pr=false" >> $GITHUB_OUTPUT
           else
+            # CHRISM - why skip scripts here?
             echo "skip-scripts=false" >> $GITHUB_OUTPUT
             echo "update-by-push=false" >> $GITHUB_OUTPUT
             echo "update-by-pr=true" >> $GITHUB_OUTPUT
           fi
+
   changes:
     if: github.repository == 'fern-api/fern'
     runs-on: ubuntu-latest
@@ -131,7 +124,7 @@ jobs:
               seed/rust-sdk/
             generator-name: rust
     outputs:
-      seed: ${{ github.event_name == 'workflow_dispatch' ||  steps.set-output.outputs.seed-changes }}
+      seed: ${{ steps.set-output.outputs.seed-changes }}
       ruby: ${{ steps.set-output.outputs.ruby-changes }}
       ruby-v2: ${{ steps.set-output.outputs.ruby-v2-changes }}
       openapi: ${{ steps.set-output.outputs.openapi-changes }}
@@ -146,20 +139,37 @@ jobs:
       rust: ${{ steps.set-output.outputs.rust-changes }}
 
     steps:
-      - if: github.event_name != 'workflow_dispatch'
-        name: Checkout repo
-        uses: actions/checkout@v4
-        with:
-          # Get sufficient history to check for changes
-          fetch-depth: 200
-          sparse-checkout: |
-            ${{ matrix.files }}
-            .github/
+      - name: Setup Info
+        id: setup-info
+        run: |
+          FETCH_DEPTH=0
+          MERGE_BASE=""
+
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.ref }}" != "refs/heads/main" ]]; then
+            git fetch origin main
+            MERGE_BASE=$(git merge-base HEAD origin/main)
+            echo "Merge base commit: $MERGE_BASE"
+
+            FETCH_DEPTH=0
+            BASE_SHA=$MERGE_BASE
+          else if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.ref }}" == "refs/heads/main" ]]; then
+            FETCH_DEPTH=200
+          else if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]; then
+            FETCH_DEPTH=200
+          else
+            echo "Unexpected event and branch combination. Event: ${{ github.event_name }}, Branch: ${{ github.ref }}"
+            exit 1
+          fi
+
+          echo "fetch_depth=$FETCH_DEPTH" >> $GITHUB_OUTPUT
+          echo "sha=$SHA" >> $GITHUB_OUTPUT
+          echo "base_sha=$BASE_SHA" >> $GITHUB_OUTPUT
 
       - name: Get generator changes for ${{ matrix.generator-name }}
         id: get-generator-changes
         uses: ./.github/actions/check-for-changed-files
         with:
+          base_sha: ${{ steps.setup-info.outputs.base_sha }}
           files: ${{ matrix.files }}
 
       - name: Set output

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -1434,4 +1434,3 @@ jobs:
         with:
           approver-gh-token: ${{ secrets.PR_BOT_GH_PAT }}
           pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
-

--- a/seed/ruby-sdk-v2/api-wide-base-path/README.md
+++ b/seed/ruby-sdk-v2/api-wide-base-path/README.md
@@ -3,7 +3,7 @@
 [![fern shield](https://img.shields.io/badge/%F0%9F%8C%BF-Built%20with%20Fern-brightgreen)](https://buildwithfern.com?utm_source=github&utm_medium=github&utm_campaign=readme&utm_source=Seed%2FRuby)
 
 The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
-
+ CHRISM FORCING A CHANGE TO TEST
 ## Reference
 
 A full reference for this library is available [here](./reference.md).

--- a/seed/ruby-sdk-v2/api-wide-base-path/README.md
+++ b/seed/ruby-sdk-v2/api-wide-base-path/README.md
@@ -3,7 +3,7 @@
 [![fern shield](https://img.shields.io/badge/%F0%9F%8C%BF-Built%20with%20Fern-brightgreen)](https://buildwithfern.com?utm_source=github&utm_medium=github&utm_campaign=readme&utm_source=Seed%2FRuby)
 
 The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
- CHRISM FORCING A CHANGE TO TEST
+
 ## Reference
 
 A full reference for this library is available [here](./reference.md).


### PR DESCRIPTION
## Description
Linear ticket: https://linear.app/buildwithfern/issue/FER-7117/ci-update-settings-for-manually-triggering-update-seed-workflow
Closes FER-7117
Update workflow for manually triggered seed-update

## Changes Made
- Get full fetch depth
- Configure base_sha for changes depending on workflow
- Remove workflow level filtering of file changes and handle at job level
- Remove `trigger-seed-snapshot-tests`, no longer needed

## Testing
- Verified manual process in CI (and it successfully added a commit to this PR)
- Will monitor merges to main for main verification