### PR TITLE
chore(ci): Make update seed work like seed tests

### DIFF
--- a/.github/actions/auto-update-seed/action.yaml
+++ b/.github/actions/auto-update-seed/action.yaml
@@ -15,9 +15,8 @@ inputs:
     required: false
     default: "false"
   fixtures-to-run:
-    description: Specific fixtures to run. If not supplied, will run all fixtures. Note - for multiple fixtures at once, separate by space, not comma.
-    required: false
-    default: ""
+    description: The fixtures to run, as JSON
+    required: true
   allow-unexpected-failures:
     description: Whether to allow unexpected failures during seed generation
     required: false
@@ -34,6 +33,17 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # Format for seed tests
+    - name: JSON to String
+      id: json-to-string
+      shell: bash
+      run: |
+        json_data='${{ inputs.fixtures-to-run }}'
+        # Convert JSON array to space-separated string
+        string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+        echo "Generated string: '$string_result'"
+        echo "as-string=$string_result" >> $GITHUB_OUTPUT
+
     - name: Run seed
       uses: ./.github/actions/cached-seed
       with:

--- a/.github/actions/auto-update-seed/action.yaml
+++ b/.github/actions/auto-update-seed/action.yaml
@@ -33,26 +33,16 @@ inputs:
 runs:
   using: "composite"
   steps:
-    # Format for seed tests
-    - name: JSON to String
-      id: json-to-string
-      shell: bash
-      run: |
-        json_data='${{ inputs.fixtures-to-run }}'
-        # Convert JSON array to space-separated string
-        string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-        echo "Generated string: '$string_result'"
-        echo "as-string=$string_result" >> $GITHUB_OUTPUT
-
-    - name: Run seed
-      uses: ./.github/actions/cached-seed
+    - name: Run All Seed Tests
+      uses: ./.github/actions/run-seed-process
       with:
-        generator-name: ${{ inputs.generator-name }}
+        sdk-name: ${{ inputs.generator-name }}
         generator-path: ${{ inputs.generator-path }}
         fixtures-to-run: ${{ inputs.fixtures-to-run }}
+        job-index: ${{ strategy.job-index }}
+        collect-metrics: false
         allow-unexpected-failures: ${{ inputs.allow-unexpected-failures }}
         skip-scripts: ${{ inputs.skip-scripts }}
-        cache-disabled: ${{ inputs.cache-disabled }}
 
     # Add changes first to simplify git diff checks, no changes will NOT error here
     - name: Check for changes

--- a/.github/actions/run-seed-process/action.yaml
+++ b/.github/actions/run-seed-process/action.yaml
@@ -11,6 +11,10 @@ inputs:
   fixtures-to-run:
     description: The fixtures to run, as JSON
     required: true
+  skip-scripts:
+    description: Whether to skip running scripts during seed generation
+    required: false
+    default: "false"
   job-index:
     description: The index of the job (when parallelized in a matrix strategy)
     required: true
