### PR TITLE
feat(ci): Collect metrics for seed tests in CI

### DIFF
--- a/.github/actions/artifact-seed-test-times/action.yaml
+++ b/.github/actions/artifact-seed-test-times/action.yaml
@@ -1,0 +1,36 @@
+name: Artifact Seed Test Times
+description: Artifact the seed test start and end times found during seed jobs
+
+inputs:
+  sdk-name:
+    description: The name of the SDK to get the test matrix for
+    required: true
+  job-index:
+    description: The index of the job (when parallelized in a matrix strategy)
+    required: true
+  start-time:
+    description: The start time of the seed tests
+    required: true
+  end-time:
+    description: The end time of the seed tests
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Create Metrics File
+      id: create-metrics
+      shell: bash
+      run: |
+        METRICS_FILE_NAME="seed-metrics-${{ inputs.sdk-name }}-${{ inputs.job-index }}.json"
+        echo "file_name=$METRICS_FILE_NAME" >> $GITHUB_OUTPUT
+        echo "{\"index\":\"${{ inputs.job-index }}\",\"startTimeSeconds\":\"${{ inputs.start-time }}\",\"endTimeSeconds\":\"${{ inputs.end-time }}\"}" > $METRICS_FILE_NAME
+
+    # Save for at least a week to help track slowdowns if/when they show up
+    - name: Upload Metrics File
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ steps.create-metrics.outputs.file_name }}
+        path: ${{ steps.create-metrics.outputs.file_name }}
+        if-no-files-found: error
+        retention-days: 7

--- a/.github/actions/cached-seed/action.yaml
+++ b/.github/actions/cached-seed/action.yaml
@@ -24,10 +24,6 @@ inputs:
     description: "Whether to skip caching and always regenerate"
     required: false
     default: "true"
-  validation-exclude-paths:
-    description: "Comma separated list of paths to exclude from validation step, typically package manager/lock files"
-    required: false
-    default: "seed/*/.mock/*"
 
 runs:
   using: "composite"

--- a/.github/actions/run-seed-process/action.yaml
+++ b/.github/actions/run-seed-process/action.yaml
@@ -1,0 +1,89 @@
+name: Run Seed Process
+description: Run whole process for seed tests
+
+inputs:
+  sdk-name:
+    description: The name of the SDK to get the test matrix for
+    required: true
+  generator-path:
+    description: The path to the generator to run
+    required: true
+  fixtures-to-run:
+    description: The fixtures to run, as JSON
+    required: true
+  job-index:
+    description: The index of the job (when parallelized in a matrix strategy)
+    required: true
+  collect-metrics:
+    description: Whether to collect metrics
+    required: false
+    default: "false"
+
+outputs:
+  start_time:
+    description: The start time of the seed tests, used for metric collection
+    value: ${{ steps.start-seed-timer.outputs.start_time }}
+  end_time:
+    description: The end time of the seed tests, used for metric collection
+    value: ${{ steps.end-seed-timer.outputs.end_time }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Record seed start time
+      id: start-seed-timer
+      shell: bash
+      run: |
+        echo "start_time=$EPOCHSECONDS" >> $GITHUB_OUTPUT
+
+    - name: Echo package
+      shell: bash
+      run: echo '${{ inputs.fixtures-to-run }}' | jq .
+
+    # Format for seed tests
+    - name: JSON to String
+      id: json-to-string
+      shell: bash
+      run: |
+        json_data='${{ inputs.fixtures-to-run }}'
+        # Convert JSON array to space-separated string
+        string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+        echo "Generated string: '$string_result'"
+        echo "as-string=$string_result" >> $GITHUB_OUTPUT
+
+    - name: Checkout repo
+      uses: actions/checkout@v4
+
+    - name: Run seed
+      if: ${{ steps.json-to-string.outputs.as-string != 'leftovers' }}
+      uses: ./.github/actions/cached-seed
+      with:
+        generator-name: ${{ inputs.sdk-name }}
+        generator-path: ${{ inputs.generator-path }}
+        fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+    - name: Handle Seed Leftover Tests
+      if: ${{ steps.json-to-string.outputs.as-string == 'leftovers' }}
+      uses: ./.github/actions/handle-leftover-seed-tests
+      with:
+        sdk-name: ${{ inputs.sdk-name }}
+        generator-path: ${{ inputs.generator-path }}
+
+    - name: Record end time
+      id: end-seed-timer
+      # Log end time even if the tests fail
+      if: always() && !cancelled()
+      shell: bash
+      run: |
+        echo "end_time=$EPOCHSECONDS" >> $GITHUB_OUTPUT
+
+    # Collect the outputs from this matrix iteration
+    - name: Collect Metrics
+      # Save metrics even if the tests fail
+      if: ${{ always() && !cancelled() && inputs.collect-metrics == 'true' }}
+      uses: ./.github/actions/artifact-seed-test-times
+      with:
+        sdk-name: ${{ inputs.sdk-name }}
+        job-index: ${{ inputs.job-index }}
+        start-time: ${{ steps.start-seed-timer.outputs.start_time }}
+        end-time: ${{ steps.end-seed-timer.outputs.end_time }}

--- a/.github/workflows/nightly-seed-metrics.yml
+++ b/.github/workflows/nightly-seed-metrics.yml
@@ -1,0 +1,35 @@
+name: Nightly Seed Metrics
+
+on:
+  # Runs every night at 9:00 AM UTC (5:00 AM ET)
+  schedule:
+    - cron: "0 9 * * *"
+  # Runs when triggered manually to do so
+  workflow_dispatch:
+
+# Cancel previous workflows when another is triggered
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  trigger-seed-snapshot-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ github.ref == 'refs/heads/main' }}
+    steps:
+      # Note: this will trigger to the default branch of the repo, not the workflow_dispatch branch
+      - name: Trigger Seed Tests with Metrics
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.FERN_GITHUB_PAT }}
+          event-type: seed-test-metrics
+          client-payload: '{"ref": "${{ github.ref }}"}'
+
+  log-dispatch-rejection:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ github.ref != 'refs/heads/main' }}
+    steps:
+      run: |
+        echo "Did not dispatch the seed metrics workflow. Only triggers from main are allowed for this workflow."

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -10,7 +10,7 @@ on:
     branches:
       - main
   repository_dispatch:
-    types: [seed-tests]
+    types: [seed-test-metrics]
   workflow_call:
   workflow_dispatch:
 
