### PR TITLE
fix(ci): Fix update-seed for push to main workflow

### DIFF
--- a/.github/actions/apply-update-seed-patches/action.yaml
+++ b/.github/actions/apply-update-seed-patches/action.yaml
@@ -41,7 +41,7 @@ runs:
       with:
         path: ./artifacts
         merge-multiple: true
-    
+
     - name: Display content of a folder
       shell: bash
       run: |

--- a/.github/actions/apply-update-seed-patches/action.yaml
+++ b/.github/actions/apply-update-seed-patches/action.yaml
@@ -1,0 +1,70 @@
+name: Apply Update Seed Patches
+description: Apply the patch artifacts that match the passed in pattern. Let the calling workflow apply patches by commit or PR depending on workflow.
+
+inputs:
+  patch-pattern:
+    description: "Pattern to determine which artifacts to apply as patches."
+    required: true
+  checkout-ref:
+    description: "Specific branch to checkout, depending on workflow. No input will checkout default branch in detached HEAD (okay for applying by PR workflow)"
+    required: false
+    default: ""
+
+outputs:
+  has-patches:
+    description: "Whether or not there were patches found to update seed."
+    value: ${{ steps.get-number-of-patches.outputs.HAS_PATCHES }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout repo
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.checkout-ref }}
+
+    - name: Create artifacts downloads directory
+      shell: bash
+      run: |
+        DIRECTORY=artifacts
+        if [ ! -d "$DIRECTORY" ]; then
+          echo "'$DIRECTORY' does NOT exist, creating it now."
+          mkdir $DIRECTORY
+        else
+          echo "WARNING: Directory '$DIRECTORY' already exists. Not an immediate error but could cause a problem downstream."
+        fi
+
+    # Merge-multiple is set so all patches are downloaded into the same folder. Otherwise
+    # they are subfoldered into folders that match *.patch pattern and cause errors downstream
+    - name: Download patches
+      uses: actions/download-artifact@v5
+      with:
+        path: ./artifacts
+        merge-multiple: true
+    
+    - name: Display content of a folder
+      shell: bash
+      run: |
+        echo "Content of 'artifacts' folder:"
+        ls -R artifacts/
+
+    - name: Get number of patches
+      shell: bash
+      id: get-number-of-patches
+      run: |
+        # Apply patches per generator for multiple, separate, PRs
+        PATCHES_PATTERN="${{ inputs.patch-pattern }}"
+        file_count=$(find ./artifacts -type f -name "$PATCHES_PATTERN" | wc -l)
+        echo "Number of patches downloaded: $file_count"
+        if [ "$file_count" -gt 0 ]; then
+          echo "HAS_PATCHES=true" >> $GITHUB_OUTPUT
+        else
+          echo "HAS_PATCHES=false" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Apply patches
+      shell: bash
+      if: ${{ steps.get-number-of-patches.outputs.HAS_PATCHES == 'true' }}
+      run: |
+        PATCHES_PATTERN="${{ inputs.patch-pattern }}"
+        git apply artifacts/$PATCHES_PATTERN

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -269,10 +269,15 @@ jobs:
           fi
 
   ruby-model-seed-update:
