### PR TITLE
chore(java): simplify README exampleStyle configuration logic

### DIFF
--- a/generators/java-v2/sdk/src/readme/ReadmeConfigBuilder.ts
+++ b/generators/java-v2/sdk/src/readme/ReadmeConfigBuilder.ts
@@ -53,16 +53,8 @@ export class ReadmeConfigBuilder {
             whiteLabel: context.ir.readmeConfig?.whiteLabel,
             customSections: getCustomSections(context),
             features,
-            // TODO: @tanmay, once this is released look for it normally
-            exampleStyle: (() => {
-                const customConfig = context.config.customConfig as { readmeConfig?: { exampleStyle?: string } };
-                const customConfigExampleStyle = customConfig?.readmeConfig?.exampleStyle;
-                const irReadmeConfig = context.ir.readmeConfig as { exampleStyle?: string } | undefined;
-                const irExampleStyle = irReadmeConfig?.exampleStyle;
-                const exampleStyle = customConfigExampleStyle ?? irExampleStyle ?? "comprehensive";
-                return exampleStyle as FernGeneratorCli.ExampleStyle;
-            })()
-        };
+            exampleStyle: context.ir.readmeConfig?.exampleStyle
+        } as FernGeneratorCli.ReadmeConfig;
     }
 
     private getLanguageInfo({ context }: { context: SdkGeneratorContext }): FernGeneratorCli.LanguageInfo {

--- a/generators/java-v2/sdk/src/readme/ReadmeSnippetBuilder.ts
+++ b/generators/java-v2/sdk/src/readme/ReadmeSnippetBuilder.ts
@@ -493,11 +493,7 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
         endpointSnippets: FernGeneratorExec.Endpoint[]
     ): Record<EndpointId, string> {
         const snippets: Record<EndpointId, string> = {};
-        const customConfig = this.context.config.customConfig as { readmeConfig?: { exampleStyle?: string } };
-        const customConfigExampleStyle = customConfig?.readmeConfig?.exampleStyle;
-        const irReadmeConfig = this.context.ir.readmeConfig as { exampleStyle?: string } | undefined;
-        const irExampleStyle = irReadmeConfig?.exampleStyle;
-        const exampleStyle = customConfigExampleStyle ?? irExampleStyle ?? "comprehensive";
+        const exampleStyle = this.context.ir.readmeConfig?.exampleStyle;
 
         const snippetsByEndpointId: Record<EndpointId, FernGeneratorExec.Endpoint[]> = {};
 


### PR DESCRIPTION
## Description
Linear ticket: Closes [FER-7341: \[Chore\] Java exampleStyle stuff had some jank code fix it](https://linear.app/buildwithfern/issue/FER-7341/chore-java-examplestyle-stuff-had-some-jank-code-fix-it)

Simplify to match other readmeConfig fields - no type assertions, no defaults, no helper methods. Natural fallback behavior when undefined. I had to do all of this BS before to get things to work locally before IR version to 61 was officially updated. 

## Testing
<!-- Describe how you tested these changes -->
- [ ] Unit tests added/updated N/A
- [x] Manual testing completed -- tested manually w/ bloomberg.
