### PR TITLE
fix(cli): handle breaking errors at top level

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/converters/ExampleEndpointFactory.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/converters/ExampleEndpointFactory.ts
@@ -42,8 +42,6 @@ export class ExampleEndpointFactory {
     }
 
     public buildEndpointExample(endpoint: EndpointWithExample): EndpointExample[] {
-        this.logger.debug(`Building endpoint example for ${endpoint.method.toUpperCase()} ${endpoint.path}`);
-
         // pares down the request/response to only multipart or json schemas.
         // other types are not supported in the builder.
         const requestSchemaIdResponse = getRequestSchema(endpoint.request);

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/generateIr.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/generateIr.ts
@@ -120,7 +120,6 @@ export function generateIr({
         if (pathItem == null) {
             return;
         }
-        taskContext.logger.debug(`Converting path ${path}`);
         const convertedOperations = convertPathItem(path, pathItem, openApi, context);
         for (const operation of convertedOperations) {
             const operationAudiences = getAudiences({ operation });
@@ -205,7 +204,6 @@ export function generateIr({
             continue;
         }
         schemas[key] = schema;
-        taskContext.logger.debug(`Converted schema ${key}`);
     }
 
     const exampleTypeFactory = new ExampleTypeFactory(

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/parse.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/parse.ts
@@ -71,56 +71,63 @@ export function parse({
     };
     let documentIndex = 0;
     for (const document of documents) {
-        const source = document.source != null ? document.source : OpenApiIrSource.openapi({ file: "<memory>" });
-        switch (document.type) {
-            case "openapi": {
-                const openapiIr = generateIrFromV3({
-                    taskContext: context,
-                    openApi: document.value,
-                    options: getParseOptions({ options: document.settings, overrides: options }),
-                    source,
-                    namespace: document.namespace
-                });
-                ir = merge(ir, openapiIr, getParseOptions({ options: document.settings, overrides: options }));
-                documentIndex++;
-                break;
+        try {
+            const source = document.source != null ? document.source : OpenApiIrSource.openapi({ file: "<memory>" });
+            switch (document.type) {
+                case "openapi": {
+                    const openapiIr = generateIrFromV3({
+                        taskContext: context,
+                        openApi: document.value,
+                        options: getParseOptions({ options: document.settings, overrides: options }),
+                        source,
+                        namespace: document.namespace
+                    });
+                    ir = merge(ir, openapiIr, getParseOptions({ options: document.settings, overrides: options }));
+                    documentIndex++;
+                    break;
+                }
+                case "asyncapi": {
+                    const parsedAsyncAPI = parseAsyncAPI({
+                        document: document.value,
+                        taskContext: context,
+                        options: getParseOptions({ options: document.settings, overrides: options }),
+                        source,
+                        asyncApiOptions: getParseAsyncOptions({ options: document.settings }),
+                        namespace: document.namespace
+                    });
+                    if (parsedAsyncAPI.servers != null) {
+                        ir.websocketServers = [
+                            ...ir.websocketServers,
+                            ...parsedAsyncAPI.servers.map((server) => ({
+                                ...server,
+                                audiences: undefined,
+                                description: undefined
+                            }))
+                        ];
+                    }
+                    if (parsedAsyncAPI.channels != null) {
+                        ir.channels = {
+                            ...ir.channels,
+                            ...parsedAsyncAPI.channels
+                        };
+                    }
+                    if (parsedAsyncAPI.groupedSchemas != null) {
+                        ir.groupedSchemas = mergeSchemaMaps(ir.groupedSchemas, parsedAsyncAPI.groupedSchemas);
+                    }
+                    if (parsedAsyncAPI.basePath != null) {
+                        ir.basePath = parsedAsyncAPI.basePath;
+                    }
+                    documentIndex++;
+                    break;
+                }
+                default:
+                    assertNever(document);
             }
-            case "asyncapi": {
-                const parsedAsyncAPI = parseAsyncAPI({
-                    document: document.value,
-                    taskContext: context,
-                    options: getParseOptions({ options: document.settings, overrides: options }),
-                    source,
-                    asyncApiOptions: getParseAsyncOptions({ options: document.settings }),
-                    namespace: document.namespace
-                });
-                if (parsedAsyncAPI.servers != null) {
-                    ir.websocketServers = [
-                        ...ir.websocketServers,
-                        ...parsedAsyncAPI.servers.map((server) => ({
-                            ...server,
-                            audiences: undefined,
-                            description: undefined
-                        }))
-                    ];
-                }
-                if (parsedAsyncAPI.channels != null) {
-                    ir.channels = {
-                        ...ir.channels,
-                        ...parsedAsyncAPI.channels
-                    };
-                }
-                if (parsedAsyncAPI.groupedSchemas != null) {
-                    ir.groupedSchemas = mergeSchemaMaps(ir.groupedSchemas, parsedAsyncAPI.groupedSchemas);
-                }
-                if (parsedAsyncAPI.basePath != null) {
-                    ir.basePath = parsedAsyncAPI.basePath;
-                }
-                documentIndex++;
-                break;
+        } catch (error) {
+            context.logger.error(`Skipping parsing document ${document.type === "openapi" ? document.value.info?.title : document.source?.file}`);
+            if (error instanceof Error) {
+                context.logger.debug(error.message, error.stack ? "\n" + error.stack : "");
             }
-            default:
-                assertNever(document);
         }
     }
     return ir;

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/parse.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/parse.ts
@@ -124,7 +124,9 @@ export function parse({
                     assertNever(document);
             }
         } catch (error) {
-            context.logger.error(`Skipping parsing document ${document.type === "openapi" ? document.value.info?.title : document.source?.file}`);
+            context.logger.error(
+                `Skipping parsing document ${document.type === "openapi" ? document.value.info?.title : document.source?.file}`
+            );
             if (error instanceof Error) {
                 context.logger.debug(error.message, error.stack ? "\n" + error.stack : "");
             }

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        If API publishing fails, alert and continue to next in fern generate --docs.
+      type: fix
+  irVersion: 61
+  createdAt: "2025-10-20"
+  version: 0.93.2
+
+- changelogEntry:
+    - summary: |
         Fix errors related to:
           - external references in OpenAPI specs
           - references in OpenAPI security schemes

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -202,7 +202,7 @@ export async function publishDocs({
             });
 
             if (response.ok) {
-                context.logger.debug(`Registered API Definition ${response.body.apiDefinitionId}`);
+                context.logger.debug(`Registered API Definition ${apiName}: ${response.body.apiDefinitionId}`);
 
                 if (response.body.dynamicIRs && dynamicIRsByLanguage) {
                     if (skipUpload) {

--- a/packages/cli/workspace/lazy-fern-workspace/src/utils/parseOpenAPI.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/utils/parseOpenAPI.ts
@@ -17,18 +17,18 @@ export async function parseOpenAPI({
     const result =
         parsed != null
             ? await bundle({
-                    ...DEFAULT_OPENAPI_BUNDLE_OPTIONS,
-                    doc: {
-                        source: new Source(absolutePathToOpenAPI, "<openapi>"),
-                        parsed
-                    },
-                    externalRefResolver: new OpenAPIRefResolver(absolutePathToOpenAPIOverrides)
-                })
+                  ...DEFAULT_OPENAPI_BUNDLE_OPTIONS,
+                  doc: {
+                      source: new Source(absolutePathToOpenAPI, "<openapi>"),
+                      parsed
+                  },
+                  externalRefResolver: new OpenAPIRefResolver(absolutePathToOpenAPIOverrides)
+              })
             : await bundle({
-                    ...DEFAULT_OPENAPI_BUNDLE_OPTIONS,
-                    ref: absolutePathToOpenAPI,
-                    externalRefResolver: new OpenAPIRefResolver(absolutePathToOpenAPIOverrides)
-                });
+                  ...DEFAULT_OPENAPI_BUNDLE_OPTIONS,
+                  ref: absolutePathToOpenAPI,
+                  externalRefResolver: new OpenAPIRefResolver(absolutePathToOpenAPIOverrides)
+              });
 
     return result.bundle.parsed;
 }

--- a/packages/cli/workspace/lazy-fern-workspace/src/utils/parseOpenAPI.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/utils/parseOpenAPI.ts
@@ -14,28 +14,21 @@ export async function parseOpenAPI({
     absolutePathToOpenAPIOverrides?: AbsoluteFilePath;
     parsed?: OpenAPI.Document;
 }): Promise<OpenAPI.Document> {
-    try {
-        const result =
-            parsed != null
-                ? await bundle({
-                      ...DEFAULT_OPENAPI_BUNDLE_OPTIONS,
-                      doc: {
-                          source: new Source(absolutePathToOpenAPI, "<openapi>"),
-                          parsed
-                      },
-                      externalRefResolver: new OpenAPIRefResolver(absolutePathToOpenAPIOverrides)
-                  })
-                : await bundle({
-                      ...DEFAULT_OPENAPI_BUNDLE_OPTIONS,
-                      ref: absolutePathToOpenAPI,
-                      externalRefResolver: new OpenAPIRefResolver(absolutePathToOpenAPIOverrides)
-                  });
+    const result =
+        parsed != null
+            ? await bundle({
+                    ...DEFAULT_OPENAPI_BUNDLE_OPTIONS,
+                    doc: {
+                        source: new Source(absolutePathToOpenAPI, "<openapi>"),
+                        parsed
+                    },
+                    externalRefResolver: new OpenAPIRefResolver(absolutePathToOpenAPIOverrides)
+                })
+            : await bundle({
+                    ...DEFAULT_OPENAPI_BUNDLE_OPTIONS,
+                    ref: absolutePathToOpenAPI,
+                    externalRefResolver: new OpenAPIRefResolver(absolutePathToOpenAPIOverrides)
+                });
 
-        return result.bundle.parsed;
-    } catch (error) {
-        if (error instanceof Error) {
-            throw new Error(`Failed to parse OpenAPI document at ${absolutePathToOpenAPI}: ${error.message}`);
-        }
-        throw new Error(`Failed to parse OpenAPI document at ${absolutePathToOpenAPI}: ${String(error)}`);
-    }
+    return result.bundle.parsed;
 }


### PR DESCRIPTION
handle some errors that cause the entire flow to break, at a higher level

With `fern check` changes upcoming, these should be caught at the `fern check` level. `fern generate` should not fail