@@ -61,6 +65,7 @@ runs:
         generator-name: ${{ inputs.sdk-name }}
         generator-path: ${{ inputs.generator-path }}
         fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+        skip-scripts: ${{ inputs.skip-scripts }}
 
     - name: Handle Seed Leftover Tests
       if: ${{ steps.json-to-string.outputs.as-string == 'leftovers' }}

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -328,7 +328,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
+          sparse-checkout: |
+            .github/actions/
 
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
@@ -360,7 +361,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
+          sparse-checkout: |
+            .github/actions/
 
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
@@ -392,7 +394,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
+          sparse-checkout: |
+            .github/actions/
 
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
@@ -424,7 +427,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
+          sparse-checkout: |
+            .github/actions/
 
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
@@ -456,7 +460,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
+          sparse-checkout: |
+            .github/actions/
 
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
@@ -488,7 +493,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
+          sparse-checkout: |
+            .github/actions/
 
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
@@ -520,7 +526,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
+          sparse-checkout: |
+            .github/actions/
 
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
@@ -552,7 +559,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
+          sparse-checkout: |
+            .github/actions/
 
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
@@ -584,7 +592,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
+          sparse-checkout: |
+            .github/actions/
 
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
@@ -616,7 +625,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
+          sparse-checkout: |
+            .github/actions/
 
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
@@ -648,7 +658,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
+          sparse-checkout: |
+            .github/actions/
 
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
@@ -680,7 +691,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
+          sparse-checkout: |
+            .github/actions/
 
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
@@ -712,7 +724,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
+          sparse-checkout: |
+            .github/actions/
 
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
@@ -744,7 +757,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
+          sparse-checkout: |
+            .github/actions/
 
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
@@ -776,7 +790,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
+          sparse-checkout: |
+            .github/actions/
 
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
@@ -808,7 +823,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
+          sparse-checkout: |
+            .github/actions/
 
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
@@ -840,7 +856,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
+          sparse-checkout: |
+            .github/actions/
 
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
@@ -872,7 +889,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
+          sparse-checkout: |
+            .github/actions/
 
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
@@ -904,7 +922,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
+          sparse-checkout: |
+            .github/actions/
 
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
@@ -936,7 +955,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
+          sparse-checkout: |
+            .github/actions/
 
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
@@ -968,7 +988,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
+          sparse-checkout: |
+            .github/actions/
 
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
@@ -1000,7 +1021,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
+          sparse-checkout: |
+            .github/actions/
 
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
@@ -1032,7 +1054,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
+          sparse-checkout: |
+            .github/actions/
 
       - name: Update seed
         uses: ./.github/actions/auto-update-seed

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -185,6 +185,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
+      fail-fast: false # Don't let failing generators block the passing generators
       matrix:
         sdk-name:
           [
@@ -213,60 +214,101 @@ jobs:
             rust-sdk
           ]
     outputs:
