### PR TITLE
fix(cli): Allow fixtures to report output folders with the same name

### DIFF
--- a/packages/seed/src/commands/test/printTestCases.ts
+++ b/packages/seed/src/commands/test/printTestCases.ts
@@ -6,7 +6,7 @@ export function printTestCases(result: TestRunner.TestResult[]): void {
     const items = result.map((r) => {
         return {
             Name: r.id,
-            "Output Folder": r.id === r.outputFolder ? " -- " : r.outputFolder,
+            "Output Folder": !r.outputFolder ? " -- " : r.outputFolder,
             Result: r.type,
             "Generation Time": r.metrics.generationTime,
             "Compile Time": r.metrics.compileTime,

--- a/packages/seed/src/commands/test/test-runner/TestRunner.ts
+++ b/packages/seed/src/commands/test/test-runner/TestRunner.ts
@@ -141,7 +141,7 @@ export abstract class TestRunner {
                 );
             }
             const taskContext = this.taskContextFactory.create(`${this.generator.workspaceName}:${id}`);
-            const outputFolder = configuration?.outputFolder ?? fixture;
+            const outputFolder = configuration?.outputFolder ?? "";
             if (!outputDir) {
                 outputDir =
                     configuration == null


### PR DESCRIPTION
## Description
Linear ticket: https://linear.app/buildwithfern/issue/FER-7228/cli-allow-output-folders-with-same-fixture-name
Closes FER-7228
Running a fixture accept-header:accept-header in the java-sdk was reporting back as accept-header:-- which was causing issues in the overnight balancing workflow

## Changes Made
- Set default output folder to empty string instead of fixture name
- When reporting, verify if output folder is empty before displaying

## Testing
- Verified on CLI with java-sdk using accept-header:accept-header, accept-header, imdb:flat-package-layout, imdb, and websocket. Verified the output folder showed where available and did not show where not available.
