### PR TITLE
fix(ci): Fix formatting of output tests

### DIFF
--- a/packages/seed/src/commands/test/testWorkspaceFixtures.ts
+++ b/packages/seed/src/commands/test/testWorkspaceFixtures.ts
@@ -78,7 +78,7 @@ export async function testGenerator({
 
     const failedFixtures = results
         .filter((res) => res.type === "failure")
-        .map((res) => (res.id === res.outputFolder ? res.id : `${res.id}:${res.outputFolder}`));
+        .map((res) => (res.id === res.outputFolder || !res.outputFolder ? res.id : `${res.id}:${res.outputFolder}`));
     const unexpectedFixtures = difference(failedFixtures, generator.workspaceConfig.allowedFailures ?? []);
 
     if (failedFixtures.length === 0) {


### PR DESCRIPTION
## Description
Linear ticket: https://linear.app/buildwithfern/issue/FER-7239/ci-fix-output-of-failing-tests-to-remove-added-character
Closes FER-7239
Don't add `:` if no output folder

## Changes Made
- Don't post `:` in name if no output folder

## Testing
- Verified in CI here with changes from this PR and PR where this was first seen: https://github.com/fern-api/fern/actions/runs/18606167338?pr=9937
