### PR TITLE
chore(rust): update readme generation `headers`, `query params` and `request type`

### DIFF
--- a/generators/rust/base/src/asIs/http_client.rs
+++ b/generators/rust/base/src/asIs/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/generators/rust/codegen/src/ast/Expression.ts
+++ b/generators/rust/codegen/src/ast/Expression.ts
@@ -82,7 +82,7 @@ export class Expression extends AstNode {
                 writer.write(methodArgs.method);
                 writer.write("(");
 
-                if (methodArgs.multiline && methodArgs.args.length > 1) {
+                if (methodArgs.multiline && methodArgs.args.length > 0) {
                     writer.newLine();
                     writer.indent();
                     methodArgs.args.forEach((arg, index) => {
@@ -137,7 +137,7 @@ export class Expression extends AstNode {
                 writer.write(funcArgs.function);
                 writer.write("(");
 
-                if (funcArgs.multiline && funcArgs.args.length > 1) {
+                if (funcArgs.multiline && funcArgs.args.length > 0) {
                     writer.newLine();
                     writer.indent();
                     funcArgs.args.forEach((arg, index) => {

--- a/generators/rust/sdk/features.yml
+++ b/generators/rust/sdk/features.yml
@@ -7,6 +7,10 @@ features:
     description: |
       When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
+  - id: REQUEST_TYPES
+    description: |
+      The SDK exports all request types as Rust structs. Simply import them from the crate to access them:
+
   - id: RETRIES
     advanced: true
     description: |
@@ -26,6 +30,16 @@ features:
     advanced: true
     description: |
       The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
+
+  - id: ADDITIONAL_HEADERS
+    advanced: true
+    description: |
+      You can add custom headers to requests using `RequestOptions`.
+
+  - id: ADDITIONAL_QUERY_STRING_PARAMETERS
+    advanced: true
+    description: |
+      You can add custom query parameters to requests using `RequestOptions`.
 
   - id: PAGINATION
     description: |

--- a/generators/rust/sdk/src/__test__/snapshots/http-client-api-key.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/http-client-api-key.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/generators/rust/sdk/src/readme/ReadmeSnippetBuilder.ts
+++ b/generators/rust/sdk/src/readme/ReadmeSnippetBuilder.ts
@@ -16,7 +16,11 @@ interface EndpointWithFilepath {
 export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
     private static CLIENT_VARIABLE_NAME = "client";
     private static ERRORS_FEATURE_ID: FernGeneratorCli.FeatureId = "ERRORS";
+    private static REQUEST_TYPES_FEATURE_ID: FernGeneratorCli.FeatureId = "REQUEST_TYPES";
     private static PAGINATION_FEATURE_ID: FernGeneratorCli.FeatureId = "PAGINATION";
+    private static ADDITIONAL_HEADERS_FEATURE_ID: FernGeneratorCli.FeatureId = "ADDITIONAL_HEADERS";
+    private static ADDITIONAL_QUERY_STRING_PARAMETERS_FEATURE_ID: FernGeneratorCli.FeatureId =
+        "ADDITIONAL_QUERY_STRING_PARAMETERS";
 
     private readonly context: SdkGeneratorContext;
     private readonly endpointsById: Record<EndpointId, EndpointWithFilepath> = {};
@@ -52,11 +56,21 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
         // Error handling
         snippets[ReadmeSnippetBuilder.ERRORS_FEATURE_ID] = this.buildErrorSnippets();
 
+        // Request types
+        snippets[ReadmeSnippetBuilder.REQUEST_TYPES_FEATURE_ID] = this.buildRequestTypesSnippets();
+
         // Retries
         snippets[FernGeneratorCli.StructuredFeatureId.Retries] = this.buildRetrySnippets();
 
         // Timeouts
         snippets[FernGeneratorCli.StructuredFeatureId.Timeouts] = this.buildTimeoutSnippets();
+
+        // Additional headers
+        snippets[ReadmeSnippetBuilder.ADDITIONAL_HEADERS_FEATURE_ID] = this.buildAdditionalHeadersSnippets();
+
+        // Additional query string parameters
+        snippets[ReadmeSnippetBuilder.ADDITIONAL_QUERY_STRING_PARAMETERS_FEATURE_ID] =
+            this.buildAdditionalQueryStringParametersSnippets();
 
         // Pagination disable it for now, currently only support normal pagination
         // snippets[ReadmeSnippetBuilder.PAGINATION_FEATURE_ID] = this.buildPaginationSnippets();
@@ -81,6 +95,33 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
         });
     }
 
+    private buildRequestTypesSnippets(): string[] {
+        // Find any endpoint with a request body across all services
+        let endpointWithRequest: EndpointWithFilepath | null = null;
+
+        for (const service of Object.values(this.context.ir.services)) {
+            for (const endpoint of service.endpoints) {
+                if (endpoint.requestBody != null && endpoint.requestBody.type === "inlinedRequestBody") {
+                    endpointWithRequest = {
+                        endpoint,
+                        fernFilepath: service.name.fernFilepath
+                    };
+                    break;
+                }
+            }
+            if (endpointWithRequest != null) {
+                break;
+            }
+        }
+
+        if (endpointWithRequest == null) {
+            return [];
+        }
+
+        const codeString = this.buildRequestTypesCode(endpointWithRequest);
+        return [this.writeCode(codeString)];
+    }
+
     private buildRetrySnippets(): string[] {
         const retryEndpoints = this.getEndpointsForFeature(FernGeneratorCli.StructuredFeatureId.Retries);
         return retryEndpoints.map((endpoint) => {
@@ -93,6 +134,24 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
         const timeoutEndpoints = this.getEndpointsForFeature(FernGeneratorCli.StructuredFeatureId.Timeouts);
         return timeoutEndpoints.map((endpoint) => {
             const codeString = this.buildTimeoutCode(endpoint);
+            return this.writeCode(codeString);
+        });
+    }
+
+    private buildAdditionalHeadersSnippets(): string[] {
+        const headerEndpoints = this.getEndpointsForFeature(ReadmeSnippetBuilder.ADDITIONAL_HEADERS_FEATURE_ID);
+        return headerEndpoints.map((endpoint) => {
+            const codeString = this.buildAdditionalHeadersCode(endpoint);
+            return this.writeCode(codeString);
+        });
+    }
+
+    private buildAdditionalQueryStringParametersSnippets(): string[] {
+        const queryEndpoints = this.getEndpointsForFeature(
+            ReadmeSnippetBuilder.ADDITIONAL_QUERY_STRING_PARAMETERS_FEATURE_ID
+        );
+        return queryEndpoints.map((endpoint) => {
+            const codeString = this.buildAdditionalQueryParamsCode(endpoint);
             return this.writeCode(codeString);
         });
     }
@@ -197,65 +256,15 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
 
     private buildErrorHandlingCode(endpoint: EndpointWithFilepath): string {
         const writer = new Writer();
+        const methodCall = this.getMethodCall(endpoint);
 
-        // Use prelude for all imports
-        const useStatements = [
-            new UseStatement({
-                path: `${this.context.getCrateName()}::prelude`,
-                items: ["*"]
-            })
-        ];
-
-        // Main function with error handling
-        const mainFunction = rust.standaloneFunction({
-            name: "main",
-            parameters: [],
-            isAsync: true,
-            attributes: [rust.attribute({ name: "tokio::main" })],
-            returnType: rust.Type.result(
-                rust.Type.reference(rust.reference({ name: "()" })),
-                rust.Type.reference(rust.reference({ name: "ApiError" }))
-            ),
-            body: CodeBlock.fromStatements(this.buildErrorHandlingBody(endpoint))
-        });
-
-        // Write use statements
-        useStatements.forEach((useStmt) => {
-            useStmt.write(writer);
-            writer.newLine();
-        });
-        writer.newLine();
-
-        // Write main function
-        mainFunction.write(writer);
-
-        return writer.toString().trim() + "\n";
-    }
-
-    private buildErrorHandlingBody(endpoint: EndpointWithFilepath): Statement[] {
-        // Build client using ClientConfig pattern
-        const configVar = Statement.let({
-            name: "config",
-            value: this.getClientConfigStruct("error", endpoint)
-        });
-
-        const clientBuild = Expression.raw(`${this.context.getClientName()}::new(config)`);
-
-        const clientVar = Statement.let({
-            name: "client",
-            value: Expression.try(clientBuild)
-        });
-
-        // Add a simple dummy method call to show error handling pattern
-        const dummyMethodCall = Expression.await(
-            Expression.methodCall({
-                target: Expression.reference("client"),
-                method: "some_method",
-                args: []
-            })
+        // Build the method call expression
+        const callExpr = Expression.await(
+            Expression.try(Expression.functionCall(`${methodCall}`, [Expression.none()]))
         );
 
-        const matchStatement = Statement.match(dummyMethodCall, [
+        // Build match statement with error handling using AST
+        const matchStatement = Statement.match(callExpr, [
             {
                 pattern: "Ok(response)",
                 body: [Statement.expression(Expression.raw('println!("Success: {:?}", response)'))]
@@ -270,7 +279,53 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
             }
         ]);
 
-        return [configVar, clientVar, matchStatement, Statement.return(Expression.ok(Expression.raw("()")))];
+        matchStatement.write(writer);
+        return writer.toString().trim();
+    }
+
+    private buildRequestTypesCode(endpoint: EndpointWithFilepath): string {
+        const writer = new Writer();
+
+        // Get the request type name (e.g., "PostWithObjectBody")
+        const requestTypeName = this.getRequestTypeName(endpoint);
+
+        if (requestTypeName == null) {
+            return "";
+        }
+
+        // Use statement to import from crate using AST
+        const useStatement = new UseStatement({
+            path: `${this.crateName}::prelude`,
+            items: ["*"]
+        });
+
+        // Create struct initialization with placeholder using Expression.raw
+        // We use raw because "..." is not a valid field name and should appear as-is
+        const structInit = Expression.raw(`${requestTypeName} {\n    ...\n}`);
+
+        const letStatement = Statement.let({
+            name: "request",
+            value: structInit
+        });
+
+        useStatement.write(writer);
+        writer.newLine();
+        writer.newLine();
+        letStatement.write(writer);
+
+        return writer.toString().trim();
+    }
+
+    private getRequestTypeName(endpoint: EndpointWithFilepath): string | null {
+        if (endpoint.endpoint.requestBody == null || endpoint.endpoint.requestBody.type !== "inlinedRequestBody") {
+            return null;
+        }
+
+        // Get the type name from the inlined request body
+        const requestBody = endpoint.endpoint.requestBody;
+
+        // Use the name property which gives us the proper PascalCase name
+        return requestBody.name.pascalCase.safeName;
     }
 
     private getClientConfigStruct(
@@ -330,99 +385,120 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
 
     private buildRetryCode(endpoint: EndpointWithFilepath): string {
         const writer = new Writer();
+        const methodCall = this.getMethodCall(endpoint);
 
-        // Use prelude for all imports
-        const useStatements = [new UseStatement({ path: `${this.crateName}::prelude`, items: ["*"] })];
+        // Build RequestOptions expression
+        const optionsExpr = Expression.functionCall("Some", [
+            Expression.methodCall({
+                target: Expression.functionCall("RequestOptions::new", []),
+                method: "max_retries",
+                args: [Expression.numberLiteral(3)]
+            })
+        ]);
 
-        // Write use statements
-        useStatements.forEach((useStmt) => {
-            useStmt.write(writer);
-            writer.newLine();
-        });
-        writer.newLine();
+        // Build the full call with multiline formatting
+        const callExpr = Expression.functionCall(`${methodCall}`, [optionsExpr], true);
 
-        const mainFunction = rust.standaloneFunction({
-            name: "main",
-            parameters: [],
-            isAsync: true,
-            attributes: [rust.attribute({ name: "tokio::main" })],
-            body: CodeBlock.fromStatements(this.buildRetryBody(endpoint))
-        });
+        // Wrap in try + await
+        const awaitExpr = Expression.await(Expression.try(callExpr));
 
-        mainFunction.write(writer);
-        return writer.toString().trim() + "\n";
-    }
-
-    private buildRetryBody(endpoint: EndpointWithFilepath): Statement[] {
-        // Build client using ClientConfig pattern
-        const configVar = Statement.let({
-            name: "config",
-            value: this.getClientConfigStruct("retry", endpoint)
+        // Create let statement
+        const statement = Statement.let({
+            name: "response",
+            value: awaitExpr
         });
 
-        const clientBuild = Expression.methodCall({
-            target: Expression.raw(`${this.context.getClientName()}::new(config)`),
-            method: "expect",
-            args: [Expression.stringLiteral("Failed to build client")]
-        });
-
-        const clientVar = Statement.let({
-            name: "client",
-            value: clientBuild
-        });
-
-        // Just show client initialization - no complex method calls
-        return [configVar, clientVar];
+        statement.write(writer);
+        return writer.toString().trim();
     }
 
     private buildTimeoutCode(endpoint: EndpointWithFilepath): string {
-        // Use prelude for all imports
-        const useStatements = [
-            new UseStatement({ path: `${this.crateName}::prelude`, items: ["*"] }),
-            new UseStatement({ path: "std::time", items: ["Duration"] })
-        ];
-
         const writer = new Writer();
+        const methodCall = this.getMethodCall(endpoint);
 
-        // Write use statements
-        useStatements.forEach((useStmt) => {
-            useStmt.write(writer);
-            writer.newLine();
+        // Build RequestOptions expression
+        const optionsExpr = Expression.functionCall("Some", [
+            Expression.methodCall({
+                target: Expression.functionCall("RequestOptions::new", []),
+                method: "timeout_seconds",
+                args: [Expression.numberLiteral(30)]
+            })
+        ]);
+
+        // Build the full call with multiline formatting
+        const callExpr = Expression.functionCall(`${methodCall}`, [optionsExpr], true);
+
+        // Wrap in try + await
+        const awaitExpr = Expression.await(Expression.try(callExpr));
+
+        // Create let statement
+        const statement = Statement.let({
+            name: "response",
+            value: awaitExpr
         });
-        writer.newLine();
 
-        const mainFunction = rust.standaloneFunction({
-            name: "main",
-            parameters: [],
-            isAsync: true,
-            attributes: [rust.attribute({ name: "tokio::main" })],
-            body: CodeBlock.fromStatements(this.buildTimeoutBody(endpoint))
-        });
-
-        mainFunction.write(writer);
-        return writer.toString().trim() + "\n";
+        statement.write(writer);
+        return writer.toString().trim();
     }
 
-    private buildTimeoutBody(endpoint: EndpointWithFilepath): Statement[] {
-        // Build client using ClientConfig pattern
-        const configVar = Statement.let({
-            name: "config",
-            value: this.getClientConfigStruct("timeout", endpoint)
-        });
+    private buildAdditionalHeadersCode(endpoint: EndpointWithFilepath): string {
+        const writer = new Writer();
+        const methodCall = this.getMethodCall(endpoint);
 
-        const clientBuild = Expression.methodCall({
-            target: Expression.raw(`${this.context.getClientName()}::new(config)`),
-            method: "expect",
-            args: [Expression.stringLiteral("Failed to build client")]
-        });
+        // Manually format using Writer for proper multi-line method chain formatting
+        writer.write(`let response = ${methodCall}(`);
+        writer.newLine();
+        writer.indent();
+        writer.write("Some(");
+        writer.newLine();
+        writer.indent();
+        writer.write("RequestOptions::new()");
+        writer.newLine();
+        writer.indent();
+        writer.write('.additional_header("X-Custom-Header", "custom-value")');
+        writer.newLine();
+        writer.write('.additional_header("X-Another-Header", "another-value")');
+        writer.dedent();
+        writer.newLine();
+        writer.dedent();
+        writer.write(")");
+        writer.newLine();
+        writer.dedent();
+        writer.write(")?");
+        writer.newLine();
+        writer.write(".await;");
 
-        const clientVar = Statement.let({
-            name: "client",
-            value: clientBuild
-        });
+        return writer.toString().trim();
+    }
 
-        // Just show client initialization - no complex method calls
-        return [configVar, clientVar];
+    private buildAdditionalQueryParamsCode(endpoint: EndpointWithFilepath): string {
+        const writer = new Writer();
+        const methodCall = this.getMethodCall(endpoint);
+
+        // Manually format using Writer for proper multi-line method chain formatting
+        writer.write(`let response = ${methodCall}(`);
+        writer.newLine();
+        writer.indent();
+        writer.write("Some(");
+        writer.newLine();
+        writer.indent();
+        writer.write("RequestOptions::new()");
+        writer.newLine();
+        writer.indent();
+        writer.write('.additional_query_param("filter", "active")');
+        writer.newLine();
+        writer.write('.additional_query_param("sort", "desc")');
+        writer.dedent();
+        writer.newLine();
+        writer.dedent();
+        writer.write(")");
+        writer.newLine();
+        writer.dedent();
+        writer.write(")?");
+        writer.newLine();
+        writer.write(".await;");
+
+        return writer.toString().trim();
     }
 
     private buildPaginationCode(endpoint: EndpointWithFilepath): string {

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -1,5 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.7.1
+  createdAt: "2025-10-15"
+  changelogEntry:
+    - type: chore
+      summary: add readme generation headers, query params and request type
+  irVersion: 59
+
 - version: 0.7.0
   createdAt: "2025-10-11"
   changelogEntry:

--- a/seed/rust-sdk/accept-header/README.md
+++ b/seed/rust-sdk/accept-header/README.md
@@ -47,27 +47,16 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
-use seed_accept::prelude::{*};
-
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = AcceptClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
+match client.service.endpoint(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
     }
-    return Ok(());
 }
 ```
 
@@ -88,17 +77,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_accept::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = AcceptClient::new(config).expect("Failed to build client");
-}
+let response = client.service.endpoint(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -106,18 +87,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_accept::prelude::{*};
-use std::time::{Duration};
+let response = client.service.endpoint(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = AcceptClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.service.endpoint(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.service.endpoint(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/accept-header/src/core/http_client.rs
+++ b/seed/rust-sdk/accept-header/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/alias-extends/README.md
+++ b/seed/rust-sdk/alias-extends/README.md
@@ -55,28 +55,29 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
+match client.extended_inline_request_body(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
+    }
+}
+```
+
+## Request Types
+
+The SDK exports all request types as Rust structs. Simply import them from the crate to access them:
+
+```rust
 use seed_alias_extends::prelude::{*};
 
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = AliasExtendsClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
-    }
-    return Ok(());
-}
+let request = InlinedChildRequest {
+    ...
+};
 ```
 
 ## Advanced
@@ -96,17 +97,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_alias_extends::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = AliasExtendsClient::new(config).expect("Failed to build client");
-}
+let response = client.extended_inline_request_body(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -114,18 +107,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_alias_extends::prelude::{*};
-use std::time::{Duration};
+let response = client.extended_inline_request_body(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = AliasExtendsClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.extended_inline_request_body(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.extended_inline_request_body(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/alias-extends/src/core/http_client.rs
+++ b/seed/rust-sdk/alias-extends/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/alias/README.md
+++ b/seed/rust-sdk/alias/README.md
@@ -46,27 +46,16 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
-use seed_alias::prelude::{*};
-
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = AliasClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
+match client.get(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
     }
-    return Ok(());
 }
 ```
 
@@ -87,17 +76,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_alias::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = AliasClient::new(config).expect("Failed to build client");
-}
+let response = client.get(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -105,18 +86,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_alias::prelude::{*};
-use std::time::{Duration};
+let response = client.get(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = AliasClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.get(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.get(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/alias/src/core/http_client.rs
+++ b/seed/rust-sdk/alias/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/any-auth/README.md
+++ b/seed/rust-sdk/any-auth/README.md
@@ -60,28 +60,29 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
+match client.auth.get_token(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
+    }
+}
+```
+
+## Request Types
+
+The SDK exports all request types as Rust structs. Simply import them from the crate to access them:
+
+```rust
 use seed_any_auth::prelude::{*};
 
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = AnyAuthClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
-    }
-    return Ok(());
-}
+let request = GetTokenRequest {
+    ...
+};
 ```
 
 ## Advanced
@@ -101,17 +102,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_any_auth::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = AnyAuthClient::new(config).expect("Failed to build client");
-}
+let response = client.auth.get_token(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -119,18 +112,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_any_auth::prelude::{*};
-use std::time::{Duration};
+let response = client.auth.get_token(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = AnyAuthClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.auth.get_token(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.auth.get_token(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/any-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/any-auth/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/api-wide-base-path/README.md
+++ b/seed/rust-sdk/api-wide-base-path/README.md
@@ -55,27 +55,16 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
-use seed_api_wide_base_path::prelude::{*};
-
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = ApiWideBasePathClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
+match client.service.post(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
     }
-    return Ok(());
 }
 ```
 
@@ -96,17 +85,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_api_wide_base_path::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = ApiWideBasePathClient::new(config).expect("Failed to build client");
-}
+let response = client.service.post(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -114,18 +95,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_api_wide_base_path::prelude::{*};
-use std::time::{Duration};
+let response = client.service.post(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = ApiWideBasePathClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.service.post(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.service.post(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/api-wide-base-path/src/core/http_client.rs
+++ b/seed/rust-sdk/api-wide-base-path/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/audiences/README.md
+++ b/seed/rust-sdk/audiences/README.md
@@ -57,28 +57,29 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
+match client.foo.find(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
+    }
+}
+```
+
+## Request Types
+
+The SDK exports all request types as Rust structs. Simply import them from the crate to access them:
+
+```rust
 use seed_audiences::prelude::{*};
 
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = AudiencesClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
-    }
-    return Ok(());
-}
+let request = FindRequest {
+    ...
+};
 ```
 
 ## Advanced
@@ -98,17 +99,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_audiences::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = AudiencesClient::new(config).expect("Failed to build client");
-}
+let response = client.foo.find(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -116,18 +109,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_audiences::prelude::{*};
-use std::time::{Duration};
+let response = client.foo.find(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = AudiencesClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.foo.find(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.foo.find(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/audiences/src/core/http_client.rs
+++ b/seed/rust-sdk/audiences/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/auth-environment-variables/README.md
+++ b/seed/rust-sdk/auth-environment-variables/README.md
@@ -47,27 +47,16 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
-use seed_auth_environment_variables::prelude::{*};
-
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = AuthEnvironmentVariablesClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
+match client.service.get_with_api_key(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
     }
-    return Ok(());
 }
 ```
 
@@ -88,17 +77,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_auth_environment_variables::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = AuthEnvironmentVariablesClient::new(config).expect("Failed to build client");
-}
+let response = client.service.get_with_api_key(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -106,18 +87,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_auth_environment_variables::prelude::{*};
-use std::time::{Duration};
+let response = client.service.get_with_api_key(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = AuthEnvironmentVariablesClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.service.get_with_api_key(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.service.get_with_api_key(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/auth-environment-variables/src/core/http_client.rs
+++ b/seed/rust-sdk/auth-environment-variables/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/basic-auth-environment-variables/README.md
+++ b/seed/rust-sdk/basic-auth-environment-variables/README.md
@@ -52,27 +52,16 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
-use seed_basic_auth_environment_variables::prelude::{*};
-
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = BasicAuthEnvironmentVariablesClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
+match client.basic_auth.post_with_basic_auth(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
     }
-    return Ok(());
 }
 ```
 
@@ -93,17 +82,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_basic_auth_environment_variables::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = BasicAuthEnvironmentVariablesClient::new(config).expect("Failed to build client");
-}
+let response = client.basic_auth.post_with_basic_auth(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -111,18 +92,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_basic_auth_environment_variables::prelude::{*};
-use std::time::{Duration};
+let response = client.basic_auth.post_with_basic_auth(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = BasicAuthEnvironmentVariablesClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.basic_auth.post_with_basic_auth(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.basic_auth.post_with_basic_auth(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/basic-auth-environment-variables/src/core/http_client.rs
+++ b/seed/rust-sdk/basic-auth-environment-variables/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/basic-auth/README.md
+++ b/seed/rust-sdk/basic-auth/README.md
@@ -52,27 +52,16 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
-use seed_basic_auth::prelude::{*};
-
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = BasicAuthClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
+match client.basic_auth.post_with_basic_auth(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
     }
-    return Ok(());
 }
 ```
 
@@ -93,17 +82,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_basic_auth::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = BasicAuthClient::new(config).expect("Failed to build client");
-}
+let response = client.basic_auth.post_with_basic_auth(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -111,18 +92,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_basic_auth::prelude::{*};
-use std::time::{Duration};
+let response = client.basic_auth.post_with_basic_auth(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = BasicAuthClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.basic_auth.post_with_basic_auth(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.basic_auth.post_with_basic_auth(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/basic-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/basic-auth/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/bearer-token-environment-variable/README.md
+++ b/seed/rust-sdk/bearer-token-environment-variable/README.md
@@ -47,27 +47,16 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
-use seed_bearer_token_environment_variable::prelude::{*};
-
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = BearerTokenEnvironmentVariableClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
+match client.service.get_with_bearer_token(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
     }
-    return Ok(());
 }
 ```
 
@@ -88,17 +77,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_bearer_token_environment_variable::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = BearerTokenEnvironmentVariableClient::new(config).expect("Failed to build client");
-}
+let response = client.service.get_with_bearer_token(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -106,18 +87,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_bearer_token_environment_variable::prelude::{*};
-use std::time::{Duration};
+let response = client.service.get_with_bearer_token(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = BearerTokenEnvironmentVariableClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.service.get_with_bearer_token(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.service.get_with_bearer_token(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/bearer-token-environment-variable/src/core/http_client.rs
+++ b/seed/rust-sdk/bearer-token-environment-variable/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/bytes-upload/README.md
+++ b/seed/rust-sdk/bytes-upload/README.md
@@ -49,27 +49,16 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
-use seed_bytes_upload::prelude::{*};
-
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = BytesUploadClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
+match client.service.upload(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
     }
-    return Ok(());
 }
 ```
 
@@ -90,17 +79,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_bytes_upload::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = BytesUploadClient::new(config).expect("Failed to build client");
-}
+let response = client.service.upload(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -108,18 +89,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_bytes_upload::prelude::{*};
-use std::time::{Duration};
+let response = client.service.upload(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = BytesUploadClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.service.upload(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.service.upload(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/bytes-upload/src/core/http_client.rs
+++ b/seed/rust-sdk/bytes-upload/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/client-side-params/README.md
+++ b/seed/rust-sdk/client-side-params/README.md
@@ -62,28 +62,29 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
+match client.service.search_resources(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
+    }
+}
+```
+
+## Request Types
+
+The SDK exports all request types as Rust structs. Simply import them from the crate to access them:
+
+```rust
 use seed_client_side_params::prelude::{*};
 
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = ClientSideParamsClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
-    }
-    return Ok(());
-}
+let request = SearchResourcesRequest {
+    ...
+};
 ```
 
 ## Advanced
@@ -103,17 +104,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_client_side_params::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = ClientSideParamsClient::new(config).expect("Failed to build client");
-}
+let response = client.service.search_resources(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -121,18 +114,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_client_side_params::prelude::{*};
-use std::time::{Duration};
+let response = client.service.search_resources(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = ClientSideParamsClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.service.search_resources(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.service.search_resources(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/client-side-params/src/core/http_client.rs
+++ b/seed/rust-sdk/client-side-params/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/content-type/README.md
+++ b/seed/rust-sdk/content-type/README.md
@@ -56,28 +56,29 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
+match client.service.patch(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
+    }
+}
+```
+
+## Request Types
+
+The SDK exports all request types as Rust structs. Simply import them from the crate to access them:
+
+```rust
 use seed_content_types::prelude::{*};
 
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = ContentTypesClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
-    }
-    return Ok(());
-}
+let request = PatchProxyRequest {
+    ...
+};
 ```
 
 ## Advanced
@@ -97,17 +98,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_content_types::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = ContentTypesClient::new(config).expect("Failed to build client");
-}
+let response = client.service.patch(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -115,18 +108,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_content_types::prelude::{*};
-use std::time::{Duration};
+let response = client.service.patch(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = ContentTypesClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.service.patch(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.service.patch(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/content-type/src/core/http_client.rs
+++ b/seed/rust-sdk/content-type/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/cross-package-type-names/README.md
+++ b/seed/rust-sdk/cross-package-type-names/README.md
@@ -57,28 +57,29 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
+match client.foo.find(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
+    }
+}
+```
+
+## Request Types
+
+The SDK exports all request types as Rust structs. Simply import them from the crate to access them:
+
+```rust
 use seed_cross_package_type_names::prelude::{*};
 
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = CrossPackageTypeNamesClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
-    }
-    return Ok(());
-}
+let request = FindRequest {
+    ...
+};
 ```
 
 ## Advanced
@@ -98,17 +99,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_cross_package_type_names::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = CrossPackageTypeNamesClient::new(config).expect("Failed to build client");
-}
+let response = client.foo.find(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -116,18 +109,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_cross_package_type_names::prelude::{*};
-use std::time::{Duration};
+let response = client.foo.find(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = CrossPackageTypeNamesClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.foo.find(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.foo.find(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/cross-package-type-names/src/core/http_client.rs
+++ b/seed/rust-sdk/cross-package-type-names/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/custom-auth/README.md
+++ b/seed/rust-sdk/custom-auth/README.md
@@ -51,27 +51,16 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
-use seed_custom_auth::prelude::{*};
-
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = CustomAuthClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
+match client.custom_auth.post_with_custom_auth(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
     }
-    return Ok(());
 }
 ```
 
@@ -92,17 +81,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_custom_auth::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = CustomAuthClient::new(config).expect("Failed to build client");
-}
+let response = client.custom_auth.post_with_custom_auth(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -110,18 +91,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_custom_auth::prelude::{*};
-use std::time::{Duration};
+let response = client.custom_auth.post_with_custom_auth(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = CustomAuthClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.custom_auth.post_with_custom_auth(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.custom_auth.post_with_custom_auth(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/custom-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/custom-auth/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/enum/README.md
+++ b/seed/rust-sdk/enum/README.md
@@ -46,28 +46,29 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
+match client.headers.send(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
+    }
+}
+```
+
+## Request Types
+
+The SDK exports all request types as Rust structs. Simply import them from the crate to access them:
+
+```rust
 use seed_enum::prelude::{*};
 
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = EnumClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
-    }
-    return Ok(());
-}
+let request = SendEnumInlinedRequest {
+    ...
+};
 ```
 
 ## Advanced
@@ -87,17 +88,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_enum::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = EnumClient::new(config).expect("Failed to build client");
-}
+let response = client.headers.send(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -105,18 +98,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_enum::prelude::{*};
-use std::time::{Duration};
+let response = client.headers.send(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = EnumClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.headers.send(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.headers.send(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/enum/src/core/http_client.rs
+++ b/seed/rust-sdk/enum/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/error-property/README.md
+++ b/seed/rust-sdk/error-property/README.md
@@ -46,27 +46,16 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
-use seed_error_property::prelude::{*};
-
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = ErrorPropertyClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
+match client.property_based_error.throw_error(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
     }
-    return Ok(());
 }
 ```
 
@@ -87,17 +76,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_error_property::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = ErrorPropertyClient::new(config).expect("Failed to build client");
-}
+let response = client.property_based_error.throw_error(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -105,18 +86,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_error_property::prelude::{*};
-use std::time::{Duration};
+let response = client.property_based_error.throw_error(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = ErrorPropertyClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.property_based_error.throw_error(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.property_based_error.throw_error(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/error-property/src/core/http_client.rs
+++ b/seed/rust-sdk/error-property/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/errors/README.md
+++ b/seed/rust-sdk/errors/README.md
@@ -55,27 +55,16 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
-use seed_errors::prelude::{*};
-
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = ErrorsClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
+match client.simple.foo_without_endpoint_error(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
     }
-    return Ok(());
 }
 ```
 
@@ -96,17 +85,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_errors::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = ErrorsClient::new(config).expect("Failed to build client");
-}
+let response = client.simple.foo_without_endpoint_error(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -114,18 +95,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_errors::prelude::{*};
-use std::time::{Duration};
+let response = client.simple.foo_without_endpoint_error(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = ErrorsClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.simple.foo_without_endpoint_error(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.simple.foo_without_endpoint_error(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/errors/src/core/http_client.rs
+++ b/seed/rust-sdk/errors/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/examples/no-custom-config/README.md
+++ b/seed/rust-sdk/examples/no-custom-config/README.md
@@ -49,27 +49,16 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
-use seed_examples::prelude::{*};
-
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = ExamplesClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
+match client.echo(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
     }
-    return Ok(());
 }
 ```
 
@@ -90,17 +79,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_examples::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = ExamplesClient::new(config).expect("Failed to build client");
-}
+let response = client.echo(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -108,18 +89,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_examples::prelude::{*};
-use std::time::{Duration};
+let response = client.echo(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = ExamplesClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.echo(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.echo(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/examples/no-custom-config/src/core/http_client.rs
+++ b/seed/rust-sdk/examples/no-custom-config/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/examples/readme-config/README.md
+++ b/seed/rust-sdk/examples/readme-config/README.md
@@ -97,27 +97,16 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
-use seed_examples::prelude::{*};
-
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = ExamplesClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
+match client.service.create_movie(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
     }
-    return Ok(());
 }
 ```
 
@@ -138,17 +127,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_examples::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = ExamplesClient::new(config).expect("Failed to build client");
-}
+let response = client.service.create_movie(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -156,18 +137,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_examples::prelude::{*};
-use std::time::{Duration};
+let response = client.service.get_movie(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = ExamplesClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.service.create_movie(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.service.create_movie(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/examples/readme-config/src/core/http_client.rs
+++ b/seed/rust-sdk/examples/readme-config/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/exhaustive/README.md
+++ b/seed/rust-sdk/exhaustive/README.md
@@ -52,28 +52,29 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
+match client.endpoints.container.get_and_return_list_of_primitives(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
+    }
+}
+```
+
+## Request Types
+
+The SDK exports all request types as Rust structs. Simply import them from the crate to access them:
+
+```rust
 use seed_exhaustive::prelude::{*};
 
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = ExhaustiveClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
-    }
-    return Ok(());
-}
+let request = PostWithObjectBody {
+    ...
+};
 ```
 
 ## Advanced
@@ -93,17 +94,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_exhaustive::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = ExhaustiveClient::new(config).expect("Failed to build client");
-}
+let response = client.endpoints.container.get_and_return_list_of_primitives(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -111,18 +104,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_exhaustive::prelude::{*};
-use std::time::{Duration};
+let response = client.endpoints.container.get_and_return_list_of_primitives(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = ExhaustiveClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.endpoints.container.get_and_return_list_of_primitives(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.endpoints.container.get_and_return_list_of_primitives(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/exhaustive/src/core/http_client.rs
+++ b/seed/rust-sdk/exhaustive/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/extends/README.md
+++ b/seed/rust-sdk/extends/README.md
@@ -56,28 +56,29 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
+match client.extended_inline_request_body(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
+    }
+}
+```
+
+## Request Types
+
+The SDK exports all request types as Rust structs. Simply import them from the crate to access them:
+
+```rust
 use seed_extends::prelude::{*};
 
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = ExtendsClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
-    }
-    return Ok(());
-}
+let request = Inlined {
+    ...
+};
 ```
 
 ## Advanced
@@ -97,17 +98,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_extends::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = ExtendsClient::new(config).expect("Failed to build client");
-}
+let response = client.extended_inline_request_body(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -115,18 +108,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_extends::prelude::{*};
-use std::time::{Duration};
+let response = client.extended_inline_request_body(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = ExtendsClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.extended_inline_request_body(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.extended_inline_request_body(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/extends/src/core/http_client.rs
+++ b/seed/rust-sdk/extends/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/extra-properties/README.md
+++ b/seed/rust-sdk/extra-properties/README.md
@@ -57,28 +57,29 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
+match client.user.create_user(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
+    }
+}
+```
+
+## Request Types
+
+The SDK exports all request types as Rust structs. Simply import them from the crate to access them:
+
+```rust
 use seed_extra_properties::prelude::{*};
 
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = ExtraPropertiesClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
-    }
-    return Ok(());
-}
+let request = CreateUserRequest {
+    ...
+};
 ```
 
 ## Advanced
@@ -98,17 +99,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_extra_properties::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = ExtraPropertiesClient::new(config).expect("Failed to build client");
-}
+let response = client.user.create_user(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -116,18 +109,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_extra_properties::prelude::{*};
-use std::time::{Duration};
+let response = client.user.create_user(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = ExtraPropertiesClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.user.create_user(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.user.create_user(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/extra-properties/src/core/http_client.rs
+++ b/seed/rust-sdk/extra-properties/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/file-download/README.md
+++ b/seed/rust-sdk/file-download/README.md
@@ -46,27 +46,16 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
-use seed_file_download::prelude::{*};
-
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = FileDownloadClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
+match client.service.simple(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
     }
-    return Ok(());
 }
 ```
 
@@ -87,17 +76,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_file_download::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = FileDownloadClient::new(config).expect("Failed to build client");
-}
+let response = client.service.simple(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -105,18 +86,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_file_download::prelude::{*};
-use std::time::{Duration};
+let response = client.service.simple(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = FileDownloadClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.service.simple(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.service.simple(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/file-download/src/core/http_client.rs
+++ b/seed/rust-sdk/file-download/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/file-upload/README.md
+++ b/seed/rust-sdk/file-upload/README.md
@@ -46,27 +46,16 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
-use seed_file_upload::prelude::{*};
-
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = FileUploadClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
+match client.service.simple(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
     }
-    return Ok(());
 }
 ```
 
@@ -87,17 +76,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_file_upload::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = FileUploadClient::new(config).expect("Failed to build client");
-}
+let response = client.service.simple(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -105,18 +86,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_file_upload::prelude::{*};
-use std::time::{Duration};
+let response = client.service.simple(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = FileUploadClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.service.simple(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.service.simple(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/file-upload/src/core/http_client.rs
+++ b/seed/rust-sdk/file-upload/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/folders/README.md
+++ b/seed/rust-sdk/folders/README.md
@@ -46,27 +46,16 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
-use seed_api::prelude::{*};
-
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = ApiClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
+match client.foo(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
     }
-    return Ok(());
 }
 ```
 
@@ -87,17 +76,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_api::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = ApiClient::new(config).expect("Failed to build client");
-}
+let response = client.foo(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -105,18 +86,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_api::prelude::{*};
-use std::time::{Duration};
+let response = client.foo(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = ApiClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.foo(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.foo(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/folders/src/core/http_client.rs
+++ b/seed/rust-sdk/folders/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/http-head/README.md
+++ b/seed/rust-sdk/http-head/README.md
@@ -46,27 +46,16 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
-use seed_http_head::prelude::{*};
-
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = HttpHeadClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
+match client.user.head(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
     }
-    return Ok(());
 }
 ```
 
@@ -87,17 +76,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_http_head::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = HttpHeadClient::new(config).expect("Failed to build client");
-}
+let response = client.user.head(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -105,18 +86,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_http_head::prelude::{*};
-use std::time::{Duration};
+let response = client.user.head(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = HttpHeadClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.user.head(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.user.head(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/http-head/src/core/http_client.rs
+++ b/seed/rust-sdk/http-head/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/idempotency-headers/README.md
+++ b/seed/rust-sdk/idempotency-headers/README.md
@@ -57,28 +57,29 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
+match client.payment.create(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
+    }
+}
+```
+
+## Request Types
+
+The SDK exports all request types as Rust structs. Simply import them from the crate to access them:
+
+```rust
 use seed_idempotency_headers::prelude::{*};
 
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = IdempotencyHeadersClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
-    }
-    return Ok(());
-}
+let request = CreatePaymentRequest {
+    ...
+};
 ```
 
 ## Advanced
@@ -98,17 +99,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_idempotency_headers::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = IdempotencyHeadersClient::new(config).expect("Failed to build client");
-}
+let response = client.payment.create(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -116,18 +109,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_idempotency_headers::prelude::{*};
-use std::time::{Duration};
+let response = client.payment.create(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = IdempotencyHeadersClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.payment.create(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.payment.create(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/idempotency-headers/src/core/http_client.rs
+++ b/seed/rust-sdk/idempotency-headers/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/imdb/imdb-custom-config/README.md
+++ b/seed/rust-sdk/imdb/imdb-custom-config/README.md
@@ -57,27 +57,16 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
-use custom_imdb_sdk::prelude::{*};
-
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = CustomImdbClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
+match client.imdb.create_movie(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
     }
-    return Ok(());
 }
 ```
 
@@ -98,17 +87,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use custom_imdb_sdk::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = CustomImdbClient::new(config).expect("Failed to build client");
-}
+let response = client.imdb.create_movie(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -116,18 +97,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use custom_imdb_sdk::prelude::{*};
-use std::time::{Duration};
+let response = client.imdb.create_movie(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = CustomImdbClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.imdb.create_movie(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.imdb.create_movie(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/imdb/imdb-custom-config/src/core/http_client.rs
+++ b/seed/rust-sdk/imdb/imdb-custom-config/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/imdb/imdb/README.md
+++ b/seed/rust-sdk/imdb/imdb/README.md
@@ -57,27 +57,16 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
-use seed_api::prelude::{*};
-
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = ApiClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
+match client.imdb.create_movie(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
     }
-    return Ok(());
 }
 ```
 
@@ -98,17 +87,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_api::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = ApiClient::new(config).expect("Failed to build client");
-}
+let response = client.imdb.create_movie(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -116,18 +97,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_api::prelude::{*};
-use std::time::{Duration};
+let response = client.imdb.create_movie(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = ApiClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.imdb.create_movie(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.imdb.create_movie(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/imdb/imdb/src/core/http_client.rs
+++ b/seed/rust-sdk/imdb/imdb/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/inferred-auth-explicit/README.md
+++ b/seed/rust-sdk/inferred-auth-explicit/README.md
@@ -60,28 +60,29 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
+match client.auth.get_token_with_client_credentials(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
+    }
+}
+```
+
+## Request Types
+
+The SDK exports all request types as Rust structs. Simply import them from the crate to access them:
+
+```rust
 use seed_inferred_auth_explicit::prelude::{*};
 
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = InferredAuthExplicitClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
-    }
-    return Ok(());
-}
+let request = GetTokenRequest {
+    ...
+};
 ```
 
 ## Advanced
@@ -101,17 +102,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_inferred_auth_explicit::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = InferredAuthExplicitClient::new(config).expect("Failed to build client");
-}
+let response = client.auth.get_token_with_client_credentials(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -119,18 +112,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_inferred_auth_explicit::prelude::{*};
-use std::time::{Duration};
+let response = client.auth.get_token_with_client_credentials(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = InferredAuthExplicitClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.auth.get_token_with_client_credentials(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.auth.get_token_with_client_credentials(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/inferred-auth-explicit/src/core/http_client.rs
+++ b/seed/rust-sdk/inferred-auth-explicit/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/inferred-auth-implicit-no-expiry/README.md
+++ b/seed/rust-sdk/inferred-auth-implicit-no-expiry/README.md
@@ -60,28 +60,29 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
+match client.auth.get_token_with_client_credentials(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
+    }
+}
+```
+
+## Request Types
+
+The SDK exports all request types as Rust structs. Simply import them from the crate to access them:
+
+```rust
 use seed_inferred_auth_implicit_no_expiry::prelude::{*};
 
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = InferredAuthImplicitNoExpiryClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
-    }
-    return Ok(());
-}
+let request = GetTokenRequest {
+    ...
+};
 ```
 
 ## Advanced
@@ -101,17 +102,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_inferred_auth_implicit_no_expiry::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = InferredAuthImplicitNoExpiryClient::new(config).expect("Failed to build client");
-}
+let response = client.auth.get_token_with_client_credentials(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -119,18 +112,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_inferred_auth_implicit_no_expiry::prelude::{*};
-use std::time::{Duration};
+let response = client.auth.get_token_with_client_credentials(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = InferredAuthImplicitNoExpiryClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.auth.get_token_with_client_credentials(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.auth.get_token_with_client_credentials(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/core/http_client.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/inferred-auth-implicit/README.md
+++ b/seed/rust-sdk/inferred-auth-implicit/README.md
@@ -60,28 +60,29 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
+match client.auth.get_token_with_client_credentials(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
+    }
+}
+```
+
+## Request Types
+
+The SDK exports all request types as Rust structs. Simply import them from the crate to access them:
+
+```rust
 use seed_inferred_auth_implicit::prelude::{*};
 
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = InferredAuthImplicitClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
-    }
-    return Ok(());
-}
+let request = GetTokenRequest {
+    ...
+};
 ```
 
 ## Advanced
@@ -101,17 +102,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_inferred_auth_implicit::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = InferredAuthImplicitClient::new(config).expect("Failed to build client");
-}
+let response = client.auth.get_token_with_client_credentials(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -119,18 +112,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_inferred_auth_implicit::prelude::{*};
-use std::time::{Duration};
+let response = client.auth.get_token_with_client_credentials(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = InferredAuthImplicitClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.auth.get_token_with_client_credentials(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.auth.get_token_with_client_credentials(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/inferred-auth-implicit/src/core/http_client.rs
+++ b/seed/rust-sdk/inferred-auth-implicit/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/license/README.md
+++ b/seed/rust-sdk/license/README.md
@@ -46,27 +46,16 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
-use seed_license::prelude::{*};
-
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = LicenseClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
+match client.get(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
     }
-    return Ok(());
 }
 ```
 
@@ -87,17 +76,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_license::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = LicenseClient::new(config).expect("Failed to build client");
-}
+let response = client.get(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -105,18 +86,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_license::prelude::{*};
-use std::time::{Duration};
+let response = client.get(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = LicenseClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.get(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.get(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/license/src/core/http_client.rs
+++ b/seed/rust-sdk/license/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/literal/README.md
+++ b/seed/rust-sdk/literal/README.md
@@ -57,28 +57,29 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
+match client.headers.send(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
+    }
+}
+```
+
+## Request Types
+
+The SDK exports all request types as Rust structs. Simply import them from the crate to access them:
+
+```rust
 use seed_literal::prelude::{*};
 
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = LiteralClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
-    }
-    return Ok(());
-}
+let request = SendLiteralsInHeadersRequest {
+    ...
+};
 ```
 
 ## Advanced
@@ -98,17 +99,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_literal::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = LiteralClient::new(config).expect("Failed to build client");
-}
+let response = client.headers.send(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -116,18 +109,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_literal::prelude::{*};
-use std::time::{Duration};
+let response = client.headers.send(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = LiteralClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.headers.send(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.headers.send(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/literal/src/core/http_client.rs
+++ b/seed/rust-sdk/literal/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/mixed-case/README.md
+++ b/seed/rust-sdk/mixed-case/README.md
@@ -49,27 +49,16 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
-use seed_mixed_case::prelude::{*};
-
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = MixedCaseClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
+match client.service.get_resource(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
     }
-    return Ok(());
 }
 ```
 
@@ -90,17 +79,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_mixed_case::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = MixedCaseClient::new(config).expect("Failed to build client");
-}
+let response = client.service.get_resource(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -108,18 +89,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_mixed_case::prelude::{*};
-use std::time::{Duration};
+let response = client.service.get_resource(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = MixedCaseClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.service.get_resource(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.service.get_resource(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/mixed-case/src/core/http_client.rs
+++ b/seed/rust-sdk/mixed-case/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/mixed-file-directory/README.md
+++ b/seed/rust-sdk/mixed-file-directory/README.md
@@ -55,27 +55,16 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
-use seed_mixed_file_directory::prelude::{*};
-
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = MixedFileDirectoryClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
+match client.organization.create(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
     }
-    return Ok(());
 }
 ```
 
@@ -96,17 +85,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_mixed_file_directory::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = MixedFileDirectoryClient::new(config).expect("Failed to build client");
-}
+let response = client.organization.create(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -114,18 +95,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_mixed_file_directory::prelude::{*};
-use std::time::{Duration};
+let response = client.organization.create(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = MixedFileDirectoryClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.organization.create(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.organization.create(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/mixed-file-directory/src/core/http_client.rs
+++ b/seed/rust-sdk/mixed-file-directory/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/multi-line-docs/README.md
+++ b/seed/rust-sdk/multi-line-docs/README.md
@@ -56,28 +56,29 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
+match client.user.create_user(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
+    }
+}
+```
+
+## Request Types
+
+The SDK exports all request types as Rust structs. Simply import them from the crate to access them:
+
+```rust
 use seed_multi_line_docs::prelude::{*};
 
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = MultiLineDocsClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
-    }
-    return Ok(());
-}
+let request = CreateUserRequest {
+    ...
+};
 ```
 
 ## Advanced
@@ -97,17 +98,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_multi_line_docs::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = MultiLineDocsClient::new(config).expect("Failed to build client");
-}
+let response = client.user.create_user(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -115,18 +108,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_multi_line_docs::prelude::{*};
-use std::time::{Duration};
+let response = client.user.create_user(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = MultiLineDocsClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.user.create_user(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.user.create_user(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/multi-line-docs/src/core/http_client.rs
+++ b/seed/rust-sdk/multi-line-docs/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/multi-url-environment-no-default/README.md
+++ b/seed/rust-sdk/multi-url-environment-no-default/README.md
@@ -56,28 +56,29 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
+match client.ec_2.boot_instance(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
+    }
+}
+```
+
+## Request Types
+
+The SDK exports all request types as Rust structs. Simply import them from the crate to access them:
+
+```rust
 use seed_multi_url_environment_no_default::prelude::{*};
 
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = MultiUrlEnvironmentNoDefaultClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
-    }
-    return Ok(());
-}
+let request = BootInstanceRequest {
+    ...
+};
 ```
 
 ## Advanced
@@ -97,17 +98,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_multi_url_environment_no_default::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = MultiUrlEnvironmentNoDefaultClient::new(config).expect("Failed to build client");
-}
+let response = client.ec_2.boot_instance(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -115,18 +108,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_multi_url_environment_no_default::prelude::{*};
-use std::time::{Duration};
+let response = client.ec_2.boot_instance(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = MultiUrlEnvironmentNoDefaultClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.ec_2.boot_instance(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.ec_2.boot_instance(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/multi-url-environment-no-default/src/core/http_client.rs
+++ b/seed/rust-sdk/multi-url-environment-no-default/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/multi-url-environment/README.md
+++ b/seed/rust-sdk/multi-url-environment/README.md
@@ -56,28 +56,29 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
+match client.ec_2.boot_instance(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
+    }
+}
+```
+
+## Request Types
+
+The SDK exports all request types as Rust structs. Simply import them from the crate to access them:
+
+```rust
 use seed_multi_url_environment::prelude::{*};
 
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = MultiUrlEnvironmentClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
-    }
-    return Ok(());
-}
+let request = BootInstanceRequest {
+    ...
+};
 ```
 
 ## Advanced
@@ -97,17 +98,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_multi_url_environment::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = MultiUrlEnvironmentClient::new(config).expect("Failed to build client");
-}
+let response = client.ec_2.boot_instance(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -115,18 +108,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_multi_url_environment::prelude::{*};
-use std::time::{Duration};
+let response = client.ec_2.boot_instance(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = MultiUrlEnvironmentClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.ec_2.boot_instance(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.ec_2.boot_instance(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/multi-url-environment/src/core/http_client.rs
+++ b/seed/rust-sdk/multi-url-environment/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/multiple-request-bodies/README.md
+++ b/seed/rust-sdk/multiple-request-bodies/README.md
@@ -49,28 +49,29 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
+match client.upload_json_document(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
+    }
+}
+```
+
+## Request Types
+
+The SDK exports all request types as Rust structs. Simply import them from the crate to access them:
+
+```rust
 use seed_api::prelude::{*};
 
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = ApiClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
-    }
-    return Ok(());
-}
+let request = UploadDocumentRequest {
+    ...
+};
 ```
 
 ## Advanced
@@ -90,17 +91,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_api::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = ApiClient::new(config).expect("Failed to build client");
-}
+let response = client.upload_json_document(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -108,18 +101,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_api::prelude::{*};
-use std::time::{Duration};
+let response = client.upload_json_document(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = ApiClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.upload_json_document(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.upload_json_document(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/multiple-request-bodies/src/core/http_client.rs
+++ b/seed/rust-sdk/multiple-request-bodies/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/no-environment/README.md
+++ b/seed/rust-sdk/no-environment/README.md
@@ -47,27 +47,16 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
-use seed_no_environment::prelude::{*};
-
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = NoEnvironmentClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
+match client.dummy.get_dummy(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
     }
-    return Ok(());
 }
 ```
 
@@ -88,17 +77,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_no_environment::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = NoEnvironmentClient::new(config).expect("Failed to build client");
-}
+let response = client.dummy.get_dummy(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -106,18 +87,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_no_environment::prelude::{*};
-use std::time::{Duration};
+let response = client.dummy.get_dummy(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = NoEnvironmentClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.dummy.get_dummy(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.dummy.get_dummy(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/no-environment/src/core/http_client.rs
+++ b/seed/rust-sdk/no-environment/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/nullable-optional/README.md
+++ b/seed/rust-sdk/nullable-optional/README.md
@@ -66,28 +66,29 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
+match client.nullable_optional.create_user(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
+    }
+}
+```
+
+## Request Types
+
+The SDK exports all request types as Rust structs. Simply import them from the crate to access them:
+
+```rust
 use seed_nullable_optional::prelude::{*};
 
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = NullableOptionalClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
-    }
-    return Ok(());
-}
+let request = UpdateComplexProfileRequest {
+    ...
+};
 ```
 
 ## Advanced
@@ -107,17 +108,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_nullable_optional::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = NullableOptionalClient::new(config).expect("Failed to build client");
-}
+let response = client.nullable_optional.create_user(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -125,18 +118,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_nullable_optional::prelude::{*};
-use std::time::{Duration};
+let response = client.nullable_optional.create_user(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = NullableOptionalClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.nullable_optional.create_user(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.nullable_optional.create_user(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/nullable-optional/src/core/http_client.rs
+++ b/seed/rust-sdk/nullable-optional/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/nullable/README.md
+++ b/seed/rust-sdk/nullable/README.md
@@ -73,28 +73,29 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
+match client.nullable.create_user(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
+    }
+}
+```
+
+## Request Types
+
+The SDK exports all request types as Rust structs. Simply import them from the crate to access them:
+
+```rust
 use seed_nullable::prelude::{*};
 
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = NullableClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
-    }
-    return Ok(());
-}
+let request = CreateUserRequest {
+    ...
+};
 ```
 
 ## Advanced
@@ -114,17 +115,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_nullable::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = NullableClient::new(config).expect("Failed to build client");
-}
+let response = client.nullable.create_user(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -132,18 +125,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_nullable::prelude::{*};
-use std::time::{Duration};
+let response = client.nullable.create_user(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = NullableClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.nullable.create_user(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.nullable.create_user(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/nullable/src/core/http_client.rs
+++ b/seed/rust-sdk/nullable/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/oauth-client-credentials-custom/README.md
+++ b/seed/rust-sdk/oauth-client-credentials-custom/README.md
@@ -61,28 +61,29 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
+match client.auth.get_token_with_client_credentials(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
+    }
+}
+```
+
+## Request Types
+
+The SDK exports all request types as Rust structs. Simply import them from the crate to access them:
+
+```rust
 use seed_oauth_client_credentials::prelude::{*};
 
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = OauthClientCredentialsClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
-    }
-    return Ok(());
-}
+let request = GetTokenRequest {
+    ...
+};
 ```
 
 ## Advanced
@@ -102,17 +103,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_oauth_client_credentials::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = OauthClientCredentialsClient::new(config).expect("Failed to build client");
-}
+let response = client.auth.get_token_with_client_credentials(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -120,18 +113,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_oauth_client_credentials::prelude::{*};
-use std::time::{Duration};
+let response = client.auth.get_token_with_client_credentials(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = OauthClientCredentialsClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.auth.get_token_with_client_credentials(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.auth.get_token_with_client_credentials(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/oauth-client-credentials-custom/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-custom/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/oauth-client-credentials-default/README.md
+++ b/seed/rust-sdk/oauth-client-credentials-default/README.md
@@ -57,28 +57,29 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
+match client.auth.get_token(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
+    }
+}
+```
+
+## Request Types
+
+The SDK exports all request types as Rust structs. Simply import them from the crate to access them:
+
+```rust
 use seed_oauth_client_credentials_default::prelude::{*};
 
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = OauthClientCredentialsDefaultClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
-    }
-    return Ok(());
-}
+let request = GetTokenRequest {
+    ...
+};
 ```
 
 ## Advanced
@@ -98,17 +99,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_oauth_client_credentials_default::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = OauthClientCredentialsDefaultClient::new(config).expect("Failed to build client");
-}
+let response = client.auth.get_token(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -116,18 +109,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_oauth_client_credentials_default::prelude::{*};
-use std::time::{Duration};
+let response = client.auth.get_token(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = OauthClientCredentialsDefaultClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.auth.get_token(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.auth.get_token(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/oauth-client-credentials-default/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-default/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/oauth-client-credentials-environment-variables/README.md
+++ b/seed/rust-sdk/oauth-client-credentials-environment-variables/README.md
@@ -60,28 +60,29 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
+match client.auth.get_token_with_client_credentials(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
+    }
+}
+```
+
+## Request Types
+
+The SDK exports all request types as Rust structs. Simply import them from the crate to access them:
+
+```rust
 use seed_oauth_client_credentials_environment_variables::prelude::{*};
 
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = OauthClientCredentialsEnvironmentVariablesClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
-    }
-    return Ok(());
-}
+let request = GetTokenRequest {
+    ...
+};
 ```
 
 ## Advanced
@@ -101,17 +102,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_oauth_client_credentials_environment_variables::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = OauthClientCredentialsEnvironmentVariablesClient::new(config).expect("Failed to build client");
-}
+let response = client.auth.get_token_with_client_credentials(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -119,18 +112,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_oauth_client_credentials_environment_variables::prelude::{*};
-use std::time::{Duration};
+let response = client.auth.get_token_with_client_credentials(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = OauthClientCredentialsEnvironmentVariablesClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.auth.get_token_with_client_credentials(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.auth.get_token_with_client_credentials(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/oauth-client-credentials-environment-variables/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-environment-variables/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/oauth-client-credentials-nested-root/README.md
+++ b/seed/rust-sdk/oauth-client-credentials-nested-root/README.md
@@ -59,28 +59,29 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
+match client.auth.get_token(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
+    }
+}
+```
+
+## Request Types
+
+The SDK exports all request types as Rust structs. Simply import them from the crate to access them:
+
+```rust
 use seed_oauth_client_credentials::prelude::{*};
 
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = OauthClientCredentialsClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
-    }
-    return Ok(());
-}
+let request = GetTokenRequest {
+    ...
+};
 ```
 
 ## Advanced
@@ -100,17 +101,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_oauth_client_credentials::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = OauthClientCredentialsClient::new(config).expect("Failed to build client");
-}
+let response = client.auth.get_token(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -118,18 +111,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_oauth_client_credentials::prelude::{*};
-use std::time::{Duration};
+let response = client.auth.get_token(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = OauthClientCredentialsClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.auth.get_token(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.auth.get_token(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/oauth-client-credentials-nested-root/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-nested-root/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/oauth-client-credentials-with-variables/README.md
+++ b/seed/rust-sdk/oauth-client-credentials-with-variables/README.md
@@ -60,28 +60,29 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
+match client.auth.get_token_with_client_credentials(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
+    }
+}
+```
+
+## Request Types
+
+The SDK exports all request types as Rust structs. Simply import them from the crate to access them:
+
+```rust
 use seed_oauth_client_credentials_with_variables::prelude::{*};
 
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = OauthClientCredentialsWithVariablesClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
-    }
-    return Ok(());
-}
+let request = GetTokenRequest {
+    ...
+};
 ```
 
 ## Advanced
@@ -101,17 +102,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_oauth_client_credentials_with_variables::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = OauthClientCredentialsWithVariablesClient::new(config).expect("Failed to build client");
-}
+let response = client.auth.get_token_with_client_credentials(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -119,18 +112,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_oauth_client_credentials_with_variables::prelude::{*};
-use std::time::{Duration};
+let response = client.auth.get_token_with_client_credentials(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = OauthClientCredentialsWithVariablesClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.auth.get_token_with_client_credentials(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.auth.get_token_with_client_credentials(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/oauth-client-credentials-with-variables/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-with-variables/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/oauth-client-credentials/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/optional/README.md
+++ b/seed/rust-sdk/optional/README.md
@@ -56,27 +56,16 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
-use seed_objects_with_imports::prelude::{*};
-
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = ObjectsWithImportsClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
+match client.optional.send_optional_body(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
     }
-    return Ok(());
 }
 ```
 
@@ -97,17 +86,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_objects_with_imports::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = ObjectsWithImportsClient::new(config).expect("Failed to build client");
-}
+let response = client.optional.send_optional_body(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -115,18 +96,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_objects_with_imports::prelude::{*};
-use std::time::{Duration};
+let response = client.optional.send_optional_body(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = ObjectsWithImportsClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.optional.send_optional_body(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.optional.send_optional_body(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/optional/src/core/http_client.rs
+++ b/seed/rust-sdk/optional/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/package-yml/README.md
+++ b/seed/rust-sdk/package-yml/README.md
@@ -56,27 +56,16 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
-use seed_package_yml::prelude::{*};
-
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = PackageYmlClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
+match client.echo(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
     }
-    return Ok(());
 }
 ```
 
@@ -97,17 +86,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_package_yml::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = PackageYmlClient::new(config).expect("Failed to build client");
-}
+let response = client.echo(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -115,18 +96,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_package_yml::prelude::{*};
-use std::time::{Duration};
+let response = client.echo(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = PackageYmlClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.echo(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.echo(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/package-yml/src/core/http_client.rs
+++ b/seed/rust-sdk/package-yml/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/pagination-custom/README.md
+++ b/seed/rust-sdk/pagination-custom/README.md
@@ -55,27 +55,16 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
-use seed_pagination::prelude::{*};
-
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = PaginationClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
+match client.users.list_usernames_custom(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
     }
-    return Ok(());
 }
 ```
 
@@ -96,17 +85,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_pagination::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = PaginationClient::new(config).expect("Failed to build client");
-}
+let response = client.users.list_usernames_custom(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -114,18 +95,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_pagination::prelude::{*};
-use std::time::{Duration};
+let response = client.users.list_usernames_custom(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = PaginationClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.users.list_usernames_custom(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.users.list_usernames_custom(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/pagination-custom/src/core/http_client.rs
+++ b/seed/rust-sdk/pagination-custom/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/pagination/README.md
+++ b/seed/rust-sdk/pagination/README.md
@@ -65,28 +65,29 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
+match client.complex.search(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
+    }
+}
+```
+
+## Request Types
+
+The SDK exports all request types as Rust structs. Simply import them from the crate to access them:
+
+```rust
 use seed_pagination::prelude::{*};
 
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = PaginationClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
-    }
-    return Ok(());
-}
+let request = ListUsersBodyCursorPaginationRequest {
+    ...
+};
 ```
 
 ## Advanced
@@ -106,17 +107,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_pagination::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = PaginationClient::new(config).expect("Failed to build client");
-}
+let response = client.complex.search(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -124,18 +117,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_pagination::prelude::{*};
-use std::time::{Duration};
+let response = client.complex.search(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = PaginationClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.complex.search(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.complex.search(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/pagination/src/core/http_client.rs
+++ b/seed/rust-sdk/pagination/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/path-parameters/README.md
+++ b/seed/rust-sdk/path-parameters/README.md
@@ -57,27 +57,16 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
-use seed_path_parameters::prelude::{*};
-
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = PathParametersClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
+match client.user.create_user(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
     }
-    return Ok(());
 }
 ```
 
@@ -98,17 +87,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_path_parameters::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = PathParametersClient::new(config).expect("Failed to build client");
-}
+let response = client.user.create_user(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -116,18 +97,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_path_parameters::prelude::{*};
-use std::time::{Duration};
+let response = client.user.create_user(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = PathParametersClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.user.create_user(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.user.create_user(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/path-parameters/src/core/http_client.rs
+++ b/seed/rust-sdk/path-parameters/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/plain-text/README.md
+++ b/seed/rust-sdk/plain-text/README.md
@@ -46,27 +46,16 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
-use seed_plain_text::prelude::{*};
-
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = PlainTextClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
+match client.service.get_text(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
     }
-    return Ok(());
 }
 ```
 
@@ -87,17 +76,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_plain_text::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = PlainTextClient::new(config).expect("Failed to build client");
-}
+let response = client.service.get_text(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -105,18 +86,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_plain_text::prelude::{*};
-use std::time::{Duration};
+let response = client.service.get_text(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = PlainTextClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.service.get_text(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.service.get_text(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/plain-text/src/core/http_client.rs
+++ b/seed/rust-sdk/plain-text/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/property-access/README.md
+++ b/seed/rust-sdk/property-access/README.md
@@ -63,27 +63,16 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
-use seed_property_access::prelude::{*};
-
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = PropertyAccessClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
+match client.create_user(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
     }
-    return Ok(());
 }
 ```
 
@@ -104,17 +93,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_property_access::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = PropertyAccessClient::new(config).expect("Failed to build client");
-}
+let response = client.create_user(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -122,18 +103,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_property_access::prelude::{*};
-use std::time::{Duration};
+let response = client.create_user(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = PropertyAccessClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.create_user(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.create_user(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/property-access/src/core/http_client.rs
+++ b/seed/rust-sdk/property-access/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/query-parameters-openapi-as-objects/README.md
+++ b/seed/rust-sdk/query-parameters-openapi-as-objects/README.md
@@ -103,27 +103,16 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
-use seed_api::prelude::{*};
-
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = ApiClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
+match client.search(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
     }
-    return Ok(());
 }
 ```
 
@@ -144,17 +133,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_api::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = ApiClient::new(config).expect("Failed to build client");
-}
+let response = client.search(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -162,18 +143,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_api::prelude::{*};
-use std::time::{Duration};
+let response = client.search(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = ApiClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.search(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.search(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/query-parameters-openapi-as-objects/src/core/http_client.rs
+++ b/seed/rust-sdk/query-parameters-openapi-as-objects/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/query-parameters-openapi/README.md
+++ b/seed/rust-sdk/query-parameters-openapi/README.md
@@ -103,27 +103,16 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
-use seed_api::prelude::{*};
-
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = ApiClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
+match client.search(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
     }
-    return Ok(());
 }
 ```
 
@@ -144,17 +133,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_api::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = ApiClient::new(config).expect("Failed to build client");
-}
+let response = client.search(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -162,18 +143,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_api::prelude::{*};
-use std::time::{Duration};
+let response = client.search(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = ApiClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.search(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.search(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/query-parameters-openapi/src/core/http_client.rs
+++ b/seed/rust-sdk/query-parameters-openapi/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/query-parameters/README.md
+++ b/seed/rust-sdk/query-parameters/README.md
@@ -100,27 +100,16 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
-use seed_query_parameters::prelude::{*};
-
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = QueryParametersClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
+match client.user.get_username(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
     }
-    return Ok(());
 }
 ```
 
@@ -141,17 +130,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_query_parameters::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = QueryParametersClient::new(config).expect("Failed to build client");
-}
+let response = client.user.get_username(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -159,18 +140,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_query_parameters::prelude::{*};
-use std::time::{Duration};
+let response = client.user.get_username(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = QueryParametersClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.user.get_username(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.user.get_username(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/query-parameters/src/core/http_client.rs
+++ b/seed/rust-sdk/query-parameters/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/request-parameters/README.md
+++ b/seed/rust-sdk/request-parameters/README.md
@@ -58,28 +58,29 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
+match client.user.create_username(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
+    }
+}
+```
+
+## Request Types
+
+The SDK exports all request types as Rust structs. Simply import them from the crate to access them:
+
+```rust
 use seed_request_parameters::prelude::{*};
 
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = RequestParametersClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
-    }
-    return Ok(());
-}
+let request = CreateUsernameRequest {
+    ...
+};
 ```
 
 ## Advanced
@@ -99,17 +100,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_request_parameters::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = RequestParametersClient::new(config).expect("Failed to build client");
-}
+let response = client.user.create_username(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -117,18 +110,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_request_parameters::prelude::{*};
-use std::time::{Duration};
+let response = client.user.create_username(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = RequestParametersClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.user.create_username(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.user.create_username(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/request-parameters/src/core/http_client.rs
+++ b/seed/rust-sdk/request-parameters/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/required-nullable/README.md
+++ b/seed/rust-sdk/required-nullable/README.md
@@ -54,27 +54,16 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
-use seed_api::prelude::{*};
-
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = ApiClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
+match client.get_foo(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
     }
-    return Ok(());
 }
 ```
 
@@ -95,17 +84,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_api::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = ApiClient::new(config).expect("Failed to build client");
-}
+let response = client.get_foo(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -113,18 +94,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_api::prelude::{*};
-use std::time::{Duration};
+let response = client.get_foo(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = ApiClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.get_foo(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.get_foo(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/required-nullable/src/core/http_client.rs
+++ b/seed/rust-sdk/required-nullable/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/reserved-keywords/README.md
+++ b/seed/rust-sdk/reserved-keywords/README.md
@@ -54,27 +54,16 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
-use seed_nursery_api::prelude::{*};
-
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = NurseryApiClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
+match client.package.test(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
     }
-    return Ok(());
 }
 ```
 
@@ -95,17 +84,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_nursery_api::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = NurseryApiClient::new(config).expect("Failed to build client");
-}
+let response = client.package.test(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -113,18 +94,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_nursery_api::prelude::{*};
-use std::time::{Duration};
+let response = client.package.test(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = NurseryApiClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.package.test(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.package.test(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/reserved-keywords/src/core/http_client.rs
+++ b/seed/rust-sdk/reserved-keywords/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/response-property/README.md
+++ b/seed/rust-sdk/response-property/README.md
@@ -46,27 +46,16 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
-use seed_response_property::prelude::{*};
-
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = ResponsePropertyClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
+match client.service.get_movie(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
     }
-    return Ok(());
 }
 ```
 
@@ -87,17 +76,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_response_property::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = ResponsePropertyClient::new(config).expect("Failed to build client");
-}
+let response = client.service.get_movie(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -105,18 +86,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_response_property::prelude::{*};
-use std::time::{Duration};
+let response = client.service.get_movie(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = ResponsePropertyClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.service.get_movie(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.service.get_movie(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/response-property/src/core/http_client.rs
+++ b/seed/rust-sdk/response-property/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/server-sent-event-examples/README.md
+++ b/seed/rust-sdk/server-sent-event-examples/README.md
@@ -55,28 +55,29 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
+match client.completions.stream(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
+    }
+}
+```
+
+## Request Types
+
+The SDK exports all request types as Rust structs. Simply import them from the crate to access them:
+
+```rust
 use seed_server_sent_events::prelude::{*};
 
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = ServerSentEventsClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
-    }
-    return Ok(());
-}
+let request = StreamCompletionRequest {
+    ...
+};
 ```
 
 ## Advanced
@@ -96,17 +97,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_server_sent_events::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = ServerSentEventsClient::new(config).expect("Failed to build client");
-}
+let response = client.completions.stream(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -114,18 +107,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_server_sent_events::prelude::{*};
-use std::time::{Duration};
+let response = client.completions.stream(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = ServerSentEventsClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.completions.stream(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.completions.stream(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/server-sent-event-examples/src/core/http_client.rs
+++ b/seed/rust-sdk/server-sent-event-examples/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/server-sent-events/README.md
+++ b/seed/rust-sdk/server-sent-events/README.md
@@ -55,28 +55,29 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
+match client.completions.stream(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
+    }
+}
+```
+
+## Request Types
+
+The SDK exports all request types as Rust structs. Simply import them from the crate to access them:
+
+```rust
 use seed_server_sent_events::prelude::{*};
 
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = ServerSentEventsClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
-    }
-    return Ok(());
-}
+let request = StreamCompletionRequest {
+    ...
+};
 ```
 
 ## Advanced
@@ -96,17 +97,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_server_sent_events::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = ServerSentEventsClient::new(config).expect("Failed to build client");
-}
+let response = client.completions.stream(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -114,18 +107,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_server_sent_events::prelude::{*};
-use std::time::{Duration};
+let response = client.completions.stream(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = ServerSentEventsClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.completions.stream(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.completions.stream(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/server-sent-events/src/core/http_client.rs
+++ b/seed/rust-sdk/server-sent-events/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/simple-api/README.md
+++ b/seed/rust-sdk/simple-api/README.md
@@ -47,27 +47,16 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
-use seed_simple_api::prelude::{*};
-
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = SimpleApiClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
+match client.user.get(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
     }
-    return Ok(());
 }
 ```
 
@@ -88,17 +77,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_simple_api::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = SimpleApiClient::new(config).expect("Failed to build client");
-}
+let response = client.user.get(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -106,18 +87,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_simple_api::prelude::{*};
-use std::time::{Duration};
+let response = client.user.get(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = SimpleApiClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.user.get(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.user.get(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/simple-api/src/core/http_client.rs
+++ b/seed/rust-sdk/simple-api/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/simple-fhir/README.md
+++ b/seed/rust-sdk/simple-fhir/README.md
@@ -46,27 +46,16 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
-use seed_api::prelude::{*};
-
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = ApiClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
+match client.get_account(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
     }
-    return Ok(());
 }
 ```
 
@@ -87,17 +76,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_api::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = ApiClient::new(config).expect("Failed to build client");
-}
+let response = client.get_account(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -105,18 +86,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_api::prelude::{*};
-use std::time::{Duration};
+let response = client.get_account(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = ApiClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.get_account(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.get_account(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/simple-fhir/src/core/http_client.rs
+++ b/seed/rust-sdk/simple-fhir/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/single-url-environment-default/basic/README.md
+++ b/seed/rust-sdk/single-url-environment-default/basic/README.md
@@ -47,27 +47,16 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
-use seed_single_url_environment_default::prelude::{*};
-
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = SingleUrlEnvironmentDefaultClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
+match client.dummy.get_dummy(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
     }
-    return Ok(());
 }
 ```
 
@@ -88,17 +77,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_single_url_environment_default::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = SingleUrlEnvironmentDefaultClient::new(config).expect("Failed to build client");
-}
+let response = client.dummy.get_dummy(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -106,18 +87,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_single_url_environment_default::prelude::{*};
-use std::time::{Duration};
+let response = client.dummy.get_dummy(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = SingleUrlEnvironmentDefaultClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.dummy.get_dummy(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.dummy.get_dummy(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/single-url-environment-default/basic/src/core/http_client.rs
+++ b/seed/rust-sdk/single-url-environment-default/basic/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/single-url-environment-default/custom-environment/README.md
+++ b/seed/rust-sdk/single-url-environment-default/custom-environment/README.md
@@ -47,27 +47,16 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
-use environment_test_sdk::prelude::{*};
-
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = SingleUrlEnvironmentDefaultClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
+match client.dummy.get_dummy(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
     }
-    return Ok(());
 }
 ```
 
@@ -88,17 +77,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use environment_test_sdk::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = SingleUrlEnvironmentDefaultClient::new(config).expect("Failed to build client");
-}
+let response = client.dummy.get_dummy(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -106,18 +87,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use environment_test_sdk::prelude::{*};
-use std::time::{Duration};
+let response = client.dummy.get_dummy(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = SingleUrlEnvironmentDefaultClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.dummy.get_dummy(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.dummy.get_dummy(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/single-url-environment-default/custom-environment/src/core/http_client.rs
+++ b/seed/rust-sdk/single-url-environment-default/custom-environment/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/single-url-environment-default/full-custom/README.md
+++ b/seed/rust-sdk/single-url-environment-default/full-custom/README.md
@@ -59,27 +59,16 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
-use full_custom_sdk::prelude::{*};
-
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = SingleUrlEnvironmentDefaultClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
+match client.dummy.get_dummy(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
     }
-    return Ok(());
 }
 ```
 
@@ -100,17 +89,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use full_custom_sdk::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = SingleUrlEnvironmentDefaultClient::new(config).expect("Failed to build client");
-}
+let response = client.dummy.get_dummy(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -118,18 +99,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use full_custom_sdk::prelude::{*};
-use std::time::{Duration};
+let response = client.dummy.get_dummy(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = SingleUrlEnvironmentDefaultClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.dummy.get_dummy(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.dummy.get_dummy(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/single-url-environment-default/full-custom/src/core/http_client.rs
+++ b/seed/rust-sdk/single-url-environment-default/full-custom/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/single-url-environment-no-default/README.md
+++ b/seed/rust-sdk/single-url-environment-no-default/README.md
@@ -47,27 +47,16 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
-use seed_single_url_environment_no_default::prelude::{*};
-
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = SingleUrlEnvironmentNoDefaultClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
+match client.dummy.get_dummy(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
     }
-    return Ok(());
 }
 ```
 
@@ -88,17 +77,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_single_url_environment_no_default::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = SingleUrlEnvironmentNoDefaultClient::new(config).expect("Failed to build client");
-}
+let response = client.dummy.get_dummy(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -106,18 +87,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_single_url_environment_no_default::prelude::{*};
-use std::time::{Duration};
+let response = client.dummy.get_dummy(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = SingleUrlEnvironmentNoDefaultClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.dummy.get_dummy(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.dummy.get_dummy(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/single-url-environment-no-default/src/core/http_client.rs
+++ b/seed/rust-sdk/single-url-environment-no-default/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/streaming-parameter/README.md
+++ b/seed/rust-sdk/streaming-parameter/README.md
@@ -56,28 +56,29 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
+match client.dummy.generate(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
+    }
+}
+```
+
+## Request Types
+
+The SDK exports all request types as Rust structs. Simply import them from the crate to access them:
+
+```rust
 use seed_streaming::prelude::{*};
 
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = StreamingClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
-    }
-    return Ok(());
-}
+let request = GenerateRequest {
+    ...
+};
 ```
 
 ## Advanced
@@ -97,17 +98,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_streaming::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = StreamingClient::new(config).expect("Failed to build client");
-}
+let response = client.dummy.generate(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -115,18 +108,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_streaming::prelude::{*};
-use std::time::{Duration};
+let response = client.dummy.generate(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = StreamingClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.dummy.generate(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.dummy.generate(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/streaming-parameter/src/core/http_client.rs
+++ b/seed/rust-sdk/streaming-parameter/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/streaming/README.md
+++ b/seed/rust-sdk/streaming/README.md
@@ -56,28 +56,29 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
+match client.dummy.generate_stream(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
+    }
+}
+```
+
+## Request Types
+
+The SDK exports all request types as Rust structs. Simply import them from the crate to access them:
+
+```rust
 use seed_streaming::prelude::{*};
 
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = StreamingClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
-    }
-    return Ok(());
-}
+let request = GenerateStreamRequest {
+    ...
+};
 ```
 
 ## Advanced
@@ -97,17 +98,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_streaming::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = StreamingClient::new(config).expect("Failed to build client");
-}
+let response = client.dummy.generate_stream(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -115,18 +108,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_streaming::prelude::{*};
-use std::time::{Duration};
+let response = client.dummy.generate_stream(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = StreamingClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.dummy.generate_stream(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.dummy.generate_stream(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/streaming/src/core/http_client.rs
+++ b/seed/rust-sdk/streaming/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/trace/README.md
+++ b/seed/rust-sdk/trace/README.md
@@ -55,28 +55,29 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
+match client.admin.update_test_submission_status(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
+    }
+}
+```
+
+## Request Types
+
+The SDK exports all request types as Rust structs. Simply import them from the crate to access them:
+
+```rust
 use seed_trace::prelude::{*};
 
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = TraceClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
-    }
-    return Ok(());
-}
+let request = StoreTracedTestCaseRequest {
+    ...
+};
 ```
 
 ## Advanced
@@ -96,17 +97,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_trace::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = TraceClient::new(config).expect("Failed to build client");
-}
+let response = client.admin.update_test_submission_status(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -114,18 +107,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_trace::prelude::{*};
-use std::time::{Duration};
+let response = client.admin.update_test_submission_status(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = TraceClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.admin.update_test_submission_status(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.admin.update_test_submission_status(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/trace/src/core/http_client.rs
+++ b/seed/rust-sdk/trace/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/undiscriminated-unions/README.md
+++ b/seed/rust-sdk/undiscriminated-unions/README.md
@@ -49,27 +49,16 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
-use seed_undiscriminated_unions::prelude::{*};
-
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = UndiscriminatedUnionsClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
+match client.union_.get(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
     }
-    return Ok(());
 }
 ```
 
@@ -90,17 +79,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_undiscriminated_unions::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = UndiscriminatedUnionsClient::new(config).expect("Failed to build client");
-}
+let response = client.union_.get(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -108,18 +89,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_undiscriminated_unions::prelude::{*};
-use std::time::{Duration};
+let response = client.union_.get(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = UndiscriminatedUnionsClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.union_.get(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.union_.get(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/undiscriminated-unions/src/core/http_client.rs
+++ b/seed/rust-sdk/undiscriminated-unions/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/unions/README.md
+++ b/seed/rust-sdk/unions/README.md
@@ -46,27 +46,16 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
-use seed_unions::prelude::{*};
-
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = UnionsClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
+match client.bigunion.get(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
     }
-    return Ok(());
 }
 ```
 
@@ -87,17 +76,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_unions::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = UnionsClient::new(config).expect("Failed to build client");
-}
+let response = client.bigunion.get(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -105,18 +86,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_unions::prelude::{*};
-use std::time::{Duration};
+let response = client.bigunion.get(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = UnionsClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.bigunion.get(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.bigunion.get(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/unions/src/core/http_client.rs
+++ b/seed/rust-sdk/unions/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/unknown/README.md
+++ b/seed/rust-sdk/unknown/README.md
@@ -50,27 +50,16 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
-use seed_unknown_as_any::prelude::{*};
-
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = UnknownAsAnyClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
+match client.unknown.post(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
     }
-    return Ok(());
 }
 ```
 
@@ -91,17 +80,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_unknown_as_any::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = UnknownAsAnyClient::new(config).expect("Failed to build client");
-}
+let response = client.unknown.post(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -109,18 +90,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_unknown_as_any::prelude::{*};
-use std::time::{Duration};
+let response = client.unknown.post(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = UnknownAsAnyClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.unknown.post(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.unknown.post(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/unknown/src/core/http_client.rs
+++ b/seed/rust-sdk/unknown/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/validation/README.md
+++ b/seed/rust-sdk/validation/README.md
@@ -57,28 +57,29 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
+match client.create(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
+    }
+}
+```
+
+## Request Types
+
+The SDK exports all request types as Rust structs. Simply import them from the crate to access them:
+
+```rust
 use seed_validation::prelude::{*};
 
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = ValidationClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
-    }
-    return Ok(());
-}
+let request = CreateRequest {
+    ...
+};
 ```
 
 ## Advanced
@@ -98,17 +99,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_validation::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = ValidationClient::new(config).expect("Failed to build client");
-}
+let response = client.create(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -116,18 +109,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_validation::prelude::{*};
-use std::time::{Duration};
+let response = client.create(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = ValidationClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.create(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.create(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/validation/src/core/http_client.rs
+++ b/seed/rust-sdk/validation/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/variables/README.md
+++ b/seed/rust-sdk/variables/README.md
@@ -46,27 +46,16 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
-use seed_variables::prelude::{*};
-
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = VariablesClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
+match client.service.post(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
     }
-    return Ok(());
 }
 ```
 
@@ -87,17 +76,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_variables::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = VariablesClient::new(config).expect("Failed to build client");
-}
+let response = client.service.post(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -105,18 +86,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_variables::prelude::{*};
-use std::time::{Duration};
+let response = client.service.post(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = VariablesClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.service.post(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.service.post(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/variables/src/core/http_client.rs
+++ b/seed/rust-sdk/variables/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/version-no-default/README.md
+++ b/seed/rust-sdk/version-no-default/README.md
@@ -49,27 +49,16 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
-use seed_version::prelude::{*};
-
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = VersionClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
+match client.user.get_user(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
     }
-    return Ok(());
 }
 ```
 
@@ -90,17 +79,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_version::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = VersionClient::new(config).expect("Failed to build client");
-}
+let response = client.user.get_user(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -108,18 +89,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_version::prelude::{*};
-use std::time::{Duration};
+let response = client.user.get_user(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = VersionClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.user.get_user(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.user.get_user(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/version-no-default/src/core/http_client.rs
+++ b/seed/rust-sdk/version-no-default/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/version/README.md
+++ b/seed/rust-sdk/version/README.md
@@ -49,27 +49,16 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
-use seed_version::prelude::{*};
-
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = VersionClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
+match client.user.get_user(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
     }
-    return Ok(());
 }
 ```
 
@@ -90,17 +79,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_version::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = VersionClient::new(config).expect("Failed to build client");
-}
+let response = client.user.get_user(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -108,18 +89,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_version::prelude::{*};
-use std::time::{Duration};
+let response = client.user.get_user(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = VersionClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.user.get_user(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.user.get_user(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/version/src/core/http_client.rs
+++ b/seed/rust-sdk/version/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);

--- a/seed/rust-sdk/websocket-inferred-auth/README.md
+++ b/seed/rust-sdk/websocket-inferred-auth/README.md
@@ -60,28 +60,29 @@ async fn main() {
 When the API returns a non-success status code (4xx or 5xx response), an error will be returned.
 
 ```rust
+match client.auth.get_token_with_client_credentials(None)?.await {
+    Ok(response) => {
+        println!("Success: {:?}", response);
+    },
+    Err(ApiError::HTTP { status, message }) => {
+        println!("API Error {}: {:?}", status, message);
+    },
+    Err(e) => {
+        println!("Other error: {:?}", e);
+    }
+}
+```
+
+## Request Types
+
+The SDK exports all request types as Rust structs. Simply import them from the crate to access them:
+
+```rust
 use seed_websocket_auth::prelude::{*};
 
-#[tokio::main]
-async fn main() -> Result<(), ApiError> {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string())
-    };
-    let client = WebsocketAuthClient::new(config)?;
-    match client.some_method().await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
-        },
-        Err(ApiError::HTTP { status, message }) => {
-            println!("API Error {}: {:?}", status, message);
-        },
-        Err(e) => {
-            println!("Other error: {:?}", e);
-        }
-    }
-    return Ok(());
-}
+let request = GetTokenRequest {
+    ...
+};
 ```
 
 ## Advanced
@@ -101,17 +102,9 @@ A request is deemed retryable when any of the following HTTP status codes is ret
 Use the `max_retries` method to configure this behavior.
 
 ```rust
-use seed_websocket_auth::prelude::{*};
-
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        max_retries: 3
-    };
-    let client = WebsocketAuthClient::new(config).expect("Failed to build client");
-}
+let response = client.auth.get_token_with_client_credentials(
+    Some(RequestOptions::new().max_retries(3))
+)?.await;
 ```
 
 ### Timeouts
@@ -119,18 +112,39 @@ async fn main() {
 The SDK defaults to a 30 second timeout. Use the `timeout` method to configure this behavior.
 
 ```rust
-use seed_websocket_auth::prelude::{*};
-use std::time::{Duration};
+let response = client.auth.get_token_with_client_credentials(
+    Some(RequestOptions::new().timeout_seconds(30))
+)?.await;
+```
 
-#[tokio::main]
-async fn main() {
-    let config = ClientConfig {
-        base_url: " ".to_string(),
-        api_key: Some("your-api-key".to_string()),
-        timeout: Duration::from_secs(30)
-    };
-    let client = WebsocketAuthClient::new(config).expect("Failed to build client");
-}
+### Additional Headers
+
+You can add custom headers to requests using `RequestOptions`.
+
+```rust
+let response = client.auth.get_token_with_client_credentials(
+    Some(
+        RequestOptions::new()
+            .additional_header("X-Custom-Header", "custom-value")
+            .additional_header("X-Another-Header", "another-value")
+    )
+)?
+.await;
+```
+
+### Additional Query String Parameters
+
+You can add custom query parameters to requests using `RequestOptions`.
+
+```rust
+let response = client.auth.get_token_with_client_credentials(
+    Some(
+        RequestOptions::new()
+            .additional_query_param("filter", "active")
+            .additional_query_param("sort", "desc")
+    )
+)?
+.await;
 ```
 
 ## Contributing

--- a/seed/rust-sdk/websocket-inferred-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/websocket-inferred-auth/src/core/http_client.rs
@@ -44,6 +44,13 @@ impl HttpClient {
             request = request.query(&params);
         }
 
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
         // Apply body if provided
         if let Some(body) = body {
             request = request.json(&body);


### PR DESCRIPTION
## Description
Linear ticket:
- https://linear.app/buildwithfern/issue/FER-7037/rust-sdk-update-readme-generation

Updated the Rust SDK generator to improve README snippet generation with better structure and formatting. The change modernizes the readme examples to provide clearer, more maintainable code samples for SDK users.


## Changes Made

- Enhanced `ReadmeSnippetBuilder.ts` to improve code snippet generation logic and formatting
- Added HTTP client improvements to base Rust generator (`http_client.rs`)
- Updated expression handling in Rust codegen AST
- Added feature flags for readme generation capabilities in `features.yml`

## Testing
- [x] Manual testing completed