-      ruby-model: ${{ steps.set-test-matrix.outputs.ruby-model-test-matrix }}
-      ruby-sdk: ${{ steps.set-test-matrix.outputs.ruby-sdk-test-matrix }}
-      ruby-sdk-v2: ${{ steps.set-test-matrix.outputs.ruby-sdk-v2-test-matrix }}
-      pydantic: ${{ steps.set-test-matrix.outputs.pydantic-test-matrix }}
-      python-sdk: ${{ steps.set-test-matrix.outputs.python-sdk-test-matrix }}
-      fastapi: ${{ steps.set-test-matrix.outputs.fastapi-test-matrix }}
-      openapi: ${{ steps.set-test-matrix.outputs.openapi-test-matrix }}
-      postman: ${{ steps.set-test-matrix.outputs.postman-test-matrix }}
-      java-sdk: ${{ steps.set-test-matrix.outputs.java-sdk-test-matrix }}
-      java-model: ${{ steps.set-test-matrix.outputs.java-model-test-matrix }}
-      java-spring: ${{ steps.set-test-matrix.outputs.java-spring-test-matrix }}
-      ts-sdk: ${{ steps.set-test-matrix.outputs.ts-sdk-test-matrix }}
-      ts-express: ${{ steps.set-test-matrix.outputs.ts-express-test-matrix }}
-      go-fiber: ${{ steps.set-test-matrix.outputs.go-fiber-test-matrix }}
-      go-model: ${{ steps.set-test-matrix.outputs.go-model-test-matrix }}
-      go-sdk: ${{ steps.set-test-matrix.outputs.go-sdk-test-matrix }}
-      csharp-model: ${{ steps.set-test-matrix.outputs.csharp-model-test-matrix }}
-      csharp-sdk: ${{ steps.set-test-matrix.outputs.csharp-sdk-test-matrix }}
-      php-model: ${{ steps.set-test-matrix.outputs.php-model-test-matrix }}
-      php-sdk: ${{ steps.set-test-matrix.outputs.php-sdk-test-matrix }}
-      swift-sdk: ${{ steps.set-test-matrix.outputs.swift-sdk-test-matrix }}
-      rust-model: ${{ steps.set-test-matrix.outputs.rust-model-test-matrix }}
-      rust-sdk: ${{ steps.set-test-matrix.outputs.rust-sdk-test-matrix }}
+      ruby-model: ${{ steps.create-seed-groups-matrix.outputs.ruby-model-test-matrix }}
+      ruby-sdk: ${{ steps.create-seed-groups-matrix.outputs.ruby-sdk-test-matrix }}
+      ruby-sdk-v2: ${{ steps.create-seed-groups-matrix.outputs.ruby-sdk-v2-test-matrix }}
+      pydantic: ${{ steps.create-seed-groups-matrix.outputs.pydantic-test-matrix }}
+      python-sdk: ${{ steps.create-seed-groups-matrix.outputs.python-sdk-test-matrix }}
+      fastapi: ${{ steps.create-seed-groups-matrix.outputs.fastapi-test-matrix }}
+      openapi: ${{ steps.create-seed-groups-matrix.outputs.openapi-test-matrix }}
+      postman: ${{ steps.create-seed-groups-matrix.outputs.postman-test-matrix }}
+      java-sdk: ${{ steps.create-seed-groups-matrix.outputs.java-sdk-test-matrix }}
+      java-model: ${{ steps.create-seed-groups-matrix.outputs.java-model-test-matrix }}
+      java-spring: ${{ steps.create-seed-groups-matrix.outputs.java-spring-test-matrix }}
+      ts-sdk: ${{ steps.create-seed-groups-matrix.outputs.ts-sdk-test-matrix }}
+      ts-express: ${{ steps.create-seed-groups-matrix.outputs.ts-express-test-matrix }}
+      go-fiber: ${{ steps.create-seed-groups-matrix.outputs.go-fiber-test-matrix }}
+      go-model: ${{ steps.create-seed-groups-matrix.outputs.go-model-test-matrix }}
+      go-sdk: ${{ steps.create-seed-groups-matrix.outputs.go-sdk-test-matrix }}
+      csharp-model: ${{ steps.create-seed-groups-matrix.outputs.csharp-model-test-matrix }}
+      csharp-sdk: ${{ steps.create-seed-groups-matrix.outputs.csharp-sdk-test-matrix }}
+      php-model: ${{ steps.create-seed-groups-matrix.outputs.php-model-test-matrix }}
+      php-sdk: ${{ steps.create-seed-groups-matrix.outputs.php-sdk-test-matrix }}
+      swift-sdk: ${{ steps.create-seed-groups-matrix.outputs.swift-sdk-test-matrix }}
+      rust-model: ${{ steps.create-seed-groups-matrix.outputs.rust-model-test-matrix }}
+      rust-sdk: ${{ steps.create-seed-groups-matrix.outputs.rust-sdk-test-matrix }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-
-      - name: Get test matrix
-        id: get-test-matrix
-        uses: ./.github/actions/get-test-matrix
         with:
-          sdk-name: ${{ matrix.sdk-name }}
-          package-amount: 10
-          include-output-folders: true
+          sparse-checkout: |
+            .github/workflow-resource-files/seed-groups/
 
-      - name: Set test matrix for ${{ matrix.sdk-name }}
-        id: set-test-matrix
+      - name: Verify Seed Groups File Exists
         run: |
-          if [[ "${{ steps.get-test-matrix.outputs.split-tests }}" == "true" ]]; then
-              BASH_VAR='${{ steps.get-test-matrix.outputs.test-matrix }}'
-              echo "${{ matrix.sdk-name }}-test-matrix=$BASH_VAR" >> $GITHUB_OUTPUT
-
-              # Echo the data to command line for visibility
-              echo "Packaged data for ${{ matrix.sdk-name }}-test-matrix:"
-              echo "$BASH_VAR" | jq .
+          if [ ! -f .github/workflow-resource-files/seed-groups/${{ matrix.sdk-name }}-seed-groups.json ]; then
+            echo "${{ matrix.sdk-name }}-seed-groups.json file not found. This file should be created automatically by the nightly-seed-grouping workflow."
+            exit 1
           else
-            echo "Set empty json matrix, which will run all tests on a single runner"
+            echo "${{ matrix.sdk-name }}-seed-groups.json file found."
+          fi
+
+      - name: Determine Parallelization
+        id: determine-parallelization
+        run: |
+          # Note: these times are the total time of generation and compilation for all seed tests. This is not a 
+          # measurement of throughput because it does not account of concurrency or parallelization. This is not 
+          # a perfect representation, but it gets the job done. 3800 seconds was chosen as it is approximately 
+          # 8 minutes when running with 16 concurrent tests as is our default setting in CI.
+          CUTOFF_TIME_FOR_PARALLELIZATION_SECONDS=3800
+          TOTAL_TEST_TIME_SECONDS=$(jq '.totalTestTimeSeconds' .github/workflow-resource-files/seed-groups/${{ matrix.sdk-name }}-seed-groups.json)
+          echo "Checking if ${{ matrix.sdk-name }} total test time of $TOTAL_TEST_TIME_SECONDS seconds is greater than $CUTOFF_TIME_FOR_PARALLELIZATION_SECONDS seconds to split tests into parallel runners"
+
+          # Validate both times are non-negative integers (zero is allowed)
+          if [[ ! $CUTOFF_TIME_FOR_PARALLELIZATION_SECONDS =~ ^[0-9]+$ ]]; then
+            echo "Cut off time from seed.yml workflow is not a non-negative integer ($CUTOFF_TIME_FOR_PARALLELIZATION_SECONDS)"
+            exit 1
+          fi
+
+          if [[ ! $TOTAL_TEST_TIME_SECONDS =~ ^[0-9]+$ ]]; then
+            echo "Total test time from ${{ matrix.sdk-name }}-seed-groups.json is not a non-negative integer ($TOTAL_TEST_TIME_SECONDS)"
+            exit 1
+          fi
+
+          # Determine if we should split tests into parallel runners based on the cutoff time
+          if [[ $TOTAL_TEST_TIME_SECONDS -gt $CUTOFF_TIME_FOR_PARALLELIZATION_SECONDS ]]; then
+            echo "Running ${{ matrix.sdk-name }} tests in parallel runners"
+            echo "split-tests=true" >> $GITHUB_OUTPUT
+          else
+            echo "Running ${{ matrix.sdk-name }} tests in a single runner"
+            echo "split-tests=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Seed Groups Matrix
+        id: create-seed-groups-matrix
+        run: |
+          # Parallelize tests and add leftover test runner, or run all tests in a single runner
+          # Note: "leftovers" and "all" are used as keywords in the matrix jobs following this setup
+          BASH_VAR=""
+          if [[ "${{ steps.determine-parallelization.outputs.split-tests }}" == "true" ]]; then
+            echo "Using balanced groups from ${{ matrix.sdk-name }}-seed-groups.json and adding a group for any leftover tests"
+            BASH_VAR=$(jq '[.groups[] | {fixtures: .fixtures}]' .github/workflow-resource-files/seed-groups/${{ matrix.sdk-name }}-seed-groups.json)
+            WITH_LEFTOVERS=$(echo "$BASH_VAR" | jq -c '. += [{"fixtures": ["leftovers"]}]')
+            echo "${{ matrix.sdk-name }}-test-matrix=$WITH_LEFTOVERS" >> $GITHUB_OUTPUT
+
+            # Echo the data to command line for visibility
+            echo "Groups for ${{ matrix.sdk-name }}-test-matrix:"
+            echo "$WITH_LEFTOVERS" | jq .
+          else
+            echo "Using single group to run all ${{ matrix.sdk-name }} tests"
             BASH_VAR='[{"fixtures":["all"]}]'
             echo "${{ matrix.sdk-name }}-test-matrix=$BASH_VAR" >> $GITHUB_OUTPUT
 
             # Echo the data to command line for visibility
-            echo "Packaged data for ${{ matrix.sdk-name }}-test-matrix:"
+            echo "Single group for ${{ matrix.sdk-name }}-test-matrix:"
             echo "$BASH_VAR" | jq .
           fi
+
 
   ruby-model-seed-update:
     runs-on: ubuntu-latest
@@ -280,7 +322,7 @@ jobs:
       }}
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
-      max-parallel: 10 # Limit the number of runners for this job to 10
+      max-parallel: 15 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.ruby-model) }}
     steps:
