### PR TITLE
chore(ruby): Adding new failure to ruby-sdk allowed failures

### DIFF
--- a/seed/ruby-sdk/seed.yml
+++ b/seed/ruby-sdk/seed.yml
@@ -136,6 +136,7 @@ allowedFailures:
   - undiscriminated-unions
   - unions
   - unknown
+  - url-form-encoded
   - validation
   - variables
   - version


### PR DESCRIPTION
## Description
Linear ticket: https://linear.app/buildwithfern/issue/FER-7334/ruby-update-allowed-failures-list
Closes FER-7334
Updating allowed failures list in ruby-sdk

## Changes Made
- Updated seed.yml for ruby-sdk for new failure

## Testing
- Will verify with CI on this PR
