### PR TITLE
fix(swift): correctly handle nullable query params in endpoint methods

### DIFF
--- a/generators/swift/sdk/src/generators/client/EndpointMethodGenerator.ts
+++ b/generators/swift/sdk/src/generators/client/EndpointMethodGenerator.ts
@@ -282,7 +282,7 @@ export class EndpointMethodGenerator {
                                             arguments_: [
                                                 swift.functionArgument({
                                                     value:
-                                                        swiftType.nonOptionalType === "custom"
+                                                        swiftType.nonOptional().nonNullableType === "custom"
                                                             ? swift.Expression.memberAccess({
                                                                   target: swift.Expression.reference("$0"),
                                                                   memberName: "rawValue"

--- a/generators/swift/sdk/versions.yml
+++ b/generators/swift/sdk/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.18.2
+  changelogEntry:
+    - type: fix
+      summary: |
+        Fixed a bug where nullable query parameters were not accessed correctly in endpoint methods.
+  createdAt: "2025-10-19"
+  irVersion: 59
+
 - version: 0.18.1
   changelogEntry:
     - type: fix


### PR DESCRIPTION
## Description
Linear ticket: [FER-7254](https://linear.app/buildwithfern/issue/FER-7254/correctly-handle-nullable-query-params-in-endpoint-method-generator)
<!-- Provide a clear and concise description of the changes made in this PR -->
Fixes a bug where the nullable query params were not properly added to the `queryParams` dictionary in endpoint methods.

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Updated `EndpointMethodGenerator` to correctly access the raw value of nullable query params

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated
- [x] Manual testing completed
