### PR TITLE
fix(cli): run IR parser in fern check

### DIFF
--- a/packages/cli/cli/src/commands/validate/validateWorkspaces.ts
+++ b/packages/cli/cli/src/commands/validate/validateWorkspaces.ts
@@ -41,7 +41,7 @@ export async function validateWorkspaces({
 
     await Promise.all(
         project.apiWorkspaces.map(async (workspace) => {
-            if (workspace.generatorsConfiguration?.groups.length === 0 && workspace.type != "fern") {
+            if (workspace.type != "fern") {
                 return;
             }
 


### PR DESCRIPTION
A quick fix for `fern check` so that it does indeed run on common APIs

after/before example:

<img width="1054" height="469" alt="image" src="https://github.com/user-attachments/assets/196a8ec8-59f9-42fb-83a3-fdcef3121837" />