### PR TITLE
fix(go): dont format or tidy when no go.mod file was created

### DIFF
--- a/generators/go-v2/base/src/project/GoProject.ts
+++ b/generators/go-v2/base/src/project/GoProject.ts
@@ -45,7 +45,8 @@ export class GoProject extends AbstractProject<AbstractGoGeneratorContext<BaseGo
             files: Object.values(this.goFiles).flat()
         });
         await this.writeRawFiles();
-        if (tidy) {
+        const isModule = this.getModuleConfig({ config: this.context.config }) != null;
+        if (tidy && isModule) {
             await this.runGoModTidy();
         }
         this.context.logger.debug(`Successfully wrote go files to ${this.absolutePathToOutputDirectory}`);
@@ -79,7 +80,8 @@ export class GoProject extends AbstractProject<AbstractGoGeneratorContext<BaseGo
         );
 
         await Promise.all(files.map(async (file) => await file.write(AbsoluteFilePath.of(outputDir))));
-        if (files.length > 0) {
+        const isModule = this.getModuleConfig({ config: this.context.config }) != null;
+        if (files.length > 0 && isModule) {
             await loggingExeca(this.context.logger, "go", ["fmt", "./..."], {
                 doNotPipeOutput: true,
                 cwd: this.absolutePathToOutputDirectory

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.13.13
+  changelogEntry:
+    - summary: |
+        final fix for embedded local packages
+      type: fix
+  createdAt: "2025-10-08"
+  irVersion: 60
+
 - version: 1.13.12
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Summary
This is the final followup to the original regression introduced a while ago that was fixed here https://github.com/fern-api/fern/pull/9756.

1. There are situations (generating embedded packages in existing go modules) where we should not produce a go.mod file with the file output
2. This means that we should not run `go fmt .` or `go mod tidy` on the intermediate files before writing them (which is why I originally broke this behavior since it was causing the generator to fail but didn't realize the intended outcome)
3. This never came up for us in seed testing since we always overwrite the module path for seed tests and therefore skip this code path