@@ -289,23 +331,13 @@ jobs:
         with:
           token: ${{ secrets.FERN_GITHUB_PAT }}
 
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
         with:
           generator-name: ruby-model
           generator-path: generators/ruby
           allow-unexpected-failures: true
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+          fixtures-to-run: ${{ toJson(matrix.fixtures) }}
           index: ${{ strategy.job-index }}
           skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
 
@@ -321,7 +353,7 @@ jobs:
       }}
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
-      max-parallel: 10 # Limit the number of runners for this job to 10
+      max-parallel: 15 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.ruby-sdk) }}
 
@@ -331,23 +363,13 @@ jobs:
         with:
           token: ${{ secrets.FERN_GITHUB_PAT }}
 
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
         with:
           generator-name: ruby-sdk
           generator-path: generators/ruby
           allow-unexpected-failures: true
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+          fixtures-to-run: ${{ toJson(matrix.fixtures) }}
           index: ${{ strategy.job-index }}
           skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
 
@@ -363,7 +385,7 @@ jobs:
       }}
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
-      max-parallel: 10 # Limit the number of runners for this job to 10
+      max-parallel: 15 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.ruby-sdk-v2) }}
 
@@ -373,23 +395,13 @@ jobs:
         with:
           token: ${{ secrets.FERN_GITHUB_PAT }}
 
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
         with:
           generator-name: ruby-sdk-v2
           generator-path: generators/ruby-v2
           allow-unexpected-failures: true
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+          fixtures-to-run: ${{ toJson(matrix.fixtures) }}
           index: ${{ strategy.job-index }}
           skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
 
