### PR TITLE
fix(ci): Compile before build step to validate changelog

### DIFF
--- a/.github/workflows/validate-changelog.yml
+++ b/.github/workflows/validate-changelog.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Checkout repo at current ref
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Install
         uses: ./.github/actions/install

--- a/.github/workflows/validate-changelog.yml
+++ b/.github/workflows/validate-changelog.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Install
         uses: ./.github/actions/install
 
+      - name: Compile
+        run: pnpm compile
+
       - name: Seed Build
         run: pnpm seed:build
 


### PR DESCRIPTION
## Description
Linear ticket: https://linear.app/buildwithfern/issue/FER-7238/ci-validate-changelog-should-compile-before-the-build-step
Closes FER-7238
Need to compile packages before building seed

## Changes Made
- Add compile step

## Testing
- Verified here in CI in build with this change and Judah's fixes (PR where this was first noticed): https://github.com/fern-api/fern/actions/runs/18604830700/job/53051809105?pr=9932