@@ -20,6 +20,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  setup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      post-metrics: ${{ steps.set-options.outputs.post-metrics }}
+    steps:
+      - name: Set Options
+        id: set-options
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "repository_dispatch" && "${{ github.event.action }}" == "seed-test-metrics" ]]; then
+            echo "post-metricss=true" >> $GITHUB_OUTPUT
+          else
+            echo "post-metrics=false" >> $GITHUB_OUTPUT
+          fi
+
   changes:
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -253,7 +269,7 @@ jobs:
   ruby-model:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    needs: [changes, get-all-test-matrices]
+    needs: [setup, changes, get-all-test-matrices]
     if: >-
       ${{
         (needs.changes.outputs.ruby == 'true' && needs.get-all-test-matrices.outputs.ruby-model != ''
@@ -265,40 +281,25 @@ jobs:
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.ruby-model) }}
     steps:
-      - name: Echo package
-        run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-      - name: Checkout repo
+      - name: Checkout action file
         uses: actions/checkout@v4
-
-      - name: Run seed
-        if: ${{ steps.json-to-string.outputs.as-string != 'leftovers' }}
-        uses: ./.github/actions/cached-seed
         with:
-          generator-name: ruby-model
-          generator-path: generators/ruby
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+          sparse-checkout: |
+            .github/actions/run-seed-process
 
-      - name: Handle Seed Leftover Tests
-        if: ${{ steps.json-to-string.outputs.as-string == 'leftovers' }}
-        uses: ./.github/actions/handle-leftover-seed-tests
+      - name: Run All Seed Tests
+        uses: ./.github/actions/run-seed-process
         with:
           sdk-name: ruby-model
           generator-path: generators/ruby
+          fixtures-to-run: ${{toJson(matrix.fixtures)}}
+          job-index: ${{ strategy.job-index }}
+          collect-metrics: ${{ needs.setup.outputs.post-metrics }}
 
   ruby-sdk:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    needs: [changes, get-all-test-matrices]
+    needs: [setup, changes, get-all-test-matrices]
     if: >-
       ${{
         (needs.changes.outputs.ruby == 'true' && needs.get-all-test-matrices.outputs.ruby-sdk != ''
@@ -310,40 +311,25 @@ jobs:
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.ruby-sdk) }}
     steps:
-      - name: Echo package
-        run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-      - name: Checkout repo
+      - name: Checkout action file
         uses: actions/checkout@v4
-
-      - name: Run seed
-        if: ${{ steps.json-to-string.outputs.as-string != 'leftovers' }}
-        uses: ./.github/actions/cached-seed
         with:
-          generator-name: ruby-sdk
-          generator-path: generators/ruby
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+          sparse-checkout: |
+            .github/actions/run-seed-process
 
-      - name: Handle Seed Leftover Tests
-        if: ${{ steps.json-to-string.outputs.as-string == 'leftovers' }}
-        uses: ./.github/actions/handle-leftover-seed-tests
+      - name: Run All Seed Tests
+        uses: ./.github/actions/run-seed-process
         with:
           sdk-name: ruby-sdk
           generator-path: generators/ruby
+          fixtures-to-run: ${{toJson(matrix.fixtures)}}
+          job-index: ${{ strategy.job-index }}
+          collect-metrics: ${{ needs.setup.outputs.post-metrics }}
 
   ruby-sdk-v2:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    needs: [changes, get-all-test-matrices]
+    needs: [setup, changes, get-all-test-matrices]
     if: >-
       ${{
         (needs.changes.outputs.ruby-v2 == 'true' && needs.get-all-test-matrices.outputs.ruby-sdk-v2 != ''
@@ -355,41 +341,25 @@ jobs:
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.ruby-sdk-v2) }}
     steps:
-      - name: Echo package
-        run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-      - name: Checkout repo
+      - name: Checkout action file
         uses: actions/checkout@v4
-
-      - name: Run seed
-        if: ${{ steps.json-to-string.outputs.as-string != 'leftovers' }}
-        uses: ./.github/actions/cached-seed
         with:
-          generator-name: ruby-sdk-v2
-          generator-path: generators/ruby-v2
-          validation-exclude-paths: "seed/*/.mock/*,seed/**/Gemfile.lock"
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+          sparse-checkout: |
+            .github/actions/run-seed-process
 
-      - name: Handle Seed Leftover Tests
-        if: ${{ steps.json-to-string.outputs.as-string == 'leftovers' }}
-        uses: ./.github/actions/handle-leftover-seed-tests
+      - name: Run All Seed Tests
+        uses: ./.github/actions/run-seed-process
         with:
           sdk-name: ruby-sdk-v2
           generator-path: generators/ruby-v2
+          fixtures-to-run: ${{toJson(matrix.fixtures)}}
+          job-index: ${{ strategy.job-index }}
+          collect-metrics: ${{ needs.setup.outputs.post-metrics }}
 
   pydantic:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    needs: [changes, get-all-test-matrices]
+    needs: [setup, changes, get-all-test-matrices]
     if: >-
       ${{
         (needs.changes.outputs.python == 'true' && needs.get-all-test-matrices.outputs.pydantic != ''
@@ -401,131 +371,85 @@ jobs:
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.pydantic) }}
     steps:
-      - name: Echo package
-        run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-      - name: Checkout repo
+      - name: Checkout action file
         uses: actions/checkout@v4
-
-      - name: Run seed
-        if: ${{ steps.json-to-string.outputs.as-string != 'leftovers' }}
-        uses: ./.github/actions/cached-seed
         with:
-          generator-name: pydantic
-          generator-path: generators/python
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+          sparse-checkout: |
+            .github/actions/run-seed-process
 
-      - name: Handle Seed Leftover Tests
-        if: ${{ steps.json-to-string.outputs.as-string == 'leftovers' }}
-        uses: ./.github/actions/handle-leftover-seed-tests
+      - name: Run All Seed Tests
+        uses: ./.github/actions/run-seed-process
         with:
           sdk-name: pydantic
           generator-path: generators/python
+          fixtures-to-run: ${{toJson(matrix.fixtures)}}
+          job-index: ${{ strategy.job-index }}
+          collect-metrics: ${{ needs.setup.outputs.post-metrics }}
 
   python-sdk:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    needs: [changes, get-all-test-matrices]