@@ -405,7 +417,7 @@ jobs:
       }}
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
-      max-parallel: 10 # Limit the number of runners for this job to 10
+      max-parallel: 15 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.pydantic) }}
 
@@ -415,23 +427,13 @@ jobs:
         with:
           token: ${{ secrets.FERN_GITHUB_PAT }}
 
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
         with:
           generator-name: pydantic
           generator-path: generators/python
           allow-unexpected-failures: true
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+          fixtures-to-run: ${{ toJson(matrix.fixtures) }}
           index: ${{ strategy.job-index }}
           skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
 
@@ -447,7 +449,7 @@ jobs:
       }}
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
-      max-parallel: 10 # Limit the number of runners for this job to 10
+      max-parallel: 15 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.python-sdk) }}
 
@@ -457,23 +459,13 @@ jobs:
         with:
           token: ${{ secrets.FERN_GITHUB_PAT }}
 
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
         with:
           generator-name: python-sdk
           generator-path: generators/python
           allow-unexpected-failures: true
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+          fixtures-to-run: ${{ toJson(matrix.fixtures) }}
           index: ${{ strategy.job-index }}
           skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
 
@@ -489,7 +481,7 @@ jobs:
       }}
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
-      max-parallel: 10 # Limit the number of runners for this job to 10
+      max-parallel: 15 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.fastapi) }}
 
@@ -499,23 +491,13 @@ jobs:
         with:
           token: ${{ secrets.FERN_GITHUB_PAT }}
 
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
         with:
           generator-name: fastapi
           generator-path: generators/python
           allow-unexpected-failures: true
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+          fixtures-to-run: ${{ toJson(matrix.fixtures) }}
           index: ${{ strategy.job-index }}
           skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
 
@@ -531,7 +513,7 @@ jobs:
       }}
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
-      max-parallel: 10 # Limit the number of runners for this job to 10
+      max-parallel: 15 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.openapi) }}
 
@@ -541,23 +523,13 @@ jobs:
         with:
           token: ${{ secrets.FERN_GITHUB_PAT }}
 
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
         with:
           generator-name: openapi
           generator-path: generators/openapi
           allow-unexpected-failures: true
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+          fixtures-to-run: ${{ toJson(matrix.fixtures) }}
           index: ${{ strategy.job-index }}
           skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
 
@@ -573,7 +545,7 @@ jobs:
       }}
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
-      max-parallel: 10 # Limit the number of runners for this job to 10
+      max-parallel: 15 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.postman) }}
 
@@ -583,23 +555,13 @@ jobs:
         with:
           token: ${{ secrets.FERN_GITHUB_PAT }}
 
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
         with:
           generator-name: postman
           generator-path: generators/postman
           allow-unexpected-failures: true
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+          fixtures-to-run: ${{ toJson(matrix.fixtures) }}
           index: ${{ strategy.job-index }}
           skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
 
@@ -615,7 +577,7 @@ jobs:
       }}
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
-      max-parallel: 10 # Limit the number of runners for this job to 10
+      max-parallel: 15 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.java-sdk) }}
 
@@ -625,23 +587,13 @@ jobs:
         with:
           token: ${{ secrets.FERN_GITHUB_PAT }}
 
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
         with:
           generator-name: java-sdk
           generator-path: generators/java
           allow-unexpected-failures: true
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+          fixtures-to-run: ${{ toJson(matrix.fixtures) }}
           index: ${{ strategy.job-index }}
           skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
 
@@ -657,7 +609,7 @@ jobs:
       }}
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
-      max-parallel: 10 # Limit the number of runners for this job to 10
+      max-parallel: 15 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.java-model) }}
 
