### PR TITLE
chore(rust): show log only on `--log-level debug`, make it more detailed

### DIFF
--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -1,5 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.7.3
+  createdAt: "2025-10-17"
+  changelogEntry:
+    - type: chore
+      summary: enable show log only on --log-level debug
+  irVersion: 61
+
 - version: 0.7.2
   createdAt: "2025-10-15"
   changelogEntry:


### PR DESCRIPTION
## Description

Linear ticket:
- https://linear.app/buildwithfern/issue/FER-7212/rust-sdk-put-all-logs-at-the-debug-level-and-only-show-on-the-flag-log

## Changes Made

- migrate all `logger.info`. --> `logger.debug`
- add more details/contexts to the logs so debugging is easier for self-service users