### PR TITLE
fix(cli): enable LICENSE file mounting in local Java SDK generation

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Fix: LICENSE file mounting in Docker containers during local generation
+      type: fix
+  createdAt: "2025-10-08"
+  irVersion: 61
+  version: 0.85.1
+
+- changelogEntry:
+    - summary: |
         Fix: Enable v61 IR to support c# generator 2.4.0+
       type: fix
   createdAt: "2025-10-06"

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/DockerExecutionEnvironment.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/DockerExecutionEnvironment.ts
@@ -25,6 +25,7 @@ export class DockerExecutionEnvironment implements ExecutionEnvironment {
         outputPath,
         snippetPath,
         snippetTemplatePath,
+        licenseFilePath,
         context,
         inspect,
         runner
@@ -42,6 +43,10 @@ export class DockerExecutionEnvironment implements ExecutionEnvironment {
         }
         if (snippetTemplatePath) {
             binds.push(`${snippetTemplatePath}:${DOCKER_PATH_TO_SNIPPET_TEMPLATES}`);
+        }
+
+        if (licenseFilePath) {
+            binds.push(`${licenseFilePath}:/tmp/LICENSE:ro`);
         }
 
         const envVars: Record<string, string> = {};

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/ExecutionEnvironment.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/ExecutionEnvironment.ts
@@ -10,6 +10,7 @@ export declare namespace ExecutionEnvironment {
         outputPath: AbsoluteFilePath;
         snippetPath?: AbsoluteFilePath;
         snippetTemplatePath?: AbsoluteFilePath;
+        licenseFilePath?: AbsoluteFilePath;
         context: TaskContext;
         inspect: boolean;
         runner: ContainerRunner | undefined;


### PR DESCRIPTION
## Description
Linear ticket: Refs [FER-6813: \[Anduril, java\] Resolve discrepancies between remote and local github generation](https://linear.app/buildwithfern/issue/FER-6813/anduril-java-resolve-discrepancies-between-remote-and-local-github)
<!-- Provide a clear and concise description of the changes made in this PR -->

Fixes parity issue where LICENSE files were missing from local generation output despite being configured in generators.yml.

## Changes Made
  - Add `licenseFilePath` parameter to `ExecutionEnvironment.ExecuteArgs` interface
  - Extract LICENSE file path from generator configuration in `runGenerator.ts`
  - Mount LICENSE file as `/tmp/LICENSE:ro` in Docker container

## Testing
<!-- Describe how you tested these changes -->
- [x] Manual testing completed -- tested directly with Anduril config