@@ -667,23 +619,13 @@ jobs:
         with:
           token: ${{ secrets.FERN_GITHUB_PAT }}
 
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
         with:
           generator-name: java-model
           generator-path: generators/java
           allow-unexpected-failures: true
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+          fixtures-to-run: ${{ toJson(matrix.fixtures) }}
           index: ${{ strategy.job-index }}
           skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
 
@@ -699,7 +641,7 @@ jobs:
       }}
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
-      max-parallel: 10 # Limit the number of runners for this job to 10
+      max-parallel: 15 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.java-spring) }}
 
@@ -709,23 +651,13 @@ jobs:
         with:
           token: ${{ secrets.FERN_GITHUB_PAT }}
 
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
         with:
           generator-name: java-spring
           generator-path: generators/java
           allow-unexpected-failures: true
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+          fixtures-to-run: ${{ toJson(matrix.fixtures) }}
           index: ${{ strategy.job-index }}
           skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
 
@@ -741,7 +673,7 @@ jobs:
       }}
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
-      max-parallel: 10 # Limit the number of runners for this job to 10
+      max-parallel: 15 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.ts-sdk) }}
 
@@ -751,23 +683,13 @@ jobs:
         with:
           token: ${{ secrets.FERN_GITHUB_PAT }}
 
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
         with:
           generator-name: ts-sdk
           generator-path: generators/typescript
           allow-unexpected-failures: true
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+          fixtures-to-run: ${{ toJson(matrix.fixtures) }}
           index: ${{ strategy.job-index }}
           skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
 
@@ -783,7 +705,7 @@ jobs:
       }}
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
-      max-parallel: 10 # Limit the number of runners for this job to 10
+      max-parallel: 15 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.ts-express) }}
 
@@ -793,23 +715,13 @@ jobs:
         with:
           token: ${{ secrets.FERN_GITHUB_PAT }}
 
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
         with:
           generator-name: ts-express
           generator-path: generators/typescript
           allow-unexpected-failures: true
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+          fixtures-to-run: ${{ toJson(matrix.fixtures) }}
           index: ${{ strategy.job-index }}
           skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
 
@@ -825,7 +737,7 @@ jobs:
       }}
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
-      max-parallel: 10 # Limit the number of runners for this job to 10
+      max-parallel: 15 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.go-fiber) }}
 
@@ -835,23 +747,13 @@ jobs:
         with:
           token: ${{ secrets.FERN_GITHUB_PAT }}
 
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
         with:
           generator-name: go-fiber
           generator-path: generators/go
           allow-unexpected-failures: true
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+          fixtures-to-run: ${{ toJson(matrix.fixtures) }}
           index: ${{ strategy.job-index }}
           skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
 
@@ -867,7 +769,7 @@ jobs:
       }}
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
-      max-parallel: 10 # Limit the number of runners for this job to 10
+      max-parallel: 15 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.go-model) }}
 
@@ -877,23 +779,13 @@ jobs:
         with:
           token: ${{ secrets.FERN_GITHUB_PAT }}
 
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
         with:
           generator-name: go-model
           generator-path: generators/go
           allow-unexpected-failures: true
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+          fixtures-to-run: ${{ toJson(matrix.fixtures) }}
           index: ${{ strategy.job-index }}
           skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
 
@@ -909,7 +801,7 @@ jobs:
       }}
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
-      max-parallel: 10 # Limit the number of runners for this job to 10
+      max-parallel: 15 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.go-sdk) }}
 
@@ -919,23 +811,13 @@ jobs:
         with:
           token: ${{ secrets.FERN_GITHUB_PAT }}
 
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
         with:
           generator-name: go-sdk
           generator-path: generators/go
           allow-unexpected-failures: true
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+          fixtures-to-run: ${{ toJson(matrix.fixtures) }}
           index: ${{ strategy.job-index }}
           skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
 
@@ -951,7 +833,7 @@ jobs:
       }}
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
-      max-parallel: 10 # Limit the number of runners for this job to 10
+      max-parallel: 15 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.csharp-model) }}
 
@@ -961,23 +843,13 @@ jobs:
         with:
           token: ${{ secrets.FERN_GITHUB_PAT }}
 
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
         with:
           generator-name: csharp-model
           generator-path: generators/csharp
           allow-unexpected-failures: true
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+          fixtures-to-run: ${{ toJson(matrix.fixtures) }}
           index: ${{ strategy.job-index }}
           skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
 
