### PR TITLE
fix(typescript): Wire tests for paginated endpoints check page token

### DIFF
--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.7.2
+  changelogEntry:
+    - summary: |
+        Wire test generation for paginated endpoints checks for page tokens and generates different mock responses for first and subsequent pages.
+      type: fix
+  createdAt: "2025-10-09"
+  irVersion: 60
+
 - version: 3.7.1
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description
Paginated body wire tests were failing because our mocks weren't taking into account the page token request. This wasn't a problem for GET endpoints because the mock is less specific, but it causes problems for POST endpoints (example is a search).

## Changes Made
- Differentiate first and second page mocks to take into account the page token

## Testing
Seed