### PR TITLE
fix(go): default request parameter values unwrap `nullable<>`

### DIFF
--- a/generators/go-v2/sdk/src/endpoint/http/HttpEndpointGenerator.ts
+++ b/generators/go-v2/sdk/src/endpoint/http/HttpEndpointGenerator.ts
@@ -453,6 +453,9 @@ export class HttpEndpointGenerator extends AbstractEndpointGenerator {
                 if (typeReference.container.type === "optional") {
                     return this.extractDefaultValue(typeReference.container.optional);
                 }
+                if (typeReference.container.type === "nullable") {
+                    return this.extractDefaultValue(typeReference.container.nullable);
+                }
                 return undefined;
             case "named": {
                 const typeDeclaration = this.context.getTypeDeclarationOrThrow(typeReference.typeId);

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,4 +1,11 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.13.14
+  changelogEntry:
+    - summary: |
+        Fix for default request values and nullable types.
+      type: fix
+  createdAt: "2025-10-12"
+  irVersion: 60
 
 - version: 1.13.13
   changelogEntry:


### PR DESCRIPTION
## Description
As said in title; two-line fix. Essentially, `useDefaultRequestParameterValues` broke if `request-nullable-schemas: true`.

## Changes Made
Two-liner to the v2 side.

## Testing
Updating tests now!
- [X] Unit tests added/updated
- [X] Manual testing completed