@@ -993,7 +865,7 @@ jobs:
       }}
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
-      max-parallel: 10 # Limit the number of runners for this job to 10
+      max-parallel: 15 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.csharp-sdk) }}
 
@@ -1003,23 +875,13 @@ jobs:
         with:
           token: ${{ secrets.FERN_GITHUB_PAT }}
 
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
         with:
           generator-name: csharp-sdk
           generator-path: generators/csharp
           allow-unexpected-failures: true
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+          fixtures-to-run: ${{ toJson(matrix.fixtures) }}
           index: ${{ strategy.job-index }}
           skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
 
@@ -1035,7 +897,7 @@ jobs:
       }}
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
-      max-parallel: 10 # Limit the number of runners for this job to 10
+      max-parallel: 15 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.php-model) }}
 
@@ -1045,23 +907,13 @@ jobs:
         with:
           token: ${{ secrets.FERN_GITHUB_PAT }}
 
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
         with:
           generator-name: php-model
           generator-path: generators/php
           allow-unexpected-failures: true
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+          fixtures-to-run: ${{ toJson(matrix.fixtures) }}
           index: ${{ strategy.job-index }}
           skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
 
@@ -1077,7 +929,7 @@ jobs:
       }}
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
-      max-parallel: 10 # Limit the number of runners for this job to 10
+      max-parallel: 15 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.php-sdk) }}
 
@@ -1087,23 +939,13 @@ jobs:
         with:
           token: ${{ secrets.FERN_GITHUB_PAT }}
 
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
         with:
           generator-name: php-sdk
           generator-path: generators/php
           allow-unexpected-failures: true
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+          fixtures-to-run: ${{ toJson(matrix.fixtures) }}
           index: ${{ strategy.job-index }}
           skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
 
@@ -1119,7 +961,7 @@ jobs:
       }}
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
-      max-parallel: 10 # Limit the number of runners for this job to 10
+      max-parallel: 15 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.swift-sdk) }}
 
@@ -1129,23 +971,13 @@ jobs:
         with:
           token: ${{ secrets.FERN_GITHUB_PAT }}
 
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
         with:
           generator-name: swift-sdk
           generator-path: generators/swift
           allow-unexpected-failures: true
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+          fixtures-to-run: ${{ toJson(matrix.fixtures) }}
           index: ${{ strategy.job-index }}
           skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
 
@@ -1161,7 +993,7 @@ jobs:
       }}
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
-      max-parallel: 10 # Limit the number of runners for this job to 10
+      max-parallel: 15 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.rust-model) }}
 
@@ -1171,23 +1003,13 @@ jobs:
         with:
           token: ${{ secrets.FERN_GITHUB_PAT }}
 
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
         with:
           generator-name: rust-model
           generator-path: generators/rust
           allow-unexpected-failures: true
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+          fixtures-to-run: ${{ toJson(matrix.fixtures) }}
           index: ${{ strategy.job-index }}
           skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
 
@@ -1203,7 +1025,7 @@ jobs:
       }}
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
-      max-parallel: 10 # Limit the number of runners for this job to 10
+      max-parallel: 15 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.rust-sdk) }}
 
@@ -1213,23 +1035,13 @@ jobs:
         with:
           token: ${{ secrets.FERN_GITHUB_PAT }}
 
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
         with:
           generator-name: rust-sdk
           generator-path: generators/rust
           allow-unexpected-failures: true
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+          fixtures-to-run: ${{ toJson(matrix.fixtures) }}
           index: ${{ strategy.job-index }}
           skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
 

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -309,7 +309,6 @@ jobs:
             echo "$BASH_VAR" | jq .
           fi
 
-
   ruby-model-seed-update:
     runs-on: ubuntu-latest
     timeout-minutes: 60


### PR DESCRIPTION
## Description
Linear ticket: https://linear.app/buildwithfern/issue/FER-6954/ci-use-package-balancer-output-in-update-seed
Closes FER-6954
Get the performance improvements from using balanced seed groupings into the update seed workflow

## Changes Made
- Updated the update-seed.yml workflow to work more like how seed.yml does
- Minor cleanup elsewhere in the file as well

## Testing
- Verified in CI here: https://github.com/fern-api/fern/actions/runs/18616737689/job/53082596070