-    strategy:
-      fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 15 # Limit the number of runners for this job
-      matrix:
-        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.python-sdk) }}
+    needs: [setup, changes, get-all-test-matrices]
     if: >-
       ${{
         (needs.changes.outputs.python == 'true' && needs.get-all-test-matrices.outputs.python-sdk != ''
         && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
       }}
-    steps:
-      - name: Echo package
-        run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-      - name: Checkout repo
-        uses: actions/checkout@v4
-
-      - name: Run seed
-        if: ${{ steps.json-to-string.outputs.as-string != 'leftovers' }}
-        uses: ./.github/actions/cached-seed
-        with:
-          generator-name: python-sdk
-          generator-path: generators/python
-          validation-exclude-paths: "seed/*/.mock/*,seed/**/poetry.lock"
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
-
-      - name: Handle Seed Leftover Tests
-        if: ${{ steps.json-to-string.outputs.as-string == 'leftovers' }}
-        uses: ./.github/actions/handle-leftover-seed-tests
-        with:
-          sdk-name: python-sdk
-          generator-path: generators/python
-
-  fastapi:
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    needs: [changes, get-all-test-matrices]
     strategy:
       fail-fast: false # Let all tests run, even if some fail
       max-parallel: 15 # Limit the number of runners for this job
       matrix:
-        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.fastapi) }}
+        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.python-sdk) }}
+    steps:
+      - name: Checkout action file
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github/actions/run-seed-process
+
+      - name: Run All Seed Tests
+        uses: ./.github/actions/run-seed-process
+        with:
+          sdk-name: python-sdk
+          generator-path: generators/python
+          fixtures-to-run: ${{toJson(matrix.fixtures)}}
+          job-index: ${{ strategy.job-index }}
+          collect-metrics: ${{ needs.setup.outputs.post-metrics }}
+
+  fastapi:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    needs: [setup, changes, get-all-test-matrices]
     if: >-
       ${{
         (needs.changes.outputs.python == 'true' && needs.get-all-test-matrices.outputs.fastapi != ''
         && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
       }}
+    strategy:
+      fail-fast: false # Let all tests run, even if some fail
+      max-parallel: 15 # Limit the number of runners for this job
+      matrix:
+        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.fastapi) }}
     steps:
-      - name: Echo package
-        run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-      - name: Checkout repo
+      - name: Checkout action file
         uses: actions/checkout@v4
-
-      - name: Run seed
-        if: ${{ steps.json-to-string.outputs.as-string != 'leftovers' }}
-        uses: ./.github/actions/cached-seed
         with:
-          generator-name: fastapi
-          generator-path: generators/python
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+          sparse-checkout: |
+            .github/actions/run-seed-process
 
-      - name: Handle Seed Leftover Tests
-        if: ${{ steps.json-to-string.outputs.as-string == 'leftovers' }}
-        uses: ./.github/actions/handle-leftover-seed-tests
+      - name: Run All Seed Tests
+        uses: ./.github/actions/run-seed-process
         with:
           sdk-name: fastapi
           generator-path: generators/python
+          fixtures-to-run: ${{toJson(matrix.fixtures)}}
+          job-index: ${{ strategy.job-index }}
+          collect-metrics: ${{ needs.setup.outputs.post-metrics }}
 
   openapi:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    needs: [changes, get-all-test-matrices]
+    needs: [setup, changes, get-all-test-matrices]
     if: >-
       ${{
         (needs.changes.outputs.openapi == 'true' && needs.get-all-test-matrices.outputs.openapi != ''
@@ -537,221 +461,145 @@ jobs:
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.openapi) }}
     steps:
-      - name: Echo package
-        run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-      - name: Checkout repo
+      - name: Checkout action file
         uses: actions/checkout@v4
-
-      - name: Run seed
-        if: ${{ steps.json-to-string.outputs.as-string != 'leftovers' }}
-        uses: ./.github/actions/cached-seed
         with:
-          generator-name: openapi
-          generator-path: generators/openapi
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+          sparse-checkout: |
+            .github/actions/run-seed-process
 
-      - name: Handle Seed Leftover Tests
-        if: ${{ steps.json-to-string.outputs.as-string == 'leftovers' }}
-        uses: ./.github/actions/handle-leftover-seed-tests
+      - name: Run All Seed Tests
+        uses: ./.github/actions/run-seed-process
         with:
           sdk-name: openapi
           generator-path: generators/openapi
+          fixtures-to-run: ${{toJson(matrix.fixtures)}}
+          job-index: ${{ strategy.job-index }}
+          collect-metrics: ${{ needs.setup.outputs.post-metrics }}
 
   postman:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    needs: [changes, get-all-test-matrices]
