### PR TITLE
fix(cli): exclude bundling APIs in docs creation request

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Skip bundling APIs with docs creation request.
+      type: fix
+  irVersion: 61
+  createdAt: "2025-10-22"
+  version: 0.93.4
+
+- changelogEntry:
+    - summary: |
         Upgrade fdr sdk to 0.139.33
       type: fix
   irVersion: 61

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -251,7 +251,8 @@ export async function publishDocs({
     const registerDocsResponse = await fdr.docs.v2.write.finishDocsRegister(
         CjsFdrSdk.docs.v1.write.DocsRegistrationId(docsRegistrationId),
         {
-            docsDefinition
+            docsDefinition,
+            excludeApis: true
         }
     );
 


### PR DESCRIPTION
this fixes some issues with running out of memory in Vercel

we don't get this anymore:
<img width="571" height="186" alt="Screenshot 2025-10-22 at 10 32 00 AM" src="https://github.com/user-attachments/assets/d363521f-0f91-4835-91b2-17c80e8b8609" />
