### PR TITLE
fix(typescript): Improve the performance of JSON serialization and parsing when `useBigInt` is enabled.

### DIFF
--- a/generators/typescript/asIs/core/json.bigint.ts
+++ b/generators/typescript/asIs/core/json.bigint.ts
@@ -43,7 +43,7 @@ const BIGINT_REGEX = new RegExp(`"(-?\\d+)${BIGINT_MARKER.replace(/[#]/g, "\\$&"
 export const toJson = (
     data: unknown,
     replacer?: (key: string, value: unknown) => unknown,
-    space?: string | number,
+    space?: string | number
 ): string => {
     // Use native JSON.stringify with a custom replacer for BigInt
     const preliminaryJSON = JSON.stringify(
@@ -54,7 +54,7 @@ export const toJson = (
             }
             return replacer ? replacer(key, value) : value;
         },
-        space,
+        space
     );
 
     // Strip quotes around numbers with marker: "123#bigint#" → 123
@@ -70,7 +70,7 @@ export const toJson = (
 
 export function fromJson<T = unknown>(
     json: string,
-    reviver?: (this: unknown, key: string, value: unknown) => unknown,
+    reviver?: (this: unknown, key: string, value: unknown) => unknown
 ): T {
     let i = 0;
     const len = json.length;

--- a/generators/typescript/asIs/core/json.bigint.ts
+++ b/generators/typescript/asIs/core/json.bigint.ts
@@ -1,10 +1,37 @@
-// Credit to Ivan Korolenko
-// Code adopted from https://github.com/Ivan-Korolenko/json-with-bigint
+const BIGINT_MARKER = "#bigint#";
+const CC_0 = 0x30,
+    CC_9 = 0x39;
+const CC_SPACE = 0x20,
+    CC_TAB = 0x09,
+    CC_LF = 0x0a,
+    CC_CR = 0x0d;
+const CC_MINUS = 0x2d,
+    CC_PLUS = 0x2b,
+    CC_DOT = 0x2e;
+const CC_QUOTE = 0x22,
+    CC_BACKSLASH = 0x5c;
+const CC_COMMA = 0x2c,
+    CC_COLON = 0x3a;
+const CC_LBRACE = 0x7b,
+    CC_RBRACE = 0x7d;
+const CC_LBRACKET = 0x5b,
+    CC_RBRACKET = 0x5d;
+const CC_E_LOWER = 0x65,
+    CC_E_UPPER = 0x45;
+const CC_T = 0x74,
+    CC_R = 0x72,
+    CC_U = 0x75,
+    CC_E = 0x65; // 'true'
+const CC_F = 0x66,
+    CC_A = 0x61,
+    CC_L = 0x6c,
+    CC_S = 0x73; // 'false'
+const CC_N = 0x6e; // 'null'
+const isWhitespace = (c: number) => c === CC_SPACE || c === CC_TAB || c === CC_LF || c === CC_CR;
+const isDigit = (c: number) => c >= CC_0 && c <= CC_9;
 
-/*
-  Function to serialize data to JSON string
-  Converts BigInt values to custom format (strings with digits and "n" at the end) and then converts them to proper big integers in JSON string
-*/
+// Cache the regex for better performance
+const BIGINT_REGEX = new RegExp(`"(-?\\d+)${BIGINT_MARKER.replace(/[#]/g, "\\$&")}"`, "g");
 
 /**
  * Serialize a value to JSON
@@ -15,56 +42,24 @@
  */
 export const toJson = (
     data: unknown,
-    replacer?: (this: unknown, key: string, value: unknown) => unknown,
-    space?: string | number
+    replacer?: (key: string, value: unknown) => unknown,
+    space?: string | number,
 ): string => {
-    if (typeof data === "bigint") {
-        return data.toString();
-    }
-    if (typeof data !== "object") {
-        return JSON.stringify(data, replacer, space);
-    }
-
-    // eslint-disable-next-line no-useless-escape
-    const bigInts = /([\[:])?"(-?\d+)n"([,\}\]])/g;
+    // Use native JSON.stringify with a custom replacer for BigInt
     const preliminaryJSON = JSON.stringify(
         data,
-        (key, value) =>
-            typeof value === "bigint"
-                ? value.toString() + "n"
-                : typeof replacer === "undefined"
-                  ? value
-                  : replacer(key, value),
-        space
+        (key: string, value: unknown) => {
+            if (typeof value === "bigint") {
+                return value.toString() + BIGINT_MARKER;
+            }
+            return replacer ? replacer(key, value) : value;
+        },
+        space,
     );
-    const finalJSON = preliminaryJSON.replace(bigInts, "$1$2$3");
 
-    return finalJSON;
+    // Strip quotes around numbers with marker: "123#bigint#" → 123
+    return preliminaryJSON.replace(BIGINT_REGEX, "$1");
 };
-
-/*
-  Function to parse JSON
-  If JSON has values presented in a lib's custom format (strings with digits and "n" character at the end), we just parse them to BigInt values (for backward compatibility with previous versions of the lib)
-  If JSON has values greater than Number.MAX_SAFE_INTEGER, we convert those values to our custom format, then parse them to BigInt values.
-  Other types of values are not affected and parsed as native JSON.parse() would parse them.
-
-  Big numbers are found and marked using a Regular Expression with these conditions:
-
-    1. Before the match there is no . and one of the following is present:
-      1.1 ":
-      1.2 ":[
-      1.3 ":[anyNumberOf(anyCharacters)
-      1.4 , with no ":"anyNumberOf(anyCharacters) before it
-    All " required in the rule are not escaped. All whitespace and newline characters outside of string values are ignored.
-
-    2. The match itself has more than 16 digits OR (16 digits and any digit of the number is greater than that of the Number.MAX_SAFE_INTEGER). And it may have a - sign at the start.
-
-    3. After the match one of the following is present:
-      3.1 , without anyNumberOf(anyCharacters) "} or anyNumberOf(anyCharacters) "] after it
-      3.2 } without " after it
-      3.3 ] without " after it
-    All whitespace and newline characters outside of string values are ignored.
-*/
 
 /**
  * Parse JSON string to object, array, or other type
@@ -72,29 +67,304 @@ export const toJson = (
  * @param reviver A function that transforms the results. This function is called for each member of the object. If a member contains nested objects, the nested objects are transformed before the parent object is.
  * @returns Parsed object, array, or other type
  */
+
 export function fromJson<T = unknown>(
     json: string,
-    reviver?: (this: unknown, key: string, value: unknown) => unknown
+    reviver?: (this: unknown, key: string, value: unknown) => unknown,
 ): T {
-    if (!json) {
-        return JSON.parse(json, reviver);
+    let i = 0;
+    const len = json.length;
+
+    function skipWhitespace() {
+        while (i < len && isWhitespace(json.charCodeAt(i))) i++;
     }
 
-    const numbersBiggerThanMaxInt = // eslint-disable-next-line no-useless-escape
-        /(?<=[^\\]":\n*\s*[\[]?|[^\\]":\n*\s*\[.*[^\.\d*]\n*\s*|(?<![^\\]"\n*\s*:\n*\s*[^\\]".*),\n*\s*)(-?\d{17,}|-?(?:[9](?:[1-9]07199254740991|0[1-9]7199254740991|00[8-9]199254740991|007[2-9]99254740991|007199[3-9]54740991|0071992[6-9]4740991|00719925[5-9]740991|007199254[8-9]40991|0071992547[5-9]0991|00719925474[1-9]991|00719925474099[2-9])))(?=,(?!.*[^\\]"(\n*\s*\}|\n*\s*\]))|\n*\s*\}[^"]?|\n*\s*\][^"])/g;
-    const serializedData = json.replace(numbersBiggerThanMaxInt, '"$1n"');
+    function parseValue(): unknown {
+        skipWhitespace();
+        const c = json.charCodeAt(i);
 
-    return JSON.parse(serializedData, (key, value) => {
-        const isCustomFormatBigInt = typeof value === "string" && Boolean(value.match(/^-?\d+n$/));
+        if (c === CC_QUOTE) return parseString();
+        if (c === CC_LBRACE) return parseObject();
+        if (c === CC_LBRACKET) return parseArray();
+        if (c === CC_MINUS || isDigit(c)) return parseNumber();
 
-        if (isCustomFormatBigInt) {
-            return BigInt(value.substring(0, value.length - 1));
+        // Check for true/false/null using character codes
+        if (c === CC_T) {
+            if (json.charCodeAt(i + 1) === CC_R && json.charCodeAt(i + 2) === CC_U && json.charCodeAt(i + 3) === CC_E) {
+                i += 4;
+                return true;
+            }
+        } else if (c === CC_F) {
+            if (
+                json.charCodeAt(i + 1) === CC_A &&
+                json.charCodeAt(i + 2) === CC_L &&
+                json.charCodeAt(i + 3) === CC_S &&
+                json.charCodeAt(i + 4) === CC_E
+            ) {
+                i += 5;
+                return false;
+            }
+        } else if (c === CC_N) {
+            if (json.charCodeAt(i + 1) === CC_U && json.charCodeAt(i + 2) === CC_L && json.charCodeAt(i + 3) === CC_L) {
+                i += 4;
+                return null;
+            }
         }
 
-        if (typeof reviver !== "undefined") {
-            return reviver(key, value);
+        throw new SyntaxError(`Unexpected character at position ${i}: ${json[i]}`);
+    }
+
+    function parseString(): string {
+        i++; // skip opening quote
+        const start = i;
+
+        // Fast path: scan for end quote without escapes
+        while (i < len) {
+            const c = json.charCodeAt(i);
+            if (c === CC_QUOTE) {
+                const result = json.slice(start, i);
+                i++;
+                return result;
+            }
+            if (c === CC_BACKSLASH) {
+                break; // Hit an escape, fall through to slow path
+            }
+            i++;
         }
 
-        return value;
-    });
+        // Slow path: handle escapes using array for better performance
+        const parts = [json.slice(start, i)];
+        while (i < len) {
+            const c = json.charCodeAt(i);
+            if (c === CC_QUOTE) {
+                i++;
+                return parts.join("");
+            }
+            if (c === CC_BACKSLASH) {
+                i++;
+                const next = json.charCodeAt(i);
+                switch (next) {
+                    case CC_QUOTE:
+                        parts.push('"');
+                        break;
+                    case CC_BACKSLASH:
+                        parts.push("\\");
+                        break;
+                    case 0x2f: // '/'
+                        parts.push("/");
+                        break;
+                    case 0x62: // 'b'
+                        parts.push("\b");
+                        break;
+                    case 0x66: // 'f'
+                        parts.push("\f");
+                        break;
+                    case CC_N: // 'n'
+                        parts.push("\n");
+                        break;
+                    case CC_R: // 'r'
+                        parts.push("\r");
+                        break;
+                    case CC_T: // 't'
+                        parts.push("\t");
+                        break;
+                    case CC_U: // 'u'
+                        parts.push(String.fromCharCode(parseInt(json.slice(i + 1, i + 5), 16)));
+                        i += 4;
+                        break;
+                    default:
+                        throw new SyntaxError(`Invalid escape sequence at position ${i}`);
+                }
+                i++;
+            } else {
+                // Accumulate regular characters
+                const chunkStart = i;
+                while (i < len) {
+                    const cc = json.charCodeAt(i);
+                    if (cc === CC_QUOTE || cc === CC_BACKSLASH) break;
+                    i++;
+                }
+                parts.push(json.slice(chunkStart, i));
+            }
+        }
+        throw new SyntaxError("Unterminated string");
+    }
+
+    function parseNumber(): number | bigint {
+        const start = i;
+
+        // Optional minus
+        if (json.charCodeAt(i) === CC_MINUS) i++;
+
+        // Integer part
+        const digitStart = i;
+        if (json.charCodeAt(i) === CC_0) {
+            i++;
+        } else if (isDigit(json.charCodeAt(i))) {
+            while (i < len && isDigit(json.charCodeAt(i))) i++;
+        }
+        const intEnd = i;
+
+        // Fraction part
+        let hasFrac = false;
+        if (json.charCodeAt(i) === CC_DOT) {
+            hasFrac = true;
+            i++;
+            while (i < len && isDigit(json.charCodeAt(i))) i++;
+        }
+
+        // Exponent part
+        let hasExp = false;
+        const c = json.charCodeAt(i);
+        if (c === CC_E_LOWER || c === CC_E_UPPER) {
+            hasExp = true;
+            i++;
+            const sign = json.charCodeAt(i);
+            if (sign === CC_MINUS || sign === CC_PLUS) i++;
+            while (i < len && isDigit(json.charCodeAt(i))) i++;
+        }
+
+        const numStr = json.slice(start, i);
+
+        // If it's a pure integer, check if we should use BigInt
+        if (!hasFrac && !hasExp) {
+            const digitCount = intEnd - digitStart;
+
+            // Quick length check - numbers > 16 digits are definitely unsafe
+            if (digitCount > 16) {
+                return BigInt(numStr);
+            }
+
+            // Numbers < 15 digits are always safe
+            if (digitCount < 15) {
+                return Number(numStr);
+            }
+
+            // For 15-16 digit numbers, convert and check
+            const num = Number(numStr);
+            if (!Number.isSafeInteger(num)) {
+                return BigInt(numStr);
+            }
+            return num;
+        }
+
+        return Number(numStr);
+    }
+
+    function parseObject(): Record<string, unknown> {
+        i++; // skip opening brace
+        skipWhitespace();
+
+        const obj: Record<string, unknown> = {};
+
+        if (json.charCodeAt(i) === CC_RBRACE) {
+            i++;
+            return obj;
+        }
+
+        while (true) {
+            skipWhitespace();
+            const key = parseString();
+            skipWhitespace();
+
+            if (json.charCodeAt(i) !== CC_COLON) {
+                throw new SyntaxError(`Expected ':' at position ${i}`);
+            }
+            i++;
+
+            const value = parseValue();
+            obj[key] = value;
+
+            skipWhitespace();
+            const c = json.charCodeAt(i);
+            if (c === CC_RBRACE) {
+                i++;
+                return obj;
+            }
+            if (c === CC_COMMA) {
+                i++;
+                continue;
+            }
+            throw new SyntaxError(`Expected ',' or '}' at position ${i}`);
+        }
+    }
+
+    function parseArray(): unknown[] {
+        i++; // skip opening bracket
+        skipWhitespace();
+
+        const arr: unknown[] = [];
+
+        if (json.charCodeAt(i) === CC_RBRACKET) {
+            i++;
+            return arr;
+        }
+
+        while (true) {
+            arr.push(parseValue());
+            skipWhitespace();
+
+            const c = json.charCodeAt(i);
+            if (c === CC_RBRACKET) {
+                i++;
+                return arr;
+            }
+            if (c === CC_COMMA) {
+                i++;
+                continue;
+            }
+            throw new SyntaxError(`Expected ',' or ']' at position ${i}`);
+        }
+    }
+
+    const result = parseValue();
+    skipWhitespace();
+
+    if (i < json.length) {
+        throw new SyntaxError(`Unexpected content at position ${i}`);
+    }
+
+    // Apply reviver if provided
+    if (!reviver) return result as T;
+
+    function reviveRecursive(holder: Record<string, unknown> | unknown[], key: string): unknown {
+        let value: unknown;
+        if (Array.isArray(holder)) {
+            const idx = Number(key);
+            if (Number.isInteger(idx)) {
+                value = holder[idx];
+            } else {
+                value = (holder as unknown as Record<string, unknown>)[key];
+            }
+        } else {
+            value = holder[key];
+        }
+
+        if (value && typeof value === "object") {
+            if (Array.isArray(value)) {
+                for (let i = 0; i < value.length; i++) {
+                    const newValue = reviveRecursive(value, String(i));
+                    if (newValue !== undefined) {
+                        value[i] = newValue;
+                    } else {
+                        delete value[i];
+                    }
+                }
+            } else {
+                const obj = value as Record<string, unknown>;
+                for (const k of Object.keys(obj)) {
+                    const newValue = reviveRecursive(obj, k);
+                    if (newValue !== undefined) {
+                        obj[k] = newValue;
+                    } else {
+                        delete obj[k];
+                    }
+                }
+            }
+        }
+
+        return reviver?.call(holder, key, value);
+    }
+
+    return reviveRecursive({ "": result }, "") as T;
 }

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.9.1
+  changelogEntry:
+    - summary: |
+        Improve the performance of JSON serialization and parsing when `useBigInt` is enabled.
+      type: fix
+  createdAt: "2025-10-16"
+  irVersion: 60
+
 - version: 3.9.0
   changelogEntry:
     - summary: |

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/core/json.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/core/json.ts
@@ -1,10 +1,37 @@
-// Credit to Ivan Korolenko
-// Code adopted from https://github.com/Ivan-Korolenko/json-with-bigint
+const BIGINT_MARKER = "#bigint#";
+const CC_0 = 0x30,
+    CC_9 = 0x39;
+const CC_SPACE = 0x20,
+    CC_TAB = 0x09,
+    CC_LF = 0x0a,
+    CC_CR = 0x0d;
+const CC_MINUS = 0x2d,
+    CC_PLUS = 0x2b,
+    CC_DOT = 0x2e;
+const CC_QUOTE = 0x22,
+    CC_BACKSLASH = 0x5c;
+const CC_COMMA = 0x2c,
+    CC_COLON = 0x3a;
+const CC_LBRACE = 0x7b,
+    CC_RBRACE = 0x7d;
+const CC_LBRACKET = 0x5b,
+    CC_RBRACKET = 0x5d;
+const CC_E_LOWER = 0x65,
+    CC_E_UPPER = 0x45;
+const CC_T = 0x74,
+    CC_R = 0x72,
+    CC_U = 0x75,
+    CC_E = 0x65; // 'true'
+const CC_F = 0x66,
+    CC_A = 0x61,
+    CC_L = 0x6c,
+    CC_S = 0x73; // 'false'
+const CC_N = 0x6e; // 'null'
+const isWhitespace = (c: number) => c === CC_SPACE || c === CC_TAB || c === CC_LF || c === CC_CR;
+const isDigit = (c: number) => c >= CC_0 && c <= CC_9;
 
-/*
-  Function to serialize data to JSON string
-  Converts BigInt values to custom format (strings with digits and "n" at the end) and then converts them to proper big integers in JSON string
-*/
+// Cache the regex for better performance
+const BIGINT_REGEX = new RegExp(`"(-?\\d+)${BIGINT_MARKER.replace(/[#]/g, "\\$&")}"`, "g");
 
 /**
  * Serialize a value to JSON
@@ -15,56 +42,24 @@
  */
 export const toJson = (
     data: unknown,
-    replacer?: (this: unknown, key: string, value: unknown) => unknown,
+    replacer?: (key: string, value: unknown) => unknown,
     space?: string | number,
 ): string => {
-    if (typeof data === "bigint") {
-        return data.toString();
-    }
-    if (typeof data !== "object") {
-        return JSON.stringify(data, replacer, space);
-    }
-
-    // eslint-disable-next-line no-useless-escape
-    const bigInts = /([[:])?"(-?\d+)n"([,}\]])/g;
+    // Use native JSON.stringify with a custom replacer for BigInt
     const preliminaryJSON = JSON.stringify(
         data,
-        (key, value) =>
-            typeof value === "bigint"
-                ? `${value.toString()}n`
-                : typeof replacer === "undefined"
-                  ? value
-                  : replacer(key, value),
+        (key: string, value: unknown) => {
+            if (typeof value === "bigint") {
+                return value.toString() + BIGINT_MARKER;
+            }
+            return replacer ? replacer(key, value) : value;
+        },
         space,
     );
-    const finalJSON = preliminaryJSON.replace(bigInts, "$1$2$3");
 
-    return finalJSON;
+    // Strip quotes around numbers with marker: "123#bigint#" → 123
+    return preliminaryJSON.replace(BIGINT_REGEX, "$1");
 };
-
-/*
-  Function to parse JSON
-  If JSON has values presented in a lib's custom format (strings with digits and "n" character at the end), we just parse them to BigInt values (for backward compatibility with previous versions of the lib)
-  If JSON has values greater than Number.MAX_SAFE_INTEGER, we convert those values to our custom format, then parse them to BigInt values.
-  Other types of values are not affected and parsed as native JSON.parse() would parse them.
-
-  Big numbers are found and marked using a Regular Expression with these conditions:
-
-    1. Before the match there is no . and one of the following is present:
-      1.1 ":
-      1.2 ":[
-      1.3 ":[anyNumberOf(anyCharacters)
-      1.4 , with no ":"anyNumberOf(anyCharacters) before it
-    All " required in the rule are not escaped. All whitespace and newline characters outside of string values are ignored.
-
-    2. The match itself has more than 16 digits OR (16 digits and any digit of the number is greater than that of the Number.MAX_SAFE_INTEGER). And it may have a - sign at the start.
-
-    3. After the match one of the following is present:
-      3.1 , without anyNumberOf(anyCharacters) "} or anyNumberOf(anyCharacters) "] after it
-      3.2 } without " after it
-      3.3 ] without " after it
-    All whitespace and newline characters outside of string values are ignored.
-*/
 
 /**
  * Parse JSON string to object, array, or other type
@@ -72,29 +67,304 @@ export const toJson = (
  * @param reviver A function that transforms the results. This function is called for each member of the object. If a member contains nested objects, the nested objects are transformed before the parent object is.
  * @returns Parsed object, array, or other type
  */
+
 export function fromJson<T = unknown>(
     json: string,
     reviver?: (this: unknown, key: string, value: unknown) => unknown,
 ): T {
-    if (!json) {
-        return JSON.parse(json, reviver);
+    let i = 0;
+    const len = json.length;
+
+    function skipWhitespace() {
+        while (i < len && isWhitespace(json.charCodeAt(i))) i++;
     }
 
-    const numbersBiggerThanMaxInt = // eslint-disable-next-line no-useless-escape
-        /(?<=[^\\]":\n*\s*[[]?|[^\\]":\n*\s*\[.*[^.\d*]\n*\s*|(?<![^\\]"\n*\s*:\n*\s*[^\\]".*),\n*\s*)(-?\d{17,}|-?(?:[9](?:[1-9]07199254740991|0[1-9]7199254740991|00[8-9]199254740991|007[2-9]99254740991|007199[3-9]54740991|0071992[6-9]4740991|00719925[5-9]740991|007199254[8-9]40991|0071992547[5-9]0991|00719925474[1-9]991|00719925474099[2-9])))(?=,(?!.*[^\\]"(\n*\s*\}|\n*\s*\]))|\n*\s*\}[^"]?|\n*\s*\][^"])/g;
-    const serializedData = json.replace(numbersBiggerThanMaxInt, '"$1n"');
+    function parseValue(): unknown {
+        skipWhitespace();
+        const c = json.charCodeAt(i);
 
-    return JSON.parse(serializedData, (key, value) => {
-        const isCustomFormatBigInt = typeof value === "string" && Boolean(value.match(/^-?\d+n$/));
+        if (c === CC_QUOTE) return parseString();
+        if (c === CC_LBRACE) return parseObject();
+        if (c === CC_LBRACKET) return parseArray();
+        if (c === CC_MINUS || isDigit(c)) return parseNumber();
 
-        if (isCustomFormatBigInt) {
-            return BigInt(value.substring(0, value.length - 1));
+        // Check for true/false/null using character codes
+        if (c === CC_T) {
+            if (json.charCodeAt(i + 1) === CC_R && json.charCodeAt(i + 2) === CC_U && json.charCodeAt(i + 3) === CC_E) {
+                i += 4;
+                return true;
+            }
+        } else if (c === CC_F) {
+            if (
+                json.charCodeAt(i + 1) === CC_A &&
+                json.charCodeAt(i + 2) === CC_L &&
+                json.charCodeAt(i + 3) === CC_S &&
+                json.charCodeAt(i + 4) === CC_E
+            ) {
+                i += 5;
+                return false;
+            }
+        } else if (c === CC_N) {
+            if (json.charCodeAt(i + 1) === CC_U && json.charCodeAt(i + 2) === CC_L && json.charCodeAt(i + 3) === CC_L) {
+                i += 4;
+                return null;
+            }
         }
 
-        if (typeof reviver !== "undefined") {
-            return reviver(key, value);
+        throw new SyntaxError(`Unexpected character at position ${i}: ${json[i]}`);
+    }
+
+    function parseString(): string {
+        i++; // skip opening quote
+        const start = i;
+
+        // Fast path: scan for end quote without escapes
+        while (i < len) {
+            const c = json.charCodeAt(i);
+            if (c === CC_QUOTE) {
+                const result = json.slice(start, i);
+                i++;
+                return result;
+            }
+            if (c === CC_BACKSLASH) {
+                break; // Hit an escape, fall through to slow path
+            }
+            i++;
         }
 
-        return value;
-    });
+        // Slow path: handle escapes using array for better performance
+        const parts = [json.slice(start, i)];
+        while (i < len) {
+            const c = json.charCodeAt(i);
+            if (c === CC_QUOTE) {
+                i++;
+                return parts.join("");
+            }
+            if (c === CC_BACKSLASH) {
+                i++;
+                const next = json.charCodeAt(i);
+                switch (next) {
+                    case CC_QUOTE:
+                        parts.push('"');
+                        break;
+                    case CC_BACKSLASH:
+                        parts.push("\\");
+                        break;
+                    case 0x2f: // '/'
+                        parts.push("/");
+                        break;
+                    case 0x62: // 'b'
+                        parts.push("\b");
+                        break;
+                    case 0x66: // 'f'
+                        parts.push("\f");
+                        break;
+                    case CC_N: // 'n'
+                        parts.push("\n");
+                        break;
+                    case CC_R: // 'r'
+                        parts.push("\r");
+                        break;
+                    case CC_T: // 't'
+                        parts.push("\t");
+                        break;
+                    case CC_U: // 'u'
+                        parts.push(String.fromCharCode(parseInt(json.slice(i + 1, i + 5), 16)));
+                        i += 4;
+                        break;
+                    default:
+                        throw new SyntaxError(`Invalid escape sequence at position ${i}`);
+                }
+                i++;
+            } else {
+                // Accumulate regular characters
+                const chunkStart = i;
+                while (i < len) {
+                    const cc = json.charCodeAt(i);
+                    if (cc === CC_QUOTE || cc === CC_BACKSLASH) break;
+                    i++;
+                }
+                parts.push(json.slice(chunkStart, i));
+            }
+        }
+        throw new SyntaxError("Unterminated string");
+    }
+
+    function parseNumber(): number | bigint {
+        const start = i;
+
+        // Optional minus
+        if (json.charCodeAt(i) === CC_MINUS) i++;
+
+        // Integer part
+        const digitStart = i;
+        if (json.charCodeAt(i) === CC_0) {
+            i++;
+        } else if (isDigit(json.charCodeAt(i))) {
+            while (i < len && isDigit(json.charCodeAt(i))) i++;
+        }
+        const intEnd = i;
+
+        // Fraction part
+        let hasFrac = false;
+        if (json.charCodeAt(i) === CC_DOT) {
+            hasFrac = true;
+            i++;
+            while (i < len && isDigit(json.charCodeAt(i))) i++;
+        }
+
+        // Exponent part
+        let hasExp = false;
+        const c = json.charCodeAt(i);
+        if (c === CC_E_LOWER || c === CC_E_UPPER) {
+            hasExp = true;
+            i++;
+            const sign = json.charCodeAt(i);
+            if (sign === CC_MINUS || sign === CC_PLUS) i++;
+            while (i < len && isDigit(json.charCodeAt(i))) i++;
+        }
+
+        const numStr = json.slice(start, i);
+
+        // If it's a pure integer, check if we should use BigInt
+        if (!hasFrac && !hasExp) {
+            const digitCount = intEnd - digitStart;
+
+            // Quick length check - numbers > 16 digits are definitely unsafe
+            if (digitCount > 16) {
+                return BigInt(numStr);
+            }
+
+            // Numbers < 15 digits are always safe
+            if (digitCount < 15) {
+                return Number(numStr);
+            }
+
+            // For 15-16 digit numbers, convert and check
+            const num = Number(numStr);
+            if (!Number.isSafeInteger(num)) {
+                return BigInt(numStr);
+            }
+            return num;
+        }
+
+        return Number(numStr);
+    }
+
+    function parseObject(): Record<string, unknown> {
+        i++; // skip opening brace
+        skipWhitespace();
+
+        const obj: Record<string, unknown> = {};
+
+        if (json.charCodeAt(i) === CC_RBRACE) {
+            i++;
+            return obj;
+        }
+
+        while (true) {
+            skipWhitespace();
+            const key = parseString();
+            skipWhitespace();
+
+            if (json.charCodeAt(i) !== CC_COLON) {
+                throw new SyntaxError(`Expected ':' at position ${i}`);
+            }
+            i++;
+
+            const value = parseValue();
+            obj[key] = value;
+
+            skipWhitespace();
+            const c = json.charCodeAt(i);
+            if (c === CC_RBRACE) {
+                i++;
+                return obj;
+            }
+            if (c === CC_COMMA) {
+                i++;
+                continue;
+            }
+            throw new SyntaxError(`Expected ',' or '}' at position ${i}`);
+        }
+    }
+
+    function parseArray(): unknown[] {
+        i++; // skip opening bracket
+        skipWhitespace();
+
+        const arr: unknown[] = [];
+
+        if (json.charCodeAt(i) === CC_RBRACKET) {
+            i++;
+            return arr;
+        }
+
+        while (true) {
+            arr.push(parseValue());
+            skipWhitespace();
+
+            const c = json.charCodeAt(i);
+            if (c === CC_RBRACKET) {
+                i++;
+                return arr;
+            }
+            if (c === CC_COMMA) {
+                i++;
+                continue;
+            }
+            throw new SyntaxError(`Expected ',' or ']' at position ${i}`);
+        }
+    }
+
+    const result = parseValue();
+    skipWhitespace();
+
+    if (i < json.length) {
+        throw new SyntaxError(`Unexpected content at position ${i}`);
+    }
+
+    // Apply reviver if provided
+    if (!reviver) return result as T;
+
+    function reviveRecursive(holder: Record<string, unknown> | unknown[], key: string): unknown {
+        let value: unknown;
+        if (Array.isArray(holder)) {
+            const idx = Number(key);
+            if (Number.isInteger(idx)) {
+                value = holder[idx];
+            } else {
+                value = (holder as unknown as Record<string, unknown>)[key];
+            }
+        } else {
+            value = holder[key];
+        }
+
+        if (value && typeof value === "object") {
+            if (Array.isArray(value)) {
+                for (let i = 0; i < value.length; i++) {
+                    const newValue = reviveRecursive(value, String(i));
+                    if (newValue !== undefined) {
+                        value[i] = newValue;
+                    } else {
+                        delete value[i];
+                    }
+                }
+            } else {
+                const obj = value as Record<string, unknown>;
+                for (const k of Object.keys(obj)) {
+                    const newValue = reviveRecursive(obj, k);
+                    if (newValue !== undefined) {
+                        obj[k] = newValue;
+                    } else {
+                        delete obj[k];
+                    }
+                }
+            }
+        }
+
+        return reviver?.call(holder, key, value);
+    }
+
+    return reviveRecursive({ "": result }, "") as T;
 }

--- a/seed/ts-sdk/exhaustive/bigint/src/core/json.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/core/json.ts
@@ -1,10 +1,37 @@
-// Credit to Ivan Korolenko
-// Code adopted from https://github.com/Ivan-Korolenko/json-with-bigint
+const BIGINT_MARKER = "#bigint#";
+const CC_0 = 0x30,
+    CC_9 = 0x39;
+const CC_SPACE = 0x20,
+    CC_TAB = 0x09,
+    CC_LF = 0x0a,
+    CC_CR = 0x0d;
+const CC_MINUS = 0x2d,
+    CC_PLUS = 0x2b,
+    CC_DOT = 0x2e;
+const CC_QUOTE = 0x22,
+    CC_BACKSLASH = 0x5c;
+const CC_COMMA = 0x2c,
+    CC_COLON = 0x3a;
+const CC_LBRACE = 0x7b,
+    CC_RBRACE = 0x7d;
+const CC_LBRACKET = 0x5b,
+    CC_RBRACKET = 0x5d;
+const CC_E_LOWER = 0x65,
+    CC_E_UPPER = 0x45;
+const CC_T = 0x74,
+    CC_R = 0x72,
+    CC_U = 0x75,
+    CC_E = 0x65; // 'true'
+const CC_F = 0x66,
+    CC_A = 0x61,
+    CC_L = 0x6c,
+    CC_S = 0x73; // 'false'
+const CC_N = 0x6e; // 'null'
+const isWhitespace = (c: number) => c === CC_SPACE || c === CC_TAB || c === CC_LF || c === CC_CR;
+const isDigit = (c: number) => c >= CC_0 && c <= CC_9;
 
-/*
-  Function to serialize data to JSON string
-  Converts BigInt values to custom format (strings with digits and "n" at the end) and then converts them to proper big integers in JSON string
-*/
+// Cache the regex for better performance
+const BIGINT_REGEX = new RegExp(`"(-?\\d+)${BIGINT_MARKER.replace(/[#]/g, "\\$&")}"`, "g");
 
 /**
  * Serialize a value to JSON
@@ -15,56 +42,24 @@
  */
 export const toJson = (
     data: unknown,
-    replacer?: (this: unknown, key: string, value: unknown) => unknown,
+    replacer?: (key: string, value: unknown) => unknown,
     space?: string | number,
 ): string => {
-    if (typeof data === "bigint") {
-        return data.toString();
-    }
-    if (typeof data !== "object") {
-        return JSON.stringify(data, replacer, space);
-    }
-
-    // eslint-disable-next-line no-useless-escape
-    const bigInts = /([[:])?"(-?\d+)n"([,}\]])/g;
+    // Use native JSON.stringify with a custom replacer for BigInt
     const preliminaryJSON = JSON.stringify(
         data,
-        (key, value) =>
-            typeof value === "bigint"
-                ? `${value.toString()}n`
-                : typeof replacer === "undefined"
-                  ? value
-                  : replacer(key, value),
+        (key: string, value: unknown) => {
+            if (typeof value === "bigint") {
+                return value.toString() + BIGINT_MARKER;
+            }
+            return replacer ? replacer(key, value) : value;
+        },
         space,
     );
-    const finalJSON = preliminaryJSON.replace(bigInts, "$1$2$3");
 
-    return finalJSON;
+    // Strip quotes around numbers with marker: "123#bigint#" → 123
+    return preliminaryJSON.replace(BIGINT_REGEX, "$1");
 };
-
-/*
-  Function to parse JSON
-  If JSON has values presented in a lib's custom format (strings with digits and "n" character at the end), we just parse them to BigInt values (for backward compatibility with previous versions of the lib)
-  If JSON has values greater than Number.MAX_SAFE_INTEGER, we convert those values to our custom format, then parse them to BigInt values.
-  Other types of values are not affected and parsed as native JSON.parse() would parse them.
-
-  Big numbers are found and marked using a Regular Expression with these conditions:
-
-    1. Before the match there is no . and one of the following is present:
-      1.1 ":
-      1.2 ":[
-      1.3 ":[anyNumberOf(anyCharacters)
-      1.4 , with no ":"anyNumberOf(anyCharacters) before it
-    All " required in the rule are not escaped. All whitespace and newline characters outside of string values are ignored.
-
-    2. The match itself has more than 16 digits OR (16 digits and any digit of the number is greater than that of the Number.MAX_SAFE_INTEGER). And it may have a - sign at the start.
-
-    3. After the match one of the following is present:
-      3.1 , without anyNumberOf(anyCharacters) "} or anyNumberOf(anyCharacters) "] after it
-      3.2 } without " after it
-      3.3 ] without " after it
-    All whitespace and newline characters outside of string values are ignored.
-*/
 
 /**
  * Parse JSON string to object, array, or other type
@@ -72,29 +67,304 @@ export const toJson = (
  * @param reviver A function that transforms the results. This function is called for each member of the object. If a member contains nested objects, the nested objects are transformed before the parent object is.
  * @returns Parsed object, array, or other type
  */
+
 export function fromJson<T = unknown>(
     json: string,
     reviver?: (this: unknown, key: string, value: unknown) => unknown,
 ): T {
-    if (!json) {
-        return JSON.parse(json, reviver);
+    let i = 0;
+    const len = json.length;
+
+    function skipWhitespace() {
+        while (i < len && isWhitespace(json.charCodeAt(i))) i++;
     }
 
-    const numbersBiggerThanMaxInt = // eslint-disable-next-line no-useless-escape
-        /(?<=[^\\]":\n*\s*[[]?|[^\\]":\n*\s*\[.*[^.\d*]\n*\s*|(?<![^\\]"\n*\s*:\n*\s*[^\\]".*),\n*\s*)(-?\d{17,}|-?(?:[9](?:[1-9]07199254740991|0[1-9]7199254740991|00[8-9]199254740991|007[2-9]99254740991|007199[3-9]54740991|0071992[6-9]4740991|00719925[5-9]740991|007199254[8-9]40991|0071992547[5-9]0991|00719925474[1-9]991|00719925474099[2-9])))(?=,(?!.*[^\\]"(\n*\s*\}|\n*\s*\]))|\n*\s*\}[^"]?|\n*\s*\][^"])/g;
-    const serializedData = json.replace(numbersBiggerThanMaxInt, '"$1n"');
+    function parseValue(): unknown {
+        skipWhitespace();
+        const c = json.charCodeAt(i);
 
-    return JSON.parse(serializedData, (key, value) => {
-        const isCustomFormatBigInt = typeof value === "string" && Boolean(value.match(/^-?\d+n$/));
+        if (c === CC_QUOTE) return parseString();
+        if (c === CC_LBRACE) return parseObject();
+        if (c === CC_LBRACKET) return parseArray();
+        if (c === CC_MINUS || isDigit(c)) return parseNumber();
 
-        if (isCustomFormatBigInt) {
-            return BigInt(value.substring(0, value.length - 1));
+        // Check for true/false/null using character codes
+        if (c === CC_T) {
+            if (json.charCodeAt(i + 1) === CC_R && json.charCodeAt(i + 2) === CC_U && json.charCodeAt(i + 3) === CC_E) {
+                i += 4;
+                return true;
+            }
+        } else if (c === CC_F) {
+            if (
+                json.charCodeAt(i + 1) === CC_A &&
+                json.charCodeAt(i + 2) === CC_L &&
+                json.charCodeAt(i + 3) === CC_S &&
+                json.charCodeAt(i + 4) === CC_E
+            ) {
+                i += 5;
+                return false;
+            }
+        } else if (c === CC_N) {
+            if (json.charCodeAt(i + 1) === CC_U && json.charCodeAt(i + 2) === CC_L && json.charCodeAt(i + 3) === CC_L) {
+                i += 4;
+                return null;
+            }
         }
 
-        if (typeof reviver !== "undefined") {
-            return reviver(key, value);
+        throw new SyntaxError(`Unexpected character at position ${i}: ${json[i]}`);
+    }
+
+    function parseString(): string {
+        i++; // skip opening quote
+        const start = i;
+
+        // Fast path: scan for end quote without escapes
+        while (i < len) {
+            const c = json.charCodeAt(i);
+            if (c === CC_QUOTE) {
+                const result = json.slice(start, i);
+                i++;
+                return result;
+            }
+            if (c === CC_BACKSLASH) {
+                break; // Hit an escape, fall through to slow path
+            }
+            i++;
         }
 
-        return value;
-    });
+        // Slow path: handle escapes using array for better performance
+        const parts = [json.slice(start, i)];
+        while (i < len) {
+            const c = json.charCodeAt(i);
+            if (c === CC_QUOTE) {
+                i++;
+                return parts.join("");
+            }
+            if (c === CC_BACKSLASH) {
+                i++;
+                const next = json.charCodeAt(i);
+                switch (next) {
+                    case CC_QUOTE:
+                        parts.push('"');
+                        break;
+                    case CC_BACKSLASH:
+                        parts.push("\\");
+                        break;
+                    case 0x2f: // '/'
+                        parts.push("/");
+                        break;
+                    case 0x62: // 'b'
+                        parts.push("\b");
+                        break;
+                    case 0x66: // 'f'
+                        parts.push("\f");
+                        break;
+                    case CC_N: // 'n'
+                        parts.push("\n");
+                        break;
+                    case CC_R: // 'r'
+                        parts.push("\r");
+                        break;
+                    case CC_T: // 't'
+                        parts.push("\t");
+                        break;
+                    case CC_U: // 'u'
+                        parts.push(String.fromCharCode(parseInt(json.slice(i + 1, i + 5), 16)));
+                        i += 4;
+                        break;
+                    default:
+                        throw new SyntaxError(`Invalid escape sequence at position ${i}`);
+                }
+                i++;
+            } else {
+                // Accumulate regular characters
+                const chunkStart = i;
+                while (i < len) {
+                    const cc = json.charCodeAt(i);
+                    if (cc === CC_QUOTE || cc === CC_BACKSLASH) break;
+                    i++;
+                }
+                parts.push(json.slice(chunkStart, i));
+            }
+        }
+        throw new SyntaxError("Unterminated string");
+    }
+
+    function parseNumber(): number | bigint {
+        const start = i;
+
+        // Optional minus
+        if (json.charCodeAt(i) === CC_MINUS) i++;
+
+        // Integer part
+        const digitStart = i;
+        if (json.charCodeAt(i) === CC_0) {
+            i++;
+        } else if (isDigit(json.charCodeAt(i))) {
+            while (i < len && isDigit(json.charCodeAt(i))) i++;
+        }
+        const intEnd = i;
+
+        // Fraction part
+        let hasFrac = false;
+        if (json.charCodeAt(i) === CC_DOT) {
+            hasFrac = true;
+            i++;
+            while (i < len && isDigit(json.charCodeAt(i))) i++;
+        }
+
+        // Exponent part
+        let hasExp = false;
+        const c = json.charCodeAt(i);
+        if (c === CC_E_LOWER || c === CC_E_UPPER) {
+            hasExp = true;
+            i++;
+            const sign = json.charCodeAt(i);
+            if (sign === CC_MINUS || sign === CC_PLUS) i++;
+            while (i < len && isDigit(json.charCodeAt(i))) i++;
+        }
+
+        const numStr = json.slice(start, i);
+
+        // If it's a pure integer, check if we should use BigInt
+        if (!hasFrac && !hasExp) {
+            const digitCount = intEnd - digitStart;
+
+            // Quick length check - numbers > 16 digits are definitely unsafe
+            if (digitCount > 16) {
+                return BigInt(numStr);
+            }
+
+            // Numbers < 15 digits are always safe
+            if (digitCount < 15) {
+                return Number(numStr);
+            }
+
+            // For 15-16 digit numbers, convert and check
+            const num = Number(numStr);
+            if (!Number.isSafeInteger(num)) {
+                return BigInt(numStr);
+            }
+            return num;
+        }
+
+        return Number(numStr);
+    }
+
+    function parseObject(): Record<string, unknown> {
+        i++; // skip opening brace
+        skipWhitespace();
+
+        const obj: Record<string, unknown> = {};
+
+        if (json.charCodeAt(i) === CC_RBRACE) {
+            i++;
+            return obj;
+        }
+
+        while (true) {
+            skipWhitespace();
+            const key = parseString();
+            skipWhitespace();
+
+            if (json.charCodeAt(i) !== CC_COLON) {
+                throw new SyntaxError(`Expected ':' at position ${i}`);
+            }
+            i++;
+
+            const value = parseValue();
+            obj[key] = value;
+
+            skipWhitespace();
+            const c = json.charCodeAt(i);
+            if (c === CC_RBRACE) {
+                i++;
+                return obj;
+            }
+            if (c === CC_COMMA) {
+                i++;
+                continue;
+            }
+            throw new SyntaxError(`Expected ',' or '}' at position ${i}`);
+        }
+    }
+
+    function parseArray(): unknown[] {
+        i++; // skip opening bracket
+        skipWhitespace();
+
+        const arr: unknown[] = [];
+
+        if (json.charCodeAt(i) === CC_RBRACKET) {
+            i++;
+            return arr;
+        }
+
+        while (true) {
+            arr.push(parseValue());
+            skipWhitespace();
+
+            const c = json.charCodeAt(i);
+            if (c === CC_RBRACKET) {
+                i++;
+                return arr;
+            }
+            if (c === CC_COMMA) {
+                i++;
+                continue;
+            }
+            throw new SyntaxError(`Expected ',' or ']' at position ${i}`);
+        }
+    }
+
+    const result = parseValue();
+    skipWhitespace();
+
+    if (i < json.length) {
+        throw new SyntaxError(`Unexpected content at position ${i}`);
+    }
+
+    // Apply reviver if provided
+    if (!reviver) return result as T;
+
+    function reviveRecursive(holder: Record<string, unknown> | unknown[], key: string): unknown {
+        let value: unknown;
+        if (Array.isArray(holder)) {
+            const idx = Number(key);
+            if (Number.isInteger(idx)) {
+                value = holder[idx];
+            } else {
+                value = (holder as unknown as Record<string, unknown>)[key];
+            }
+        } else {
+            value = holder[key];
+        }
+
+        if (value && typeof value === "object") {
+            if (Array.isArray(value)) {
+                for (let i = 0; i < value.length; i++) {
+                    const newValue = reviveRecursive(value, String(i));
+                    if (newValue !== undefined) {
+                        value[i] = newValue;
+                    } else {
+                        delete value[i];
+                    }
+                }
+            } else {
+                const obj = value as Record<string, unknown>;
+                for (const k of Object.keys(obj)) {
+                    const newValue = reviveRecursive(obj, k);
+                    if (newValue !== undefined) {
+                        obj[k] = newValue;
+                    } else {
+                        delete obj[k];
+                    }
+                }
+            }
+        }
+
+        return reviver?.call(holder, key, value);
+    }
+
+    return reviveRecursive({ "": result }, "") as T;
 }

--- a/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/src/core/json.ts
+++ b/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/src/core/json.ts
@@ -1,10 +1,37 @@
-// Credit to Ivan Korolenko
-// Code adopted from https://github.com/Ivan-Korolenko/json-with-bigint
+const BIGINT_MARKER = "#bigint#";
+const CC_0 = 0x30,
+    CC_9 = 0x39;
+const CC_SPACE = 0x20,
+    CC_TAB = 0x09,
+    CC_LF = 0x0a,
+    CC_CR = 0x0d;
+const CC_MINUS = 0x2d,
+    CC_PLUS = 0x2b,
+    CC_DOT = 0x2e;
+const CC_QUOTE = 0x22,
+    CC_BACKSLASH = 0x5c;
+const CC_COMMA = 0x2c,
+    CC_COLON = 0x3a;
+const CC_LBRACE = 0x7b,
+    CC_RBRACE = 0x7d;
+const CC_LBRACKET = 0x5b,
+    CC_RBRACKET = 0x5d;
+const CC_E_LOWER = 0x65,
+    CC_E_UPPER = 0x45;
+const CC_T = 0x74,
+    CC_R = 0x72,
+    CC_U = 0x75,
+    CC_E = 0x65; // 'true'
+const CC_F = 0x66,
+    CC_A = 0x61,
+    CC_L = 0x6c,
+    CC_S = 0x73; // 'false'
+const CC_N = 0x6e; // 'null'
+const isWhitespace = (c: number) => c === CC_SPACE || c === CC_TAB || c === CC_LF || c === CC_CR;
+const isDigit = (c: number) => c >= CC_0 && c <= CC_9;
 
-/*
-  Function to serialize data to JSON string
-  Converts BigInt values to custom format (strings with digits and "n" at the end) and then converts them to proper big integers in JSON string
-*/
+// Cache the regex for better performance
+const BIGINT_REGEX = new RegExp(`"(-?\\d+)${BIGINT_MARKER.replace(/[#]/g, "\\$&")}"`, "g");
 
 /**
  * Serialize a value to JSON
@@ -15,56 +42,24 @@
  */
 export const toJson = (
     data: unknown,
-    replacer?: (this: unknown, key: string, value: unknown) => unknown,
+    replacer?: (key: string, value: unknown) => unknown,
     space?: string | number,
 ): string => {
-    if (typeof data === "bigint") {
-        return data.toString();
-    }
-    if (typeof data !== "object") {
-        return JSON.stringify(data, replacer, space);
-    }
-
-    // eslint-disable-next-line no-useless-escape
-    const bigInts = /([[:])?"(-?\d+)n"([,}\]])/g;
+    // Use native JSON.stringify with a custom replacer for BigInt
     const preliminaryJSON = JSON.stringify(
         data,
-        (key, value) =>
-            typeof value === "bigint"
-                ? `${value.toString()}n`
-                : typeof replacer === "undefined"
-                  ? value
-                  : replacer(key, value),
+        (key: string, value: unknown) => {
+            if (typeof value === "bigint") {
+                return value.toString() + BIGINT_MARKER;
+            }
+            return replacer ? replacer(key, value) : value;
+        },
         space,
     );
-    const finalJSON = preliminaryJSON.replace(bigInts, "$1$2$3");
 
-    return finalJSON;
+    // Strip quotes around numbers with marker: "123#bigint#" → 123
+    return preliminaryJSON.replace(BIGINT_REGEX, "$1");
 };
-
-/*
-  Function to parse JSON
-  If JSON has values presented in a lib's custom format (strings with digits and "n" character at the end), we just parse them to BigInt values (for backward compatibility with previous versions of the lib)
-  If JSON has values greater than Number.MAX_SAFE_INTEGER, we convert those values to our custom format, then parse them to BigInt values.
-  Other types of values are not affected and parsed as native JSON.parse() would parse them.
-
-  Big numbers are found and marked using a Regular Expression with these conditions:
-
-    1. Before the match there is no . and one of the following is present:
-      1.1 ":
-      1.2 ":[
-      1.3 ":[anyNumberOf(anyCharacters)
-      1.4 , with no ":"anyNumberOf(anyCharacters) before it
-    All " required in the rule are not escaped. All whitespace and newline characters outside of string values are ignored.
-
-    2. The match itself has more than 16 digits OR (16 digits and any digit of the number is greater than that of the Number.MAX_SAFE_INTEGER). And it may have a - sign at the start.
-
-    3. After the match one of the following is present:
-      3.1 , without anyNumberOf(anyCharacters) "} or anyNumberOf(anyCharacters) "] after it
-      3.2 } without " after it
-      3.3 ] without " after it
-    All whitespace and newline characters outside of string values are ignored.
-*/
 
 /**
  * Parse JSON string to object, array, or other type
@@ -72,29 +67,304 @@ export const toJson = (
  * @param reviver A function that transforms the results. This function is called for each member of the object. If a member contains nested objects, the nested objects are transformed before the parent object is.
  * @returns Parsed object, array, or other type
  */
+
 export function fromJson<T = unknown>(
     json: string,
     reviver?: (this: unknown, key: string, value: unknown) => unknown,
 ): T {
-    if (!json) {
-        return JSON.parse(json, reviver);
+    let i = 0;
+    const len = json.length;
+
+    function skipWhitespace() {
+        while (i < len && isWhitespace(json.charCodeAt(i))) i++;
     }
 
-    const numbersBiggerThanMaxInt = // eslint-disable-next-line no-useless-escape
-        /(?<=[^\\]":\n*\s*[[]?|[^\\]":\n*\s*\[.*[^.\d*]\n*\s*|(?<![^\\]"\n*\s*:\n*\s*[^\\]".*),\n*\s*)(-?\d{17,}|-?(?:[9](?:[1-9]07199254740991|0[1-9]7199254740991|00[8-9]199254740991|007[2-9]99254740991|007199[3-9]54740991|0071992[6-9]4740991|00719925[5-9]740991|007199254[8-9]40991|0071992547[5-9]0991|00719925474[1-9]991|00719925474099[2-9])))(?=,(?!.*[^\\]"(\n*\s*\}|\n*\s*\]))|\n*\s*\}[^"]?|\n*\s*\][^"])/g;
-    const serializedData = json.replace(numbersBiggerThanMaxInt, '"$1n"');
+    function parseValue(): unknown {
+        skipWhitespace();
+        const c = json.charCodeAt(i);
 
-    return JSON.parse(serializedData, (key, value) => {
-        const isCustomFormatBigInt = typeof value === "string" && Boolean(value.match(/^-?\d+n$/));
+        if (c === CC_QUOTE) return parseString();
+        if (c === CC_LBRACE) return parseObject();
+        if (c === CC_LBRACKET) return parseArray();
+        if (c === CC_MINUS || isDigit(c)) return parseNumber();
 
-        if (isCustomFormatBigInt) {
-            return BigInt(value.substring(0, value.length - 1));
+        // Check for true/false/null using character codes
+        if (c === CC_T) {
+            if (json.charCodeAt(i + 1) === CC_R && json.charCodeAt(i + 2) === CC_U && json.charCodeAt(i + 3) === CC_E) {
+                i += 4;
+                return true;
+            }
+        } else if (c === CC_F) {
+            if (
+                json.charCodeAt(i + 1) === CC_A &&
+                json.charCodeAt(i + 2) === CC_L &&
+                json.charCodeAt(i + 3) === CC_S &&
+                json.charCodeAt(i + 4) === CC_E
+            ) {
+                i += 5;
+                return false;
+            }
+        } else if (c === CC_N) {
+            if (json.charCodeAt(i + 1) === CC_U && json.charCodeAt(i + 2) === CC_L && json.charCodeAt(i + 3) === CC_L) {
+                i += 4;
+                return null;
+            }
         }
 
-        if (typeof reviver !== "undefined") {
-            return reviver(key, value);
+        throw new SyntaxError(`Unexpected character at position ${i}: ${json[i]}`);
+    }
+
+    function parseString(): string {
+        i++; // skip opening quote
+        const start = i;
+
+        // Fast path: scan for end quote without escapes
+        while (i < len) {
+            const c = json.charCodeAt(i);
+            if (c === CC_QUOTE) {
+                const result = json.slice(start, i);
+                i++;
+                return result;
+            }
+            if (c === CC_BACKSLASH) {
+                break; // Hit an escape, fall through to slow path
+            }
+            i++;
         }
 
-        return value;
-    });
+        // Slow path: handle escapes using array for better performance
+        const parts = [json.slice(start, i)];
+        while (i < len) {
+            const c = json.charCodeAt(i);
+            if (c === CC_QUOTE) {
+                i++;
+                return parts.join("");
+            }
+            if (c === CC_BACKSLASH) {
+                i++;
+                const next = json.charCodeAt(i);
+                switch (next) {
+                    case CC_QUOTE:
+                        parts.push('"');
+                        break;
+                    case CC_BACKSLASH:
+                        parts.push("\\");
+                        break;
+                    case 0x2f: // '/'
+                        parts.push("/");
+                        break;
+                    case 0x62: // 'b'
+                        parts.push("\b");
+                        break;
+                    case 0x66: // 'f'
+                        parts.push("\f");
+                        break;
+                    case CC_N: // 'n'
+                        parts.push("\n");
+                        break;
+                    case CC_R: // 'r'
+                        parts.push("\r");
+                        break;
+                    case CC_T: // 't'
+                        parts.push("\t");
+                        break;
+                    case CC_U: // 'u'
+                        parts.push(String.fromCharCode(parseInt(json.slice(i + 1, i + 5), 16)));
+                        i += 4;
+                        break;
+                    default:
+                        throw new SyntaxError(`Invalid escape sequence at position ${i}`);
+                }
+                i++;
+            } else {
+                // Accumulate regular characters
+                const chunkStart = i;
+                while (i < len) {
+                    const cc = json.charCodeAt(i);
+                    if (cc === CC_QUOTE || cc === CC_BACKSLASH) break;
+                    i++;
+                }
+                parts.push(json.slice(chunkStart, i));
+            }
+        }
+        throw new SyntaxError("Unterminated string");
+    }
+
+    function parseNumber(): number | bigint {
+        const start = i;
+
+        // Optional minus
+        if (json.charCodeAt(i) === CC_MINUS) i++;
+
+        // Integer part
+        const digitStart = i;
+        if (json.charCodeAt(i) === CC_0) {
+            i++;
+        } else if (isDigit(json.charCodeAt(i))) {
+            while (i < len && isDigit(json.charCodeAt(i))) i++;
+        }
+        const intEnd = i;
+
+        // Fraction part
+        let hasFrac = false;
+        if (json.charCodeAt(i) === CC_DOT) {
+            hasFrac = true;
+            i++;
+            while (i < len && isDigit(json.charCodeAt(i))) i++;
+        }
+
+        // Exponent part
+        let hasExp = false;
+        const c = json.charCodeAt(i);
+        if (c === CC_E_LOWER || c === CC_E_UPPER) {
+            hasExp = true;
+            i++;
+            const sign = json.charCodeAt(i);
+            if (sign === CC_MINUS || sign === CC_PLUS) i++;
+            while (i < len && isDigit(json.charCodeAt(i))) i++;
+        }
+
+        const numStr = json.slice(start, i);
+
+        // If it's a pure integer, check if we should use BigInt
+        if (!hasFrac && !hasExp) {
+            const digitCount = intEnd - digitStart;
+
+            // Quick length check - numbers > 16 digits are definitely unsafe
+            if (digitCount > 16) {
+                return BigInt(numStr);
+            }
+
+            // Numbers < 15 digits are always safe
+            if (digitCount < 15) {
+                return Number(numStr);
+            }
+
+            // For 15-16 digit numbers, convert and check
+            const num = Number(numStr);
+            if (!Number.isSafeInteger(num)) {
+                return BigInt(numStr);
+            }
+            return num;
+        }
+
+        return Number(numStr);
+    }
+
+    function parseObject(): Record<string, unknown> {
+        i++; // skip opening brace
+        skipWhitespace();
+
+        const obj: Record<string, unknown> = {};
+
+        if (json.charCodeAt(i) === CC_RBRACE) {
+            i++;
+            return obj;
+        }
+
+        while (true) {
+            skipWhitespace();
+            const key = parseString();
+            skipWhitespace();
+
+            if (json.charCodeAt(i) !== CC_COLON) {
+                throw new SyntaxError(`Expected ':' at position ${i}`);
+            }
+            i++;
+
+            const value = parseValue();
+            obj[key] = value;
+
+            skipWhitespace();
+            const c = json.charCodeAt(i);
+            if (c === CC_RBRACE) {
+                i++;
+                return obj;
+            }
+            if (c === CC_COMMA) {
+                i++;
+                continue;
+            }
+            throw new SyntaxError(`Expected ',' or '}' at position ${i}`);
+        }
+    }
+
+    function parseArray(): unknown[] {
+        i++; // skip opening bracket
+        skipWhitespace();
+
+        const arr: unknown[] = [];
+
+        if (json.charCodeAt(i) === CC_RBRACKET) {
+            i++;
+            return arr;
+        }
+
+        while (true) {
+            arr.push(parseValue());
+            skipWhitespace();
+
+            const c = json.charCodeAt(i);
+            if (c === CC_RBRACKET) {
+                i++;
+                return arr;
+            }
+            if (c === CC_COMMA) {
+                i++;
+                continue;
+            }
+            throw new SyntaxError(`Expected ',' or ']' at position ${i}`);
+        }
+    }
+
+    const result = parseValue();
+    skipWhitespace();
+
+    if (i < json.length) {
+        throw new SyntaxError(`Unexpected content at position ${i}`);
+    }
+
+    // Apply reviver if provided
+    if (!reviver) return result as T;
+
+    function reviveRecursive(holder: Record<string, unknown> | unknown[], key: string): unknown {
+        let value: unknown;
+        if (Array.isArray(holder)) {
+            const idx = Number(key);
+            if (Number.isInteger(idx)) {
+                value = holder[idx];
+            } else {
+                value = (holder as unknown as Record<string, unknown>)[key];
+            }
+        } else {
+            value = holder[key];
+        }
+
+        if (value && typeof value === "object") {
+            if (Array.isArray(value)) {
+                for (let i = 0; i < value.length; i++) {
+                    const newValue = reviveRecursive(value, String(i));
+                    if (newValue !== undefined) {
+                        value[i] = newValue;
+                    } else {
+                        delete value[i];
+                    }
+                }
+            } else {
+                const obj = value as Record<string, unknown>;
+                for (const k of Object.keys(obj)) {
+                    const newValue = reviveRecursive(obj, k);
+                    if (newValue !== undefined) {
+                        obj[k] = newValue;
+                    } else {
+                        delete obj[k];
+                    }
+                }
+            }
+        }
+
+        return reviver?.call(holder, key, value);
+    }
+
+    return reviveRecursive({ "": result }, "") as T;
 }


### PR DESCRIPTION
## Description
Improve the performance of JSON serialization and parsing when `useBigInt` is enabled.

Benchmark (not included in source code):
<img width="663" height="364" alt="Screenshot 2025-10-16 at 11 15 46 PM" src="https://github.com/user-attachments/assets/66514dae-0902-43fe-9fbd-02eec67b3f44" />
<img width="672" height="371" alt="Screenshot 2025-10-16 at 11 16 11 PM" src="https://github.com/user-attachments/assets/d3bb10df-c466-42fa-a105-b80efb4a633b" />

`current` is the old JSON code, `updated` is the optimized JSON code.

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated
- [x] Manual testing completed