-    strategy:
-      fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 15 # Limit the number of runners for this job
-      matrix:
-        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.postman) }}
+    needs: [setup, changes, get-all-test-matrices]
     if: >-
       ${{
         (needs.changes.outputs.postman == 'true' && needs.get-all-test-matrices.outputs.postman != ''
         && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
       }}
-    steps:
-      - name: Echo package
-        run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-      - name: Checkout repo
-        uses: actions/checkout@v4
-
-      - name: Run seed
-        if: ${{ steps.json-to-string.outputs.as-string != 'leftovers' }}
-        uses: ./.github/actions/cached-seed
-        with:
-          generator-name: postman
-          generator-path: generators/postman
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
-
-      - name: Handle Seed Leftover Tests
-        if: ${{ steps.json-to-string.outputs.as-string == 'leftovers' }}
-        uses: ./.github/actions/handle-leftover-seed-tests
-        with:
-          sdk-name: postman
-          generator-path: generators/postman
-
-  java-sdk:
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    needs: [changes, get-all-test-matrices]
     strategy:
       fail-fast: false # Let all tests run, even if some fail
       max-parallel: 15 # Limit the number of runners for this job
       matrix:
-        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.java-sdk) }}
+        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.postman) }}
+    steps:
+      - name: Checkout action file
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github/actions/run-seed-process
+
+      - name: Run All Seed Tests
+        uses: ./.github/actions/run-seed-process
+        with:
+          sdk-name: postman
+          generator-path: generators/postman
+          fixtures-to-run: ${{toJson(matrix.fixtures)}}
+          job-index: ${{ strategy.job-index }}
+          collect-metrics: ${{ needs.setup.outputs.post-metrics }}
+
+  java-sdk:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    needs: [setup, changes, get-all-test-matrices]
     if: >-
       ${{
         (needs.changes.outputs.java == 'true' && needs.get-all-test-matrices.outputs.java-sdk != ''
         && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
       }}
-    steps:
-      - name: Echo package
-        run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-
-      - name: Checkout repo
-        uses: actions/checkout@v4
-
-      - name: Run seed
-        if: ${{ steps.json-to-string.outputs.as-string != 'leftovers' }}
-        uses: ./.github/actions/cached-seed
-        with:
-          generator-name: java-sdk
-          generator-path: generators/java generators/java-v2
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
-
-      - name: Handle Seed Leftover Tests
-        if: ${{ steps.json-to-string.outputs.as-string == 'leftovers' }}
-        uses: ./.github/actions/handle-leftover-seed-tests
-        with:
-          sdk-name: java-sdk
-          generator-path: generators/java generators/java-v2
-
-  java-model:
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    needs: [changes, get-all-test-matrices]
     strategy:
       fail-fast: false # Let all tests run, even if some fail
       max-parallel: 15 # Limit the number of runners for this job
       matrix:
-        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.java-model) }}
+        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.java-sdk) }}
+    steps:
+      - name: Checkout action file
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github/actions/run-seed-process
+
+      - name: Run All Seed Tests
+        uses: ./.github/actions/run-seed-process
+        with:
+          sdk-name: java-sdk
+          generator-path: generators/java generators/java-v2
+          fixtures-to-run: ${{toJson(matrix.fixtures)}}
+          job-index: ${{ strategy.job-index }}
+          collect-metrics: ${{ needs.setup.outputs.post-metrics }}
+
+  java-model:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    needs: [setup, changes, get-all-test-matrices]
     if: >-
       ${{
         (needs.changes.outputs.java == 'true' && needs.get-all-test-matrices.outputs.java-model != ''
         && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
       }}
-    steps:
-      - name: Echo package
-        run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-      - name: Checkout repo
-        uses: actions/checkout@v4
-
-      - name: Run seed
-        if: ${{ steps.json-to-string.outputs.as-string != 'leftovers' }}
-        uses: ./.github/actions/cached-seed
-        with:
-          generator-name: java-model
-          generator-path: generators/java
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
-
-      - name: Handle Seed Leftover Tests
-        if: ${{ steps.json-to-string.outputs.as-string == 'leftovers' }}
-        uses: ./.github/actions/handle-leftover-seed-tests
-        with:
-          sdk-name: java-model
-          generator-path: generators/java
-
-  java-spring:
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    needs: [changes, get-all-test-matrices]
     strategy:
       fail-fast: false # Let all tests run, even if some fail
       max-parallel: 15 # Limit the number of runners for this job
       matrix:
-        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.java-spring) }}
+        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.java-model) }}
+    steps:
+      - name: Checkout action file
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github/actions/run-seed-process
+
+      - name: Run All Seed Tests
+        uses: ./.github/actions/run-seed-process
+        with:
+          sdk-name: java-model
+          generator-path: generators/java
+          fixtures-to-run: ${{toJson(matrix.fixtures)}}
+          job-index: ${{ strategy.job-index }}
+          collect-metrics: ${{ needs.setup.outputs.post-metrics }}
+
+  java-spring:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    needs: [setup, changes, get-all-test-matrices]
     if: >-
       ${{
         (needs.changes.outputs.java == 'true' && needs.get-all-test-matrices.outputs.java-spring != ''
         && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
       }}
+    strategy:
+      fail-fast: false # Let all tests run, even if some fail
+      max-parallel: 15 # Limit the number of runners for this job
+      matrix:
+        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.java-spring) }}
     steps:
-      - name: Echo package
-        run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-      - name: Checkout repo
+      - name: Checkout action file
         uses: actions/checkout@v4
-
-      - name: Run seed
-        if: ${{ steps.json-to-string.outputs.as-string != 'leftovers' }}
-        uses: ./.github/actions/cached-seed
         with:
-          generator-name: java-spring
-          generator-path: generators/java
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+          sparse-checkout: |
+            .github/actions/run-seed-process
 
-      - name: Handle Seed Leftover Tests
-        if: ${{ steps.json-to-string.outputs.as-string == 'leftovers' }}
-        uses: ./.github/actions/handle-leftover-seed-tests
+      - name: Run All Seed Tests
+        uses: ./.github/actions/run-seed-process
         with:
           sdk-name: java-spring
           generator-path: generators/java
+          fixtures-to-run: ${{toJson(matrix.fixtures)}}
+          job-index: ${{ strategy.job-index }}
+          collect-metrics: ${{ needs.setup.outputs.post-metrics }}
 
-  typescript-sdk:
+  ts-sdk:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    needs: [changes, get-all-test-matrices]
+    needs: [setup, changes, get-all-test-matrices]
     if: >-
       ${{
         (needs.changes.outputs.typescript == 'true' && needs.get-all-test-matrices.outputs.ts-sdk != ''
@@ -763,87 +611,55 @@ jobs:
       matrix:
         include: ${{ fromJson(needs.get-all-test-matrices.outputs.ts-sdk) }}
     steps:
-      - name: Echo package
-        run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-
-      - name: Checkout repo
+      - name: Checkout action file
         uses: actions/checkout@v4
-
-      - name: Run seed
-        if: ${{ steps.json-to-string.outputs.as-string != 'leftovers' }}
-        uses: ./.github/actions/cached-seed
         with:
-          generator-name: ts-sdk
-          generator-path: generators/typescript
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
-          validation-exclude-paths: "seed/*/.mock/*,seed/ts-sdk/**/pnpm-lock.yaml"
+          sparse-checkout: |
+            .github/actions/run-seed-process
 
-      - name: Handle Seed Leftover Tests
-        if: ${{ steps.json-to-string.outputs.as-string == 'leftovers' }}
-        uses: ./.github/actions/handle-leftover-seed-tests
+      - name: Run All Seed Tests
+        uses: ./.github/actions/run-seed-process
         with:
           sdk-name: ts-sdk
           generator-path: generators/typescript
+          fixtures-to-run: ${{toJson(matrix.fixtures)}}
+          job-index: ${{ strategy.job-index }}
+          collect-metrics: ${{ needs.setup.outputs.post-metrics }}
 
-  typescript-express:
+  ts-express:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    needs: [changes, get-all-test-matrices]
-    strategy:
-      fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 15 # Limit the number of runners for this job
-      matrix:
-        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.ts-express) }}
+    needs: [setup, changes, get-all-test-matrices]
     if: >-
       ${{
         (needs.changes.outputs.typescript == 'true' && needs.get-all-test-matrices.outputs.ts-express != ''
         && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
       }}
+    strategy:
+      fail-fast: false # Let all tests run, even if some fail
+      max-parallel: 15 # Limit the number of runners for this job
+      matrix:
+        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.ts-express) }}
     steps:
-      - name: Echo package
-        run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-      - name: Checkout repo
+      - name: Checkout action file
         uses: actions/checkout@v4
-
-      - name: Run seed
-        if: ${{ steps.json-to-string.outputs.as-string != 'leftovers' }}
-        uses: ./.github/actions/cached-seed
         with:
