### PR TITLE
chore(ci): Filter compilation for faster runs on validate-changelog and run on all generators

### DIFF
--- a/.github/workflows/validate-changelog.yml
+++ b/.github/workflows/validate-changelog.yml
@@ -34,7 +34,7 @@ jobs:
         uses: ./.github/actions/install
 
       - name: Compile
-        run: pnpm compile
+        run: pnpm exec turbo compile '--filter=@fern-api/seed-cli'
 
       - name: Seed Build
         run: pnpm seed:build

--- a/scripts/validate-all-changelogs.sh
+++ b/scripts/validate-all-changelogs.sh
@@ -7,28 +7,28 @@ set -e
 
 # Run all validations in parallel and collect errors
 generators=(
-    ruby-model,
-    ruby-sdk,
-    ruby-sdk-v2,
-    pydantic,
-    python-sdk,
-    fastapi,
-    openapi,
-    postman,
-    java-sdk,
-    java-model,
-    java-spring,
-    ts-sdk,
-    ts-express,
-    go-fiber,
-    go-model,
-    go-sdk,
-    csharp-model,
-    csharp-sdk,
-    php-model,
-    php-sdk,
-    swift-sdk,
-    rust-model,
+    ruby-model
+    ruby-sdk
+    ruby-sdk-v2
+    pydantic
+    python-sdk
+    fastapi
+    openapi
+    postman
+    java-sdk
+    java-model
+    java-spring
+    ts-sdk
+    ts-express
+    go-fiber
+    go-model
+    go-sdk
+    csharp-model
+    csharp-sdk
+    php-model
+    php-sdk
+    swift-sdk
+    rust-model
     rust-sdk
 )
 

--- a/scripts/validate-all-changelogs.sh
+++ b/scripts/validate-all-changelogs.sh
@@ -7,24 +7,29 @@ set -e
 
 # Run all validations in parallel and collect errors
 generators=(
-    fastapi
-    pydantic
-    python-sdk
-    go-sdk
-    ruby-sdk
-    postman
-    openapi
-    java-sdk
-    java-model
-    java-spring
-    ts-express
-    csharp-sdk
-    csharp-model
-    php-sdk
-    php-model
+    ruby-model,
+    ruby-sdk,
+    ruby-sdk-v2,
+    pydantic,
+    python-sdk,
+    fastapi,
+    openapi,
+    postman,
+    java-sdk,
+    java-model,
+    java-spring,
+    ts-sdk,
+    ts-express,
+    go-fiber,
+    go-model,
+    go-sdk,
+    csharp-model,
+    csharp-sdk,
+    php-model,
+    php-sdk,
+    swift-sdk,
+    rust-model,
     rust-sdk
-    rust-model
-    swift-sdk
 )
 
 # Create temporary files for each generator's output


### PR DESCRIPTION
## Description
Linear ticket: https://linear.app/buildwithfern/issue/FER-7243/ci-speed-up-validate-changelog-workflow and https://linear.app/buildwithfern/issue/FER-7245/ci-run-validate-changelog-for-all-generators
Closes FER-7243 and Closes FER-7245
Filtering the compilation step in the validate-changelogs workflow to speed up the workflow run and updating generator list

## Changes Made
- Updated command to filter compilation
- Updated list of generators to run

## Testing
- Verified in test branch CI here: https://github.com/fern-api/fern/actions/runs/18618530026/job/53086487816?pr=9961