### PR TITLE
feat(ci): Adding allowed failures and fixture counts to seed metrics runs

### DIFF
--- a/.github/actions/artifact-seed-metrics/action.yaml
+++ b/.github/actions/artifact-seed-metrics/action.yaml
@@ -1,5 +1,5 @@
-name: Artifact Seed Test Times
-description: Artifact the seed test start and end times found during seed jobs
+name: Artifact Seed Metrics
+description: Artifact the seed test start and end times found during seed jobs, as well as the generator's determinism
 
 inputs:
   sdk-name:
@@ -14,6 +14,9 @@ inputs:
   end-time:
     description: The end time of the seed tests
     required: true
+  deterministic:
+    description: Whether the run portion of seed generation is deterministic or not (will reproduce the same results on repeated runs)
+    required: true
 
 runs:
   using: "composite"
@@ -24,7 +27,7 @@ runs:
       run: |
         METRICS_FILE_NAME="seed-metrics-${{ inputs.sdk-name }}-${{ inputs.job-index }}.json"
         echo "file_name=$METRICS_FILE_NAME" >> $GITHUB_OUTPUT
-        echo "{\"index\":\"${{ inputs.job-index }}\",\"startTimeSeconds\":\"${{ inputs.start-time }}\",\"endTimeSeconds\":\"${{ inputs.end-time }}\"}" > $METRICS_FILE_NAME
+        echo "{\"index\":\"${{ inputs.job-index }}\",\"startTimeSeconds\":\"${{ inputs.start-time }}\",\"endTimeSeconds\":\"${{ inputs.end-time }}\",\"deterministic\":\"${{ inputs.deterministic }}\"}" > $METRICS_FILE_NAME
 
     # Save for at least a week to help track slowdowns if/when they show up
     - name: Upload Metrics File

--- a/.github/actions/run-seed-process/action.yaml
+++ b/.github/actions/run-seed-process/action.yaml
@@ -22,6 +22,10 @@ inputs:
     description: Whether to collect metrics
     required: false
     default: "false"
+  determinism-exclude-paths:
+    description: "JSON array of paths to exclude from determinism verification step, typically package manager/lock files"
+    required: false
+    default: '["seed/*/.mock/*"]'
 
 outputs:
   start_time:
@@ -82,13 +86,23 @@ runs:
       run: |
         echo "end_time=$EPOCHSECONDS" >> $GITHUB_OUTPUT
 
+    # Run after seed is built, do this separately so we can keep seed time collection limited to seed generation
+    # Note: tests failing can be a cause of this reporting as non-deterministic
+    - name: Verify Determinism
+      id: verify-determinism
+      if: ${{ always() && !cancelled() && inputs.collect-metrics == 'true' }}
+      uses: ./.github/actions/verify-determinism
+      with:
+        determinism-exclude-paths: ${{ inputs.determinism-exclude-paths }}
+
     # Collect the outputs from this matrix iteration
-    - name: Collect Metrics
+    - name: Collect All Metrics
       # Save metrics even if the tests fail
       if: ${{ always() && !cancelled() && inputs.collect-metrics == 'true' }}
-      uses: ./.github/actions/artifact-seed-test-times
+      uses: ./.github/actions/artifact-seed-metrics
       with:
         sdk-name: ${{ inputs.sdk-name }}
         job-index: ${{ inputs.job-index }}
         start-time: ${{ steps.start-seed-timer.outputs.start_time }}
         end-time: ${{ steps.end-seed-timer.outputs.end_time }}
+        deterministic: ${{ steps.verify-determinism.outputs.deterministic}}