-          generator-name: ts-express
-          generator-path: generators/typescript
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+          sparse-checkout: |
+            .github/actions/run-seed-process
 
-      - name: Handle Seed Leftover Tests
-        if: ${{ steps.json-to-string.outputs.as-string == 'leftovers' }}
-        uses: ./.github/actions/handle-leftover-seed-tests
+      - name: Run All Seed Tests
+        uses: ./.github/actions/run-seed-process
         with:
           sdk-name: ts-express
           generator-path: generators/typescript
+          fixtures-to-run: ${{toJson(matrix.fixtures)}}
+          job-index: ${{ strategy.job-index }}
+          collect-metrics: ${{ needs.setup.outputs.post-metrics }}
 
   go-fiber:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    needs: [changes, get-all-test-matrices]
+    needs: [setup, changes, get-all-test-matrices]
     if: >-
       ${{
         (needs.changes.outputs.go == 'true' && needs.get-all-test-matrices.outputs.go-fiber != ''
@@ -855,41 +671,25 @@ jobs:
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.go-fiber) }}
     steps:
-      - name: Echo package
-        run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-
-      - name: Checkout repo
+      - name: Checkout action file
         uses: actions/checkout@v4
-
-      - name: Run seed
-        if: ${{ steps.json-to-string.outputs.as-string != 'leftovers' }}
-        uses: ./.github/actions/cached-seed
         with:
-          generator-name: go-fiber
-          generator-path: generators/go generators/go-v2
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+          sparse-checkout: |
+            .github/actions/run-seed-process
 
-      - name: Handle Seed Leftover Tests
-        if: ${{ steps.json-to-string.outputs.as-string == 'leftovers' }}
-        uses: ./.github/actions/handle-leftover-seed-tests
+      - name: Run All Seed Tests
+        uses: ./.github/actions/run-seed-process
         with:
           sdk-name: go-fiber
           generator-path: generators/go generators/go-v2
+          fixtures-to-run: ${{toJson(matrix.fixtures)}}
+          job-index: ${{ strategy.job-index }}
+          collect-metrics: ${{ needs.setup.outputs.post-metrics }}
 
   go-model:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    needs: [changes, get-all-test-matrices]
+    needs: [setup, changes, get-all-test-matrices]
     if: >-
       ${{
         (needs.changes.outputs.go == 'true' && needs.get-all-test-matrices.outputs.go-model != ''
@@ -901,41 +701,25 @@ jobs:
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.go-model) }}
     steps:
-      - name: Echo package
-        run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-
-      - name: Checkout repo
+      - name: Checkout action file
         uses: actions/checkout@v4
-
-      - name: Run seed
-        if: ${{ steps.json-to-string.outputs.as-string != 'leftovers' }}
-        uses: ./.github/actions/cached-seed
         with:
-          generator-name: go-model
-          generator-path: generators/go generators/go-v2
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+          sparse-checkout: |
+            .github/actions/run-seed-process
 
-      - name: Handle Seed Leftover Tests
-        if: ${{ steps.json-to-string.outputs.as-string == 'leftovers' }}
-        uses: ./.github/actions/handle-leftover-seed-tests
+      - name: Run All Seed Tests
+        uses: ./.github/actions/run-seed-process
         with:
           sdk-name: go-model
           generator-path: generators/go generators/go-v2
+          fixtures-to-run: ${{toJson(matrix.fixtures)}}
+          job-index: ${{ strategy.job-index }}
+          collect-metrics: ${{ needs.setup.outputs.post-metrics }}
 
   go-sdk:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    needs: [changes, get-all-test-matrices]
+    needs: [setup, changes, get-all-test-matrices]
     if: >-
       ${{
         (needs.changes.outputs.go == 'true' && needs.get-all-test-matrices.outputs.go-sdk != ''
@@ -947,40 +731,25 @@ jobs:
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.go-sdk) }}
     steps:
-      - name: Echo package
-        run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-      - name: Checkout repo
+      - name: Checkout action file
         uses: actions/checkout@v4
-
-      - name: Run seed
-        if: ${{ steps.json-to-string.outputs.as-string != 'leftovers' }}
-        uses: ./.github/actions/cached-seed
         with:
-          generator-name: go-sdk
-          generator-path: generators/go generators/go-v2
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+          sparse-checkout: |
+            .github/actions/run-seed-process
 
-      - name: Handle Seed Leftover Tests
-        if: ${{ steps.json-to-string.outputs.as-string == 'leftovers' }}
-        uses: ./.github/actions/handle-leftover-seed-tests
+      - name: Run All Seed Tests
+        uses: ./.github/actions/run-seed-process
         with:
           sdk-name: go-sdk
           generator-path: generators/go generators/go-v2
+          fixtures-to-run: ${{toJson(matrix.fixtures)}}
+          job-index: ${{ strategy.job-index }}
+          collect-metrics: ${{ needs.setup.outputs.post-metrics }}
 
   csharp-model:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    needs: [changes, get-all-test-matrices]
+    needs: [setup, changes, get-all-test-matrices]
     if: >-
       ${{
         (needs.changes.outputs.csharp == 'true' && needs.get-all-test-matrices.outputs.csharp-model != ''
@@ -992,40 +761,25 @@ jobs:
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.csharp-model) }}
     steps:
-      - name: Echo package
-        run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-      - name: Checkout repo
+      - name: Checkout action file
         uses: actions/checkout@v4
-
-      - name: Run seed
-        if: ${{ steps.json-to-string.outputs.as-string != 'leftovers' }}
-        uses: ./.github/actions/cached-seed
         with:
-          generator-name: csharp-model
-          generator-path: generators/csharp
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+          sparse-checkout: |
+            .github/actions/run-seed-process
 
-      - name: Handle Seed Leftover Tests
-        if: ${{ steps.json-to-string.outputs.as-string == 'leftovers' }}
-        uses: ./.github/actions/handle-leftover-seed-tests
+      - name: Run All Seed Tests
+        uses: ./.github/actions/run-seed-process
         with:
           sdk-name: csharp-model
           generator-path: generators/csharp
+          fixtures-to-run: ${{toJson(matrix.fixtures)}}
+          job-index: ${{ strategy.job-index }}
+          collect-metrics: ${{ needs.setup.outputs.post-metrics }}
 
   csharp-sdk:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    needs: [changes, get-all-test-matrices]
+    needs: [setup, changes, get-all-test-matrices]
     if: >-
       ${{
         (needs.changes.outputs.csharp == 'true' && needs.get-all-test-matrices.outputs.csharp-sdk != ''
@@ -1037,40 +791,25 @@ jobs:
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.csharp-sdk) }}
     steps:
