### PR TITLE
fix(ci): Remove deprecated parameter

### DIFF
--- a/.github/actions/auto-update-seed/action.yaml
+++ b/.github/actions/auto-update-seed/action.yaml
@@ -40,7 +40,6 @@ runs:
         generator-name: ${{ inputs.generator-name }}
         generator-path: ${{ inputs.generator-path }}
         fixtures-to-run: ${{ inputs.fixtures-to-run }}
-        validate-git-diff: false
         allow-unexpected-failures: ${{ inputs.allow-unexpected-failures }}
         skip-scripts: ${{ inputs.skip-scripts }}
         cache-disabled: ${{ inputs.cache-disabled }}


### PR DESCRIPTION
## Description
Linear ticket: https://linear.app/buildwithfern/issue/FER-7232/ci-remove-deprecated-parameter
Closes FER-7232
There was a removed parameter in seed tests that never got removed from update-seed

## Changes Made
- Deleted input parameter

## Testing
Tested in CI here: https://github.com/fern-api/fern/actions/runs/18598338902
