### PR TITLE
fix(ci): Format nightly seed metrics workflow and force changes when collecting metrics

### DIFF
--- a/.github/workflows/nightly-seed-metrics.yml
+++ b/.github/workflows/nightly-seed-metrics.yml
@@ -31,5 +31,6 @@ jobs:
     timeout-minutes: 5
     if: ${{ github.ref != 'refs/heads/main' }}
     steps:
-      run: |
-        echo "Did not dispatch the seed metrics workflow. Only triggers from main are allowed for this workflow."
+      - name: Log Dispatch Rejection
+        run: |
+          echo "Did not dispatch the seed metrics workflow. Only triggers from main are allowed for this workflow."

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -30,15 +30,20 @@ jobs:
         id: set-options
         shell: bash
         run: |
+          echo "GitHub Event: ${{ github.event_name }}"
+          echo "GitHub Event Action: ${{ github.event.action }}"
           if [[ "${{ github.event_name }}" == "repository_dispatch" && "${{ github.event.action }}" == "seed-test-metrics" ]]; then
-            echo "post-metricss=true" >> $GITHUB_OUTPUT
+            echo "post-metrics=true" >> $GITHUB_OUTPUT
+            echo "Set to collect metrics on this run"
           else
             echo "post-metrics=false" >> $GITHUB_OUTPUT
+            echo "Will not collect metrics on this run"
           fi
 
   changes:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    needs: [setup]
     strategy:
       matrix:
         generator-name: [ruby, ruby-v2, openapi, python, postman, java, typescript, go, csharp, php, swift, rust]
@@ -136,7 +141,13 @@ jobs:
       - name: Set output
         id: set-output
         run: |
-          echo "${{ matrix.generator-name }}-changes=${{ steps.get-generator-changes.outputs.any_changed }}" >> $GITHUB_OUTPUT
+          if [[ "${{ needs.setup.outputs.post-metrics }}" == "true" ]]; then
+            echo "${{ matrix.generator-name }}-changes=true" >> $GITHUB_OUTPUT
+            echo "Forced changes to true to collect metrics data."
+          else
+            echo "${{ matrix.generator-name }}-changes=${{ steps.get-generator-changes.outputs.any_changed }}" >> $GITHUB_OUTPUT
+            echo "Set changes according to output of get-generator-changes step"
+          fi
 
   get-all-test-matrices:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description
Linear ticket: https://linear.app/buildwithfern/issue/FER-7156/ci-fix-formatting-and-workflow-for-seed-metrics
Closes FER-7156
Update workflow to be...valid... and fixing the use case of changes to always be true when collecting metrics

## Changes Made
- Force `changes` to be true when collecting metrics 
- Formatting fix to nightly-seed-metrics workflow

## Testing
- Verified here: https://github.com/fern-api/fern/actions/runs/18387849276