-    needs: [changes, setup, get-all-test-matrices]
-    if: ${{ needs.changes.outputs.ruby == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    needs: [changes, setup, get-all-test-matrices]
+    if: >-
+      ${{ 
+        always() && !cancelled() &&
+        (needs.changes.outputs.ruby == 'true' ||  needs.changes.outputs.seed == 'true') &&
+        needs.get-all-test-matrices.outputs.ruby-model != ''
+      }}
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 10 # Limit the number of runners for this job to 10
@@ -305,10 +310,15 @@ jobs:
           skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
 
   ruby-sdk-seed-update:
-    needs: [changes, setup, get-all-test-matrices]
-    if: ${{ needs.changes.outputs.ruby == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    needs: [changes, setup, get-all-test-matrices]
+    if: >-
+      ${{ 
+        always() && !cancelled() &&
+        (needs.changes.outputs.ruby == 'true' ||  needs.changes.outputs.seed == 'true') &&
+        needs.get-all-test-matrices.outputs.ruby-sdk != ''
+      }}
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 10 # Limit the number of runners for this job to 10
@@ -342,11 +352,15 @@ jobs:
           skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
 
   ruby-sdk-v2-seed-update:
-    needs: [changes, setup, get-all-test-matrices]
-    if: ${{ needs.changes.outputs.ruby-v2 == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
-
+    needs: [changes, setup, get-all-test-matrices]
+    if: >-
+      ${{ 
+        always() && !cancelled() &&
+        (needs.changes.outputs.ruby-v2 == 'true' ||  needs.changes.outputs.seed == 'true') &&
+        needs.get-all-test-matrices.outputs.ruby-sdk-v2 != ''
+      }}
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 10 # Limit the number of runners for this job to 10
@@ -380,10 +394,15 @@ jobs:
           skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
 
   pydantic-seed-update:
-    needs: [changes, setup, get-all-test-matrices]
-    if: ${{ needs.changes.outputs.python == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    needs: [changes, setup, get-all-test-matrices]
+    if: >-
+      ${{ 
+        always() && !cancelled() &&
+        (needs.changes.outputs.python == 'true' ||  needs.changes.outputs.seed == 'true') &&
+        needs.get-all-test-matrices.outputs.pydantic != ''
+      }}
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 10 # Limit the number of runners for this job to 10
@@ -417,10 +436,15 @@ jobs:
           skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
 
   python-sdk-seed-update:
-    needs: [changes, setup, get-all-test-matrices]
-    if: ${{ needs.changes.outputs.python == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    needs: [changes, setup, get-all-test-matrices]
+    if: >-
+      ${{ 
+        always() && !cancelled() &&
+        (needs.changes.outputs.python == 'true' ||  needs.changes.outputs.seed == 'true') &&
+        needs.get-all-test-matrices.outputs.python-sdk != ''
+      }}
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 10 # Limit the number of runners for this job to 10
@@ -454,10 +478,15 @@ jobs:
           skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
 
   fastapi-seed-update:
-    needs: [changes, setup, get-all-test-matrices]
-    if: ${{ needs.changes.outputs.python == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    needs: [changes, setup, get-all-test-matrices]
+    if: >-
+      ${{ 
+        always() && !cancelled() &&
+        (needs.changes.outputs.python == 'true' ||  needs.changes.outputs.seed == 'true') &&
+        needs.get-all-test-matrices.outputs.fastapi != ''
+      }}
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 10 # Limit the number of runners for this job to 10
@@ -491,10 +520,15 @@ jobs:
           skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
 
   openapi-seed-update:
-    needs: [changes, setup, get-all-test-matrices]
-    if: ${{ needs.changes.outputs.openapi == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    needs: [changes, setup, get-all-test-matrices]
+    if: >-
+      ${{ 
+        always() && !cancelled() &&
+        (needs.changes.outputs.openapi == 'true' ||  needs.changes.outputs.seed == 'true') &&
+        needs.get-all-test-matrices.outputs.openapi != ''
+      }}
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 10 # Limit the number of runners for this job to 10
@@ -528,10 +562,15 @@ jobs:
           skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
 
   postman-seed-update:
-    needs: [changes, setup, get-all-test-matrices]
-    if: ${{ needs.changes.outputs.postman == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    needs: [changes, setup, get-all-test-matrices]
+    if: >-
+      ${{ 
+        always() && !cancelled() &&
+        (needs.changes.outputs.psotman == 'true' ||  needs.changes.outputs.seed == 'true') &&
+        needs.get-all-test-matrices.outputs.postman != ''
+      }}
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 10 # Limit the number of runners for this job to 10
@@ -565,10 +604,15 @@ jobs:
           skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
 
   java-sdk-seed-update:
-    needs: [changes, setup, get-all-test-matrices]
-    if: ${{ needs.changes.outputs.java == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    needs: [changes, setup, get-all-test-matrices]
+    if: >-
+      ${{ 
+        always() && !cancelled() &&
+        (needs.changes.outputs.java == 'true' ||  needs.changes.outputs.seed == 'true') &&
+        needs.get-all-test-matrices.outputs.java-sdk != ''
+      }}
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 10 # Limit the number of runners for this job to 10
@@ -602,10 +646,15 @@ jobs:
           skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
 
   java-model-seed-update:
-    needs: [changes, setup, get-all-test-matrices]
-    if: ${{ needs.changes.outputs.java == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    needs: [changes, setup, get-all-test-matrices]
+    if: >-
+      ${{ 
+        always() && !cancelled() &&
+        (needs.changes.outputs.java == 'true' ||  needs.changes.outputs.seed == 'true') &&
+        needs.get-all-test-matrices.outputs.java-model != ''
+      }}
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 10 # Limit the number of runners for this job to 10
@@ -639,10 +688,15 @@ jobs:
           skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
 
   java-spring-seed-update:
-    needs: [changes, setup, get-all-test-matrices]
-    if: ${{ needs.changes.outputs.java == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    needs: [changes, setup, get-all-test-matrices]
+    if: >-
+      ${{ 
+        always() && !cancelled() &&
+        (needs.changes.outputs.java == 'true' ||  needs.changes.outputs.seed == 'true') &&
+        needs.get-all-test-matrices.outputs.java-spring != ''
+      }}
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 10 # Limit the number of runners for this job to 10
@@ -676,10 +730,15 @@ jobs:
           skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
 
   typescript-sdk-seed-update:
-    needs: [changes, setup, get-all-test-matrices]
-    if: ${{ needs.changes.outputs.typescript == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    needs: [changes, setup, get-all-test-matrices]
+    if: >-
+      ${{ 
+        always() && !cancelled() &&
+        (needs.changes.outputs.typescript == 'true' ||  needs.changes.outputs.seed == 'true') &&
+        needs.get-all-test-matrices.outputs.ts-sdk != ''
+      }}
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 10 # Limit the number of runners for this job to 10
@@ -713,10 +772,15 @@ jobs:
           skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
 
   typescript-express-seed-update:
-    needs: [changes, setup, get-all-test-matrices]
-    if: ${{ needs.changes.outputs.typescript == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    needs: [changes, setup, get-all-test-matrices]
+    if: >-
+      ${{ 
+        always() && !cancelled() &&
+        (needs.changes.outputs.typescript == 'true' ||  needs.changes.outputs.seed == 'true') &&
+        needs.get-all-test-matrices.outputs.ts-express != ''
+      }}
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 10 # Limit the number of runners for this job to 10
@@ -750,9 +814,15 @@ jobs:
           skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
 
   go-fiber-seed-update:
-    needs: [changes, setup, get-all-test-matrices]
-    if: ${{ needs.changes.outputs.go == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
+    needs: [changes, setup, get-all-test-matrices]
+    if: >-
+      ${{ 
+        always() && !cancelled() &&
+        (needs.changes.outputs.go == 'true' ||  needs.changes.outputs.seed == 'true') &&
+        needs.get-all-test-matrices.outputs.go-fiber != ''
+      }}
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 10 # Limit the number of runners for this job to 10
@@ -786,10 +856,15 @@ jobs:
           skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
 
   go-model-seed-update:
-    needs: [changes, setup, get-all-test-matrices]
-    if: ${{ needs.changes.outputs.go == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    needs: [changes, setup, get-all-test-matrices]
+    if: >-
+      ${{ 
+        always() && !cancelled() &&
+        (needs.changes.outputs.go == 'true' ||  needs.changes.outputs.seed == 'true') &&
+        needs.get-all-test-matrices.outputs.go-model != ''
+      }}
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 10 # Limit the number of runners for this job to 10
@@ -823,10 +898,15 @@ jobs:
           skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
 
   go-sdk-seed-update:
-    needs: [changes, setup, get-all-test-matrices]
-    if: ${{ needs.changes.outputs.go == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    needs: [changes, setup, get-all-test-matrices]
+    if: >-
+      ${{ 
+        always() && !cancelled() &&
+        (needs.changes.outputs.go == 'true' ||  needs.changes.outputs.seed == 'true') &&
+        needs.get-all-test-matrices.outputs.go-sdk != ''
+      }}
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 10 # Limit the number of runners for this job to 10
@@ -860,10 +940,15 @@ jobs:
           skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
 
   csharp-model-seed-update:
-    needs: [changes, setup, get-all-test-matrices]
-    if: ${{ needs.changes.outputs.csharp == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    needs: [changes, setup, get-all-test-matrices]
+    if: >-
+      ${{ 
+        always() && !cancelled() &&
+        (needs.changes.outputs.csharp == 'true' ||  needs.changes.outputs.seed == 'true') &&
+        needs.get-all-test-matrices.outputs.csharp-model != ''
+      }}
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 10 # Limit the number of runners for this job to 10
@@ -897,10 +982,15 @@ jobs:
           skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
 
   csharp-sdk-seed-update:
-    needs: [changes, setup, get-all-test-matrices]
-    if: ${{ needs.changes.outputs.csharp == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    needs: [changes, setup, get-all-test-matrices]
+    if: >-
+      ${{ 
+        always() && !cancelled() &&
+        (needs.changes.outputs.csharp == 'true' ||  needs.changes.outputs.seed == 'true') &&
+        needs.get-all-test-matrices.outputs.csharp-sdk != ''
+      }}
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 10 # Limit the number of runners for this job to 10
@@ -934,10 +1024,15 @@ jobs:
           skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
 
   php-model-seed-update:
-    needs: [changes, setup, get-all-test-matrices]
-    if: ${{ needs.changes.outputs.php == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    needs: [changes, setup, get-all-test-matrices]
+    if: >-
+      ${{ 
+        always() && !cancelled() &&
+        (needs.changes.outputs.php == 'true' ||  needs.changes.outputs.seed == 'true') &&
+        needs.get-all-test-matrices.outputs.php-model != ''
+      }}
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 10 # Limit the number of runners for this job to 10
@@ -971,10 +1066,15 @@ jobs:
           skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
 
   php-sdk-seed-update:
-    needs: [changes, setup, get-all-test-matrices]
-    if: ${{ needs.changes.outputs.php == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    needs: [changes, setup, get-all-test-matrices]
+    if: >-
+      ${{ 
+        always() && !cancelled() &&
+        (needs.changes.outputs.php == 'true' ||  needs.changes.outputs.seed == 'true') &&
+        needs.get-all-test-matrices.outputs.php-sdk != ''
+      }}
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 10 # Limit the number of runners for this job to 10
@@ -1008,10 +1108,15 @@ jobs:
           skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
 
   swift-sdk-seed-update:
-    needs: [changes, setup, get-all-test-matrices]
-    if: ${{ needs.changes.outputs.swift == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    needs: [changes, setup, get-all-test-matrices]
+    if: >-
+      ${{ 
+        always() && !cancelled() &&
+        (needs.changes.outputs.swift == 'true' ||  needs.changes.outputs.seed == 'true') &&
+        needs.get-all-test-matrices.outputs.swift-sdk != ''
+      }}
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 10 # Limit the number of runners for this job to 10
@@ -1045,10 +1150,15 @@ jobs:
           skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
 
   rust-model-seed-update:
-    needs: [changes, setup, get-all-test-matrices]
-    if: ${{ needs.changes.outputs.rust == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    needs: [changes, setup, get-all-test-matrices]
+    if: >-
+      ${{ 
+        always() && !cancelled() &&
+        (needs.changes.outputs.rust == 'true' ||  needs.changes.outputs.seed == 'true') &&
+        needs.get-all-test-matrices.outputs.rust-model != ''
+      }}
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 10 # Limit the number of runners for this job to 10
@@ -1082,10 +1192,15 @@ jobs:
           skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
 
   rust-sdk-seed-update:
-    needs: [changes, setup, get-all-test-matrices]
-    if: ${{ needs.changes.outputs.rust == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    needs: [changes, setup, get-all-test-matrices]
+    if: >-
+      ${{ 
+        always() && !cancelled() &&
+        (needs.changes.outputs.rust == 'true' ||  needs.changes.outputs.seed == 'true') &&
+        needs.get-all-test-matrices.outputs.rust-sdk != ''
+      }}
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 10 # Limit the number of runners for this job to 10
@@ -1121,8 +1236,6 @@ jobs:
   # Use always() to ensure this runs even if stages from needs are skipped.
   # Add check back to make sure it doesn't run for failures or cancellations.
   commit-seed-changes-by-push:
-    outputs:
-      has-patches: ${{ steps.get-number-of-patches.outputs.HAS_PATCHES }}
     if: >-
       ${{
         always() && needs.setup.outputs.update-by-push == 'true' &&
@@ -1160,79 +1273,48 @@ jobs:
 
     timeout-minutes: 10
     steps:
-      - name: Extract branch name
-        id: extract_branch
+      # Get running branch name
+      - name: Extract Branch Name
+        id: extract-branch
         shell: bash
         run: |
           echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
           echo $branch
 
-      # Checkout the branch directly to avoid detaching the head so we can commit back changes
-      - name: Checkout repo
+      # Get action file specific to the running branch
+      - name: Checkout Action File
         uses: actions/checkout@v4
         with:
-          ref: ${{ steps.extract_branch.outputs.branch }}
-          token: ${{ secrets.FERN_GITHUB_PAT }}
+          ref: ${{ steps.extract-branch.outputs.branch }}
+          sparse-checkout: |
+            .github/
 
-      - name: Create artifacts downloads directory
-        shell: bash
-        run: |
-          DIRECTORY=artifacts
-          if [ ! -d "$DIRECTORY" ]; then
-            echo "'$DIRECTORY' does NOT exist, creating it now."
-            mkdir $DIRECTORY
-          else
-            echo "WARNING: Directory '$DIRECTORY' already exists. Not an immediate error but could cause a problem downstream."
-          fi
-
-      # Merge-multiple is set so all patches are downloaded into the same folder. Otherwise
-      # they are subfoldered into folders that match *.patch pattern and cause errors downstream
-      - name: Download patches
-        uses: actions/download-artifact@v5
+      # Match to all patch files, since we are committing all generator changes at once
+      # Checkout the branch directly to avoid detaching the head so we can commit back changes
+      - name: Apply Patches
+        id: apply-patches
+        uses: ./.github/actions/apply-update-seed-patches
         with:
-          path: ./artifacts
-          merge-multiple: true
+          patch-pattern: seed-*.patch
+          checkout-ref: ${{ steps.extract-branch.outputs.branch }}
 
-      - name: Get number of patches
-        shell: bash
-        id: get-number-of-patches
-        run: |
-          # Apply all patches together for single commit
-          file_count=$(find ./artifacts -type f -name "*.patch" | wc -l)
-          echo "Number of patches downloaded: $file_count"
-          if [ "$file_count" -gt 0 ]; then
-            echo "HAS_PATCHES=true" >> $GITHUB_OUTPUT
-          else
-            echo "HAS_PATCHES=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Display content of a folder
-        run: |
-          echo "Content of 'artifacts' folder:"
-          ls -R artifacts/
-
-      - name: Apply patches
-        shell: bash
-        if: ${{ steps.get-number-of-patches.outputs.HAS_PATCHES == 'true' }}
-        run: |
-          git apply artifacts/*.patch
-
+      # Commit all applied patches back to branch (will be checked out in apply-patches step)
       - name: Add and Commit Changes
         id: commit-changes
         uses: EndBug/add-and-commit@v9
-        if: ${{ steps.get-number-of-patches.outputs.HAS_PATCHES == 'true' }}
+        if: ${{ steps.apply-patches.outputs.has-patches == 'true' }}
         with:
           add: "seed/*"
           push: true
           fetch: false
           message: "Automated update of seed files"
 
-  # Verify that the branch is the default branch (running for push to main)
+  # Verify that the branch is the default branch (running for PR to main)
   commit-seed-changes-by-pr:
     if: >-
       ${{
         always() &&
-        github.ref == format('refs/heads/{0}', github.event.repository.default_branch) &&
+        github.ref == 'refs/heads/main' &&
         needs.setup.outputs.update-by-pr == 'true' &&
         !contains(needs.*.result, 'failure') && 
         !contains(needs.*.result, 'cancelled')
@@ -1343,58 +1425,23 @@ jobs:
           - language-name: rust
             sdk-name: rust-sdk
     steps:
-      # Can checkout detached head here since changes will be PR'd
-      - name: Checkout repo
+      - name: Checkout Action File
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
+          sparse-checkout: |
+            .github/
 
-      - name: Create artifacts downloads directory
-        shell: bash
-        run: |
-          DIRECTORY=artifacts
-          if [ ! -d "$DIRECTORY" ]; then
-            echo "'$DIRECTORY' does NOT exist, creating it now."
-            mkdir $DIRECTORY
-          else
-            echo "WARNING: Directory '$DIRECTORY' already exists. Not an immediate error but could cause a problem downstream."
-          fi
-
-      # Merge-multiple is set so all patches are downloaded into the same folder. Otherwise
-      # they are subfoldered into folders that match *.patch pattern and cause errors downstream
-      - name: Download patches
-        uses: actions/download-artifact@v5
+      # Don't set checkout-ref, applying by PR so we can checkout detached
+      # Only match to patches with this matrix name, since we are PR'ing per generator
+      - name: Apply Patches
+        id: apply-patches
+        uses: ./.github/actions/apply-update-seed-patches
         with:
-          path: ./artifacts
-          merge-multiple: true
-
-      - name: Get number of patches
-        shell: bash
-        id: get-number-of-patches
-        run: |
-          # Apply patches per generator for multiple, separate, PRs
-          file_count=$(find ./artifacts -type f -name "${{ matrix.sdk-name }}-*.patch" | wc -l)
-          echo "Number of patches downloaded: $file_count"
-          if [ "$file_count" -gt 0 ]; then
-            echo "HAS_PATCHES=true" >> $GITHUB_OUTPUT
-          else
-            echo "HAS_PATCHES=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Display content of a folder
-        run: |
-          echo "Content of 'artifacts' folder:"
-          ls -R artifacts/
-
-      - name: Apply patches
-        shell: bash
-        if: ${{ steps.get-number-of-patches.outputs.HAS_PATCHES == 'true' }}
-        run: |
-          git apply artifacts/${{ matrix.sdk-name }}-*.patch
+          patch-pattern: seed-${{ matrix.sdk-name }}-*.patch
 
       # Create PR, approve and set to merge per generator
       - name: Create Pull Request
-        if: steps.get-number-of-patches.outputs.HAS_PATCHES == 'true'
+        if: steps.apply-patches.outputs.has-patches == 'true'
         id: cpr
         uses: peter-evans/create-pull-request@v5
         with:


### PR DESCRIPTION
## Description
Linear ticket: https://linear.app/buildwithfern/issue/FER-7163/ci-fix-update-seed-runs-on-main-after-merge
Closes FER-7163
Auto seed updates were not running on merges to main. This update blends the workflow for merges to main and pushes to a workflow branch to help condense differences. Remaining change was to differ branches to add changes to and to have seed-update jobs "run but skip" instead of being removed entirely when not run (to fix a downstream issue)

## Changes Made
- Moved most of seed application patching to combined file for cleanup and reusability
- Updated seed update jobs to always run and skip where no changes

## Testing
- Verified in CI testing here: https://github.com/fern-api/fern/pull/9826