-      - name: Echo package
-        run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-      - name: Checkout repo
+      - name: Checkout action file
         uses: actions/checkout@v4
-
-      - name: Run seed
-        if: ${{ steps.json-to-string.outputs.as-string != 'leftovers' }}
-        uses: ./.github/actions/cached-seed
         with:
-          generator-name: csharp-sdk
-          generator-path: generators/csharp
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+          sparse-checkout: |
+            .github/actions/run-seed-process
 
-      - name: Handle Seed Leftover Tests
-        if: ${{ steps.json-to-string.outputs.as-string == 'leftovers' }}
-        uses: ./.github/actions/handle-leftover-seed-tests
+      - name: Run All Seed Tests
+        uses: ./.github/actions/run-seed-process
         with:
           sdk-name: csharp-sdk
           generator-path: generators/csharp
+          fixtures-to-run: ${{toJson(matrix.fixtures)}}
+          job-index: ${{ strategy.job-index }}
+          collect-metrics: ${{ needs.setup.outputs.post-metrics }}
 
   php-model:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    needs: [changes, get-all-test-matrices]
+    needs: [setup, changes, get-all-test-matrices]
     if: >-
       ${{
         (needs.changes.outputs.php == 'true' && needs.get-all-test-matrices.outputs.php-model != ''
@@ -1082,40 +821,25 @@ jobs:
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.php-model) }}
     steps:
-      - name: Echo package
-        run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-      - name: Checkout repo
+      - name: Checkout action file
         uses: actions/checkout@v4
-
-      - name: Run seed
-        if: ${{ steps.json-to-string.outputs.as-string != 'leftovers' }}
-        uses: ./.github/actions/cached-seed
         with:
-          generator-name: php-model
-          generator-path: generators/php
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+          sparse-checkout: |
+            .github/actions/run-seed-process
 
-      - name: Handle Seed Leftover Tests
-        if: ${{ steps.json-to-string.outputs.as-string == 'leftovers' }}
-        uses: ./.github/actions/handle-leftover-seed-tests
+      - name: Run All Seed Tests
+        uses: ./.github/actions/run-seed-process
         with:
           sdk-name: php-model
           generator-path: generators/php
+          fixtures-to-run: ${{toJson(matrix.fixtures)}}
+          job-index: ${{ strategy.job-index }}
+          collect-metrics: ${{ needs.setup.outputs.post-metrics }}
 
   php-sdk:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    needs: [changes, get-all-test-matrices]
+    needs: [setup, changes, get-all-test-matrices]
     if: >-
       ${{
         (needs.changes.outputs.php == 'true' && needs.get-all-test-matrices.outputs.php-sdk != ''
@@ -1127,40 +851,25 @@ jobs:
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.php-sdk) }}
     steps:
-      - name: Echo package
-        run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-      - name: Checkout repo
+      - name: Checkout action file
         uses: actions/checkout@v4
-
-      - name: Run seed
-        if: ${{ steps.json-to-string.outputs.as-string != 'leftovers' }}
-        uses: ./.github/actions/cached-seed
         with:
-          generator-name: php-sdk
-          generator-path: generators/php
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+          sparse-checkout: |
+            .github/actions/run-seed-process
 
-      - name: Handle Seed Leftover Tests
-        if: ${{ steps.json-to-string.outputs.as-string == 'leftovers' }}
-        uses: ./.github/actions/handle-leftover-seed-tests
+      - name: Run All Seed Tests
+        uses: ./.github/actions/run-seed-process
         with:
           sdk-name: php-sdk
           generator-path: generators/php
+          fixtures-to-run: ${{toJson(matrix.fixtures)}}
+          job-index: ${{ strategy.job-index }}
+          collect-metrics: ${{ needs.setup.outputs.post-metrics }}
 
   swift-sdk:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    needs: [changes, get-all-test-matrices]
+    needs: [setup, changes, get-all-test-matrices]
     if: >-
       ${{
         (needs.changes.outputs.swift == 'true' && needs.get-all-test-matrices.outputs.swift-sdk != ''
@@ -1172,40 +881,25 @@ jobs:
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.swift-sdk) }}
     steps:
-      - name: Echo package
-        run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-      - name: Checkout repo
+      - name: Checkout action file
         uses: actions/checkout@v4
-
-      - name: Run seed
-        if: ${{ steps.json-to-string.outputs.as-string != 'leftovers' }}
-        uses: ./.github/actions/cached-seed
         with:
-          generator-name: swift-sdk
-          generator-path: generators/swift
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+          sparse-checkout: |
+            .github/actions/run-seed-process
 
-      - name: Handle Seed Leftover Tests
-        if: ${{ steps.json-to-string.outputs.as-string == 'leftovers' }}
-        uses: ./.github/actions/handle-leftover-seed-tests
+      - name: Run All Seed Tests
+        uses: ./.github/actions/run-seed-process
         with:
           sdk-name: swift-sdk
           generator-path: generators/swift
+          fixtures-to-run: ${{toJson(matrix.fixtures)}}
+          job-index: ${{ strategy.job-index }}
+          collect-metrics: ${{ needs.setup.outputs.post-metrics }}
 
   rust-model:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    needs: [changes, get-all-test-matrices]
+    needs: [setup, changes, get-all-test-matrices]
     if: >-
       ${{
         (needs.changes.outputs.rust == 'true' && needs.get-all-test-matrices.outputs.rust-model != ''
@@ -1217,40 +911,25 @@ jobs:
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.rust-model) }}
     steps:
-      - name: Echo package
-        run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-      - name: Checkout repo
+      - name: Checkout action file
         uses: actions/checkout@v4
-
-      - name: Run seed
-        if: ${{ steps.json-to-string.outputs.as-string != 'leftovers' }}
-        uses: ./.github/actions/cached-seed
         with:
-          generator-name: rust-model
-          generator-path: generators/rust
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+          sparse-checkout: |
+            .github/actions/run-seed-process
 
-      - name: Handle Seed Leftover Tests
-        if: ${{ steps.json-to-string.outputs.as-string == 'leftovers' }}
-        uses: ./.github/actions/handle-leftover-seed-tests
+      - name: Run All Seed Tests
+        uses: ./.github/actions/run-seed-process
         with:
           sdk-name: rust-model
           generator-path: generators/rust
+          fixtures-to-run: ${{toJson(matrix.fixtures)}}
+          job-index: ${{ strategy.job-index }}
+          collect-metrics: ${{ needs.setup.outputs.post-metrics }}
 
   rust-sdk:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    needs: [changes, get-all-test-matrices]