--- a/.github/actions/verify-determinism/action.yaml
+++ b/.github/actions/verify-determinism/action.yaml
@@ -1,0 +1,46 @@
+name: Verify Deterministic
+description: To be run after seed generation to compare against committed code and verify the results match.
+
+inputs:
+  determinism-exclude-paths:
+    description: "JSON array of paths to exclude from determinism verification step, typically package manager/lock files"
+    required: false
+    default: '["seed/*/.mock/*"]'
+
+outputs:
+  deterministic:
+    description: "Test matrix without any packaging"
+    value: ${{ steps.validate.outputs.deterministic }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Validate results
+      id: validate
+      shell: bash
+      run: |
+        # Parse JSON array and build exclude arguments
+        JSON_INPUT='${{ inputs.determinism-exclude-paths }}'
+        echo "Input JSON:"
+        echo ${JSON_INPUT} | jq .
+
+        # Build exclude array
+        EXCLUDE_ARGS=()
+        for EXCLUDE_PATTERN in $(echo "${JSON_INPUT}" | jq -c -r '.[]'); do
+          EXCLUDE_ARGS+=(":(exclude)${EXCLUDE_PATTERN}")
+        done
+
+        # Log for debugging
+        echo "Built exclude args as:"
+        printf '%s\n' "${EXCLUDE_ARGS[@]}"
+
+        # Set results. Run with quiet flag to avoid GitHub Actions log limits
+        if git --no-pager diff --exit-code --quiet -- "${EXCLUDE_ARGS[@]}"; then
+          echo "Results match"
+          echo "deterministic=true" >> $GITHUB_OUTPUT
+        else
+          # Note: need to add the || true when outputting the diff to gracefully avoid a SIGPIPE error when we stop reading the output of diff
+          echo "Changes detected in git-tracked files. Showing first 50 lines of diff (to avoid log limits in GitHub Actions):"
+          git --no-pager diff -- "${EXCLUDE_ARGS[@]}" | head -50 || true
+          echo "deterministic=false" >> $GITHUB_OUTPUT
+        fi

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -366,6 +366,7 @@ jobs:
           fixtures-to-run: ${{toJson(matrix.fixtures)}}
           job-index: ${{ strategy.job-index }}
           collect-metrics: ${{ needs.setup.outputs.post-metrics }}
+          determinism-exclude-paths: '["seed/*/.mock/*", "seed/**/Gemfile.lock"]'
 
   pydantic:
     runs-on: ubuntu-latest
@@ -426,6 +427,7 @@ jobs:
           fixtures-to-run: ${{toJson(matrix.fixtures)}}
           job-index: ${{ strategy.job-index }}
           collect-metrics: ${{ needs.setup.outputs.post-metrics }}
+          determinism-exclude-paths: '["seed/*/.mock/*", "seed/**/poetry.lock"]'
 
   fastapi:
     runs-on: ubuntu-latest
@@ -636,6 +638,7 @@ jobs:
           fixtures-to-run: ${{toJson(matrix.fixtures)}}
           job-index: ${{ strategy.job-index }}
           collect-metrics: ${{ needs.setup.outputs.post-metrics }}
+          determinism-exclude-paths: '["seed/*/.mock/*", "seed/ts-sdk/**/pnpm-lock.yaml"]'
 
   ts-express:
     runs-on: ubuntu-latest
@@ -1078,6 +1081,175 @@ jobs:
             exit 1
           fi
 
+  collect-allowed-failures:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [setup, changes, get-all-test-matrices]
+    if: >-
+      ${{
+        always() && !cancelled() && needs.setup.outputs.post-metrics == 'true'
+      }}
+    strategy:
+      fail-fast: false # Let all collections run, even if some fail
+      matrix:
+        seed-generator-alias:
+          [
+            ruby-model,
+            ruby-sdk,
+            ruby-sdk-v2,
+            pydantic,
+            python-sdk,
+            fastapi,
+            openapi,
+            postman,
+            java-sdk,
+            java-model,
+            java-spring,
+            ts-sdk,
+            ts-express,
+            go-fiber,
+            go-model,
+            go-sdk,
+            csharp-model,
+            csharp-sdk,
+            php-model,
+            php-sdk,
+            swift-sdk,
+            rust-model,
+            rust-sdk
+          ]
+    outputs:
+      ruby-model-total-fixtures-count: ${{ steps.extract-all-fixture-info.outputs.ruby-model-total-fixtures-count }}
+      ruby-model-allowed-failures: ${{ steps.extract-all-fixture-info.outputs.ruby-model-allowed-failures }}
+      ruby-model-allowed-failures-count: ${{ steps.extract-all-fixture-info.outputs.ruby-model-allowed-failures-count }}
+
+      ruby-sdk-total-fixtures-count: ${{ steps.extract-all-fixture-info.outputs.ruby-sdk-total-fixtures-count }}
+      ruby-sdk-allowed-failures: ${{ steps.extract-all-fixture-info.outputs.ruby-sdk-allowed-failures }}
+      ruby-sdk-allowed-failures-count: ${{ steps.extract-all-fixture-info.outputs.ruby-sdk-allowed-failures-count }}
+
+      ruby-sdk-v2-total-fixtures-count: ${{ steps.extract-all-fixture-info.outputs.ruby-sdk-v2-total-fixtures-count }}
+      ruby-sdk-v2-allowed-failures: ${{ steps.extract-all-fixture-info.outputs.ruby-sdk-v2-allowed-failures }}
+      ruby-sdk-v2-allowed-failures-count: ${{ steps.extract-all-fixture-info.outputs.ruby-sdk-v2-allowed-failures-count }}
+
+      pydantic-total-fixtures-count: ${{ steps.extract-all-fixture-info.outputs.pydantic-total-fixtures-count }}
+      pydantic-allowed-failures: ${{ steps.extract-all-fixture-info.outputs.pydantic-allowed-failures }}
+      pydantic-allowed-failures-count: ${{ steps.extract-all-fixture-info.outputs.pydantic-allowed-failures-count }}
+
+      python-sdk-total-fixtures-count: ${{ steps.extract-all-fixture-info.outputs.python-sdk-total-fixtures-count }}
+      python-sdk-allowed-failures: ${{ steps.extract-all-fixture-info.outputs.python-sdk-allowed-failures }}
+      python-sdk-allowed-failures-count: ${{ steps.extract-all-fixture-info.outputs.python-sdk-allowed-failures-count }}
+
+      fastapi-total-fixtures-count: ${{ steps.extract-all-fixture-info.outputs.fastapi-total-fixtures-count }}
+      fastapi-allowed-failures: ${{ steps.extract-all-fixture-info.outputs.fastapi-allowed-failures }}
+      fastapi-allowed-failures-count: ${{ steps.extract-all-fixture-info.outputs.fastapi-allowed-failures-count }}
+
+      openapi-total-fixtures-count: ${{ steps.extract-all-fixture-info.outputs.openapi-total-fixtures-count }}
+      openapi-allowed-failures: ${{ steps.extract-all-fixture-info.outputs.openapi-allowed-failures }}
+      openapi-allowed-failures-count: ${{ steps.extract-all-fixture-info.outputs.openapi-allowed-failures-count }}
+
+      postman-total-fixtures-count: ${{ steps.extract-all-fixture-info.outputs.postman-total-fixtures-count }}
+      postman-allowed-failures: ${{ steps.extract-all-fixture-info.outputs.postman-allowed-failures }}
+      postman-allowed-failures-count: ${{ steps.extract-all-fixture-info.outputs.postman-allowed-failures-count }}
+
+      java-sdk-total-fixtures-count: ${{ steps.extract-all-fixture-info.outputs.java-sdk-total-fixtures-count }}
+      java-sdk-allowed-failures: ${{ steps.extract-all-fixture-info.outputs.java-sdk-allowed-failures }}
+      java-sdk-allowed-failures-count: ${{ steps.extract-all-fixture-info.outputs.java-sdk-allowed-failures-count }}
+
+      java-model-total-fixtures-count: ${{ steps.extract-all-fixture-info.outputs.java-model-total-fixtures-count }}
+      java-model-allowed-failures: ${{ steps.extract-all-fixture-info.outputs.java-model-allowed-failures }}
+      java-model-allowed-failures-count: ${{ steps.extract-all-fixture-info.outputs.java-model-allowed-failures-count }}
+
+      java-spring-total-fixtures-count: ${{ steps.extract-all-fixture-info.outputs.java-spring-total-fixtures-count }}
+      java-spring-allowed-failures: ${{ steps.extract-all-fixture-info.outputs.java-spring-allowed-failures }}
+      java-spring-allowed-failures-count: ${{ steps.extract-all-fixture-info.outputs.java-spring-allowed-failures-count }}
+
+      ts-sdk-total-fixtures-count: ${{ steps.extract-all-fixture-info.outputs.ts-sdk-total-fixtures-count }}
+      ts-sdk-allowed-failures: ${{ steps.extract-all-fixture-info.outputs.ts-sdk-allowed-failures }}
+      ts-sdk-allowed-failures-count: ${{ steps.extract-all-fixture-info.outputs.ts-sdk-allowed-failures-count }}
+
+      ts-express-total-fixtures-count: ${{ steps.extract-all-fixture-info.outputs.ts-express-total-fixtures-count }}
+      ts-express-allowed-failures: ${{ steps.extract-all-fixture-info.outputs.ts-express-allowed-failures }}
+      ts-express-allowed-failures-count: ${{ steps.extract-all-fixture-info.outputs.ts-express-allowed-failures-count }}
+
+      go-fiber-total-fixtures-count: ${{ steps.extract-all-fixture-info.outputs.go-fiber-total-fixtures-count }}
+      go-fiber-allowed-failures: ${{ steps.extract-all-fixture-info.outputs.go-fiber-allowed-failures }}
+      go-fiber-allowed-failures-count: ${{ steps.extract-all-fixture-info.outputs.go-fiber-allowed-failures-count }}
+
+      go-model-total-fixtures-count: ${{ steps.extract-all-fixture-info.outputs.go-model-total-fixtures-count }}
+      go-model-allowed-failures: ${{ steps.extract-all-fixture-info.outputs.go-model-allowed-failures }}
+      go-model-allowed-failures-count: ${{ steps.extract-all-fixture-info.outputs.go-model-allowed-failures-count }}
+
+      go-sdk-total-fixtures-count: ${{ steps.extract-all-fixture-info.outputs.go-sdk-total-fixtures-count }}
+      go-sdk-allowed-failures: ${{ steps.extract-all-fixture-info.outputs.go-sdk-allowed-failures }}
+      go-sdk-allowed-failures-count: ${{ steps.extract-all-fixture-info.outputs.go-sdk-allowed-failures-count }}
+
+      csharp-model-total-fixtures-count: ${{ steps.extract-all-fixture-info.outputs.csharp-model-total-fixtures-count }}
+      csharp-model-allowed-failures: ${{ steps.extract-all-fixture-info.outputs.csharp-model-allowed-failures }}
+      csharp-model-allowed-failures-count: ${{ steps.extract-all-fixture-info.outputs.csharp-model-allowed-failures-count }}
+
+      csharp-sdk-total-fixtures-count: ${{ steps.extract-all-fixture-info.outputs.csharp-sdk-total-fixtures-count }}
+      csharp-sdk-allowed-failures: ${{ steps.extract-all-fixture-info.outputs.csharp-sdk-allowed-failures }}
+      csharp-sdk-allowed-failures-count: ${{ steps.extract-all-fixture-info.outputs.csharp-sdk-allowed-failures-count }}
+
+      php-model-total-fixtures-count: ${{ steps.extract-all-fixture-info.outputs.php-model-total-fixtures-count }}
+      php-model-allowed-failures: ${{ steps.extract-all-fixture-info.outputs.php-model-allowed-failures }}
+      php-model-allowed-failures-count: ${{ steps.extract-all-fixture-info.outputs.php-model-allowed-failures-count }}
+
+      php-sdk-total-fixtures-count: ${{ steps.extract-all-fixture-info.outputs.php-sdk-total-fixtures-count }}
+      php-sdk-allowed-failures: ${{ steps.extract-all-fixture-info.outputs.php-sdk-allowed-failures }}
+      php-sdk-allowed-failures-count: ${{ steps.extract-all-fixture-info.outputs.php-sdk-allowed-failures-count }}
+
+      swift-sdk-total-fixtures-count: ${{ steps.extract-all-fixture-info.outputs.swift-sdk-total-fixtures-count }}
+      swift-sdk-allowed-failures: ${{ steps.extract-all-fixture-info.outputs.swift-sdk-allowed-failures }}
+      swift-sdk-allowed-failures-count: ${{ steps.extract-all-fixture-info.outputs.swift-sdk-allowed-failures-count }}
+
+      rust-model-total-fixtures-count: ${{ steps.extract-all-fixture-info.outputs.rust-model-total-fixtures-count }}
+      rust-model-allowed-failures: ${{ steps.extract-all-fixture-info.outputs.rust-model-allowed-failures }}
+      rust-model-allowed-failures-count: ${{ steps.extract-all-fixture-info.outputs.rust-model-allowed-failures-count }}
+
+      rust-sdk-total-fixtures-count: ${{ steps.extract-all-fixture-info.outputs.rust-sdk-total-fixtures-count }}
+      rust-sdk-allowed-failures: ${{ steps.extract-all-fixture-info.outputs.rust-sdk-allowed-failures }}
+      rust-sdk-allowed-failures-count: ${{ steps.extract-all-fixture-info.outputs.rust-sdk-allowed-failures-count }}
+    steps:
+      - name: Checkout Files with Test Info
+        uses: actions/checkout@v4
+        with:
+          # Only need most recent commit
+          fetch-depth: 1
+          sparse-checkout: |
+            seed/${{ matrix.seed-generator-alias }}/seed.yml
+            .github/workflow-resource-files/seed-groups/${{ matrix.seed-generator-alias }}-seed-groups.json
+
+      - name: Extract All Fixture Info
+        shell: bash
+        id: extract-all-fixture-info
+        run: |
+          # Extract total fixture count from groups in balanced test file into a single value
+          FIXTURE_COUNT=$(jq '.groups | map(.fixtures) | flatten | length' .github/workflow-resource-files/seed-groups/${{ matrix.seed-generator-alias }}-seed-groups.json)
+
+          # Output for debugging
+          echo "Found $FIXTURE_COUNT total fixtures"
+
+          # Set defaults for allowed failures data
+          ALLOWED_FAILURES="[]"
+          ALLOWED_FAILURES_COUNT=0
+
+          # Read allowed failures from yml file as JSON data, if it exists
+          if [[ $(yq 'has("allowedFailures")' seed/${{ matrix.seed-generator-alias }}/seed.yml) == "true" ]]; then
+            # Parameter exists, extract allowed failures as JSON data from file
+            ALLOWED_FAILURES=$(yq -o json '.allowedFailures' seed/${{ matrix.seed-generator-alias }}/seed.yml)
+            ALLOWED_FAILURES_COUNT=$(echo "$ALLOWED_FAILURES" | jq 'length')
+          fi
+
+          # Output for debugging
+          echo "Found $ALLOWED_FAILURES_COUNT total allowed failures"
+          echo "$ALLOWED_FAILURES" | jq .
+
+          # Set outputs
+          echo "${{ matrix.seed-generator-alias }}-total-fixtures-count=$FIXTURE_COUNT" >> $GITHUB_OUTPUT
+          echo "${{ matrix.seed-generator-alias }}-allowed-failures=$(echo "$ALLOWED_FAILURES" | jq -c .)" >> $GITHUB_OUTPUT
+          echo "${{ matrix.seed-generator-alias }}-allowed-failures-count=$ALLOWED_FAILURES_COUNT" >> $GITHUB_OUTPUT
+
   post-metrics:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -1107,11 +1279,12 @@ jobs:
         php-sdk,
         swift-sdk,
         rust-model,
-        rust-sdk
+        rust-sdk,
+        collect-allowed-failures
       ]
     if: ${{ always() && !cancelled() && needs.setup.outputs.post-metrics == 'true' }}
     strategy:
-      fail-fast: false # Let all tests run, even if some fail
+      fail-fast: false # Let all posts run, even if some fail
       matrix:
         seed-generator-alias:
           [
@@ -1213,6 +1386,16 @@ jobs:
 
           echo "all_tests_passing=$all_tests_passing" >> $GITHUB_OUTPUT
 
+          # Determine if all of seed generation is deterministic for a given generator. One reporting as a failure means the collective is a failure.
+          all_seed_files_deterministic=$(find "./$METRICS_PATH" -name "$METRICS_PATTERN" -exec jq -r '.deterministic' {} \; | grep -v -q "true" && echo "false" || echo "true")
+
+          # If empty for any reason, default to false
+          if [ -z "$all_seed_files_deterministic" ]; then
+            all_seed_files_deterministic="false"
+          fi
+
+          echo "all_seed_files_deterministic=$all_seed_files_deterministic" >> $GITHUB_OUTPUT
+
       - name: Post to PostHog
         # https://github.com/PostHog/posthog-github-action
         uses: PostHog/posthog-github-action@v0.1
@@ -1226,5 +1409,9 @@ jobs:
               "seed_generator_alias": "${{ matrix.seed-generator-alias }}",
               "run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
               "duration_seconds": ${{ steps.parse-seed-test-metrics.outputs.duration_seconds }},
-              "all_tests_passing": "${{ steps.parse-seed-test-metrics.outputs.all_tests_passing }}"
+              "all_tests_passing": "${{ steps.parse-seed-test-metrics.outputs.all_tests_passing }}",
+              "all_seed_files_deterministic": "${{ steps.parse-seed-test-metrics.outputs.all_seed_files_deterministic }}",
+              "total_fixture_count": ${{ needs.collect-allowed-failures.outputs[format('{0}-total-fixtures-count', matrix.seed-generator-alias)] }},
+              "allowed_failures": ${{ needs.collect-allowed-failures.outputs[format('{0}-allowed-failures', matrix.seed-generator-alias)] }},
+              "allowed_failures_count": ${{ needs.collect-allowed-failures.outputs[format('{0}-allowed-failures-count', matrix.seed-generator-alias)] }}
             }


### PR DESCRIPTION
## Description
Linear ticket: https://linear.app/buildwithfern/issue/FER-7274/ci-add-back-a-means-of-checking-if-generators-are-deterministic and https://linear.app/buildwithfern/issue/FER-7346/ci-add-allowed-failures-total-fixtures-and-determinism-data-to-posthog
Closes FER-7274 and Closes FER-7346
Running a test for determinism (does overnight run of seed match the results checked into the code) and adding more info to PostHog collection from overnight metrics run

## Changes Made
- Added test for determinism in seed metrics run overnight
- Collect allowed failures, allowed failures total, determinism, and fixtures total to PostHog dat

## Testing
- Verified in CI here: https://github.com/fern-api/fern/actions/runs/18722087190