+    needs: [setup, changes, get-all-test-matrices]
     if: >-
       ${{
         (needs.changes.outputs.rust == 'true' && needs.get-all-test-matrices.outputs.rust-sdk != ''
@@ -1262,35 +941,20 @@ jobs:
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.rust-sdk) }}
     steps:
-      - name: Echo package
-        run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-      - name: Checkout repo
+      - name: Checkout action file
         uses: actions/checkout@v4
-
-      - name: Run seed
-        if: ${{ steps.json-to-string.outputs.as-string != 'leftovers' }}
-        uses: ./.github/actions/cached-seed
         with:
-          generator-name: rust-sdk
-          generator-path: generators/rust
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+          sparse-checkout: |
+            .github/actions/run-seed-process
 
-      - name: Handle Seed Leftover Tests
-        if: ${{ steps.json-to-string.outputs.as-string == 'leftovers' }}
-        uses: ./.github/actions/handle-leftover-seed-tests
+      - name: Run All Seed Tests
+        uses: ./.github/actions/run-seed-process
         with:
           sdk-name: rust-sdk
           generator-path: generators/rust
+          fixtures-to-run: ${{toJson(matrix.fixtures)}}
+          job-index: ${{ strategy.job-index }}
+          collect-metrics: ${{ needs.setup.outputs.post-metrics }}
 
   # Round up all tests into job with defined name for PR merge requirements
   seed-test-results:
@@ -1309,8 +973,8 @@ jobs:
         java-sdk,
         java-model,
         java-spring,
-        typescript-sdk,
-        typescript-express,
+        ts-sdk,
+        ts-express,
         go-fiber,
         go-model,
         go-sdk,
@@ -1322,6 +986,10 @@ jobs:
         rust-model,
         rust-sdk
       ]
+    if: >-
+      ${{
+        always() && !cancelled()
+      }}
     strategy:
       fail-fast: false # Let all tests run, even if some fail
       matrix:
@@ -1338,8 +1006,8 @@ jobs:
             java-sdk,
             java-model,
             java-spring,
-            typescript-sdk,
-            typescript-express,
+            ts-sdk,
+            ts-express,
             go-fiber,
             go-model,
             go-sdk,
@@ -1351,34 +1019,201 @@ jobs:
             rust-model,
             rust-sdk
           ]
-    if: >-
-      ${{
-        always() && !cancelled()
-      }}
+    outputs:
+      ruby-model-passing: ${{ steps.report-results.outputs.ruby-model-passing }}
+      ruby-sdk-passing: ${{ steps.report-results.outputs.ruby-sdk-passing }}
+      ruby-sdk-v2-passing: ${{ steps.report-results.outputs.ruby-sdk-v2-passing }}
+      pydantic-passing: ${{ steps.report-results.outputs.pydantic-passing }}
+      python-sdk-passing: ${{ steps.report-results.outputs.python-sdk-passing }}
+      fastapi-passing: ${{ steps.report-results.outputs.fastapi-passing }}
+      openapi-passing: ${{ steps.report-results.outputs.openapi-passing }}
+      postman-passing: ${{ steps.report-results.outputs.postman-passing }}
+      java-sdk-passing: ${{ steps.report-results.outputs.java-sdk-passing }}
+      java-model-passing: ${{ steps.report-results.outputs.java-model-passing }}
+      java-spring-passing: ${{ steps.report-results.outputs.java-spring-passing }}
+      ts-sdk-passing: ${{ steps.report-results.outputs.ts-sdk-passing }}
+      ts-express-passing: ${{ steps.report-results.outputs.ts-express-passing }}
+      go-fiber-passing: ${{ steps.report-results.outputs.go-fiber-passing }}
+      go-model-passing: ${{ steps.report-results.outputs.go-model-passing }}
+      go-sdk-passing: ${{ steps.report-results.outputs.go-sdk-passing }}
+      csharp-model-passing: ${{ steps.report-results.outputs.csharp-model-passing }}
+      csharp-sdk-passing: ${{ steps.report-results.outputs.csharp-sdk-passing }}
+      php-model-passing: ${{ steps.report-results.outputs.php-model-passing }}
+      php-sdk-passing: ${{ steps.report-results.outputs.php-sdk-passing }}
+      swift-sdk-passing: ${{ steps.report-results.outputs.swift-sdk-passing }}
+      rust-model-passing: ${{ steps.report-results.outputs.rust-model-passing }}
+      rust-sdk-passing: ${{ steps.report-results.outputs.rust-sdk-passing }}
     steps:
-      - name: Report passing status of ${{ matrix.job-name }} seed tests
-        if: >-
-          ${{ 
-            fromJSON(toJSON(needs))[matrix.job-name].result == 'success'
-          }}
+      - name: Report ${{ matrix.job-name }} seed test results
+        id: report-results
         run: |
-          echo "${{ matrix.job-name }} seed tests are all passing"
+          RESULT="${{ fromJSON(toJSON(needs))[matrix.job-name].result }}"
 
-      - name: Report no changes detected for ${{ matrix.job-name }} seed tests (pass)
-        if: >-
-          ${{ 
-            fromJSON(toJSON(needs))[matrix.job-name].result == 'skipped'
-          }}
-        run: |
-          echo "No changes detected for ${{ matrix.job-name }} seed tests. Passing."
+          # Set output for passing status
+          if [ "$RESULT" = "success" ] || [ "$RESULT" = "skipped" ]; then
+            echo "${{ matrix.job-name }}-passing=true" >> $GITHUB_OUTPUT
+          else
+            echo "${{ matrix.job-name }}-passing=false" >> $GITHUB_OUTPUT
+          fi
 
-      - name: Report failing status of ${{ matrix.job-name }} seed tests
-        if: >-
-          ${{ 
-            fromJSON(toJSON(needs))[matrix.job-name].result != 'success' &&  
-            fromJSON(toJSON(needs))[matrix.job-name].result != 'skipped'
-          }}
+          # Log results and fail if required (for PR requirements)
+          if [ "$RESULT" = "success" ]; then
+            echo "${{ matrix.job-name }} seed tests are all passing"
+          elif [ "$RESULT" = "skipped" ]; then
+            echo "No changes detected for ${{ matrix.job-name }} seed tests. Passing."
+          else
+            echo "${{ matrix.job-name }} seed tests had changes and were not successful"
+            echo "Result of parallelized tests: $RESULT"
+            exit 1
+          fi
+
+  post-metrics:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs:
+      [
+        setup,
+        seed-test-results,
+        ruby-model,
+        ruby-sdk,
+        ruby-sdk-v2,
+        pydantic,
+        python-sdk,
+        fastapi,
+        openapi,
+        postman,
+        java-sdk,
+        java-model,
+        java-spring,
+        ts-sdk,
+        ts-express,
+        go-fiber,
+        go-model,
+        go-sdk,
+        csharp-model,
+        csharp-sdk,
+        php-model,
+        php-sdk,
+        swift-sdk,
+        rust-model,
+        rust-sdk
+      ]
+    if: ${{ always() && !cancelled() && needs.setup.outputs.post-metrics == 'true' }}
+    strategy:
+      fail-fast: false # Let all tests run, even if some fail
+      matrix:
+        seed-generator-alias:
+          [
+            ruby-model,
+            ruby-sdk,
+            ruby-sdk-v2,
+            pydantic,
+            python-sdk,
+            fastapi,
+            openapi,
+            postman,
+            java-sdk,
+            java-model,
+            java-spring,
+            ts-sdk,
+            ts-express,
+            go-fiber,
+            go-model,
+            go-sdk,
+            csharp-model,
+            csharp-sdk,
+            php-model,
+            php-sdk,
+            swift-sdk,
+            rust-model,
+            rust-sdk
+          ]
+    steps:
+      - name: Create Metrics Artifacts Info
+        shell: bash
+        id: artifacts-info
         run: |
-          echo "${{ matrix.job-name }} seed tests had changes and were not successful"
-          echo "Result of parallelized tests: ${{ fromJSON(toJSON(needs))[matrix.job-name].result }}"
-          exit 1
+          DIRECTORY=seed-test-time-artifacts
+          echo "metrics_path=$DIRECTORY" >> $GITHUB_OUTPUT
+          echo "metrics_pattern=seed-metrics-${{ matrix.seed-generator-alias }}-*.json" >> $GITHUB_OUTPUT
+          if [ ! -d "$DIRECTORY" ]; then
+            echo "'$DIRECTORY' does NOT exist, creating it now."
+            mkdir $DIRECTORY
+          else
+            echo "WARNING: Directory '$DIRECTORY' already exists. Not an immediate error but could cause a problem downstream."
+          fi
+
+      - name: Download Seed Test Time Artifacts
+        uses: actions/download-artifact@v5
+        with:
+          path: ${{ steps.artifacts-info.outputs.metrics_path }}
+          pattern: ${{ steps.artifacts-info.outputs.metrics_pattern }}
+          merge-multiple: true
+
+      - name: Get Number of Metrics Artifacts
+        shell: bash
+        id: get-number-of-metric-artifacts
+        run: |
+          METRICS_PATH="${{ steps.artifacts-info.outputs.metrics_path }}"
+          METRICS_PATTERN="${{ steps.artifacts-info.outputs.metrics_pattern }}"
+          echo "Looking for files in: $METRICS_PATH"
+          echo "Using pattern: $METRICS_PATTERN"
+
+          # Check for artifacts
+          file_count=$(find "./$METRICS_PATH" -type f -name "$METRICS_PATTERN" | wc -l)
+          if [ "$file_count" -gt 0 ]; then
+            echo "Found $file_count artifacts for seed metrics"
+          else
+            echo "Found 0 artifacts for seed metrics"
+            exit 1
+          fi
+
+      - name: Display Content of Metrics Artifacts Folder
+        run: |
+          METRICS_PATH="${{ steps.artifacts-info.outputs.metrics_path }}"
+          echo "Content of '$METRICS_PATH' folder:"
+          ls -R $METRICS_PATH/
+
+      - name: Parse Seed Test Metrics
+        id: parse-seed-test-metrics
+        run: |
+          METRICS_PATH="${{ steps.artifacts-info.outputs.metrics_path }}"
+          METRICS_PATTERN="${{ steps.artifacts-info.outputs.metrics_pattern }}"
+
+          # Combine all JSON files into an array and find min start time and max end time
+          min_start=$(jq -r '.startTimeSeconds' ./$METRICS_PATH/$METRICS_PATTERN | sort | head -n 1)
+          max_end=$(jq -r '.endTimeSeconds' ./$METRICS_PATH/$METRICS_PATTERN | sort | tail -n 1)
+
+          # Calculate duration in seconds
+          duration_seconds=$((max_end - min_start))
+
+          echo "Earliest start time: $min_start"
+          echo "Latest end time: $max_end"
+          echo "Duration: $duration_seconds"
+          echo "duration_seconds=$duration_seconds" >> $GITHUB_OUTPUTß
+
+          # Determine if all tests passing. Note: seed-generator-alias needs to match CI job name for this parsing to work
+          all_tests_passing="${{ needs.seed-test-results.outputs[format('{0}-passing', matrix.seed-generator-alias)] }}"
+
+          # If empty for any reason, default to false
+          if [ -z "$all_tests_passing" ]; then
+            all_tests_passing="false"
+          fi
+
+          echo "all_tests_passing=$all_tests_passing" >> $GITHUB_OUTPUT
+
+      - name: Post to PostHog
+        # https://github.com/PostHog/posthog-github-action
+        uses: PostHog/posthog-github-action@v0.1
+        with:
+          posthog-token: ${{ secrets.POSTHOG_API_KEY }}
+          event: "gh-actions-seed-test-metrics-event"
+          properties: |
+            {
+              "event_type": "${{ github.event_name }}",
+              "branch": "${{ github.ref_name }}",
+              "seed_generator_alias": "${{ matrix.seed-generator-alias }}",
+              "run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+              "duration_seconds": "${{ steps.parse-seed-test-metrics.outputs.duration_seconds }}",
+              "all_tests_passing": "${{ steps.parse-seed-test-metrics.outputs.all_tests_passing }}"
+            }


### PR DESCRIPTION
## Description
Linear ticket: https://linear.app/buildwithfern/issue/FER-6900/setup-performance-metrics-for-seed
Closes FER-6900
After nightly run of seed balancing, kickoff a seed test run that will collect metrics and post to PostHog
PostHog dashboard: https://us.posthog.com/project/10039/dashboard/580716

## Changes Made
- Added repository dispatch to nightly run to start metrics collection
- Added setup job to seed.yml to determine if metrics should be collected or not
- Collapsed a lot of code per generator into shared files
- Removed validation-exclude-paths (dead code)
- Added new job to collect metrics and post to PostHog

## Testing
- Tested in CI, last run here: https://github.com/fern-api/fern/actions/runs/18383197146
