### PR TITLE
fix(internal): fix broken recursive handling of escaped `$`

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Fix broken recursive unescaping of \ during handling of \$ in IR generation.
+      type: fix
+  irVersion: 61
+  createdAt: "2025-10-23"
+  version: 0.94.3
+
+- changelogEntry:
+    - summary: |
         Improve IR hashing in IntermediateRepresentationChangeDetector.
         Previously it looked at the entire IR. Now it only compares the
         parts of the IR that describe the API interface.
@@ -61,9 +69,9 @@
 
 - changelogEntry:
     - summary: |
-        Turns HTTP snippets on by default in docs generation. 
+        Turns HTTP snippets on by default in docs generation.
 
-        To turn HTTP snippets off, set `settings.http-snippets: false` in the `docs.yml` file. You can also specify an explicit list of snippets to include. 
+        To turn HTTP snippets off, set `settings.http-snippets: false` in the `docs.yml` file. You can also specify an explicit list of snippets to include.
 
         ```docs.yml
         # this will only generate typescript and python snippets, no curl
@@ -79,7 +87,7 @@
 
 - changelogEntry:
     - summary: |
-        For debugging purposes, generating a docs preview via `fern generate --docs --preview`, it is now possible to specify `--skip-upload` to 
+        For debugging purposes, generating a docs preview via `fern generate --docs --preview`, it is now possible to specify `--skip-upload` to
         skip the asset uploading step.
       type: feat
   irVersion: 61
@@ -215,7 +223,7 @@
 
         page-actions:
           default: cursor
-          options: 
+          options:
             chatgpt: false
             claude: true
             vscode: true
@@ -244,7 +252,7 @@
 
 - changelogEntry:
     - summary: |
-        Fixes `displayName` generation to be stricter for `oneOf` variants. 
+        Fixes `displayName` generation to be stricter for `oneOf` variants.
         Now, a display name will be set if a `summary` or `title` is provided for a variant, otherwise none will be generated.
       type: fix
   irVersion: 60

--- a/packages/cli/generation/ir-generator/src/converters/type-declarations/convertExampleType.ts
+++ b/packages/cli/generation/ir-generator/src/converters/type-declarations/convertExampleType.ts
@@ -396,11 +396,6 @@ function convertPrimitiveExample({
     example: RawSchemas.ExampleTypeReferenceSchema;
     typeBeingExemplified: PrimitiveTypeV1;
 }): ExampleTypeReferenceShape {
-    // Handle escaped dollar signs (e.g., "\$100" becomes "$100")
-    if (typeof example === "string" && example.startsWith(`\\${EXAMPLE_REFERENCE_PREFIX}`)) {
-        example = example.slice(1);
-    }
-
     return PrimitiveTypeV1._visit(typeBeingExemplified, {
         string: () => {
             if (typeof example !== "string") {
@@ -410,9 +405,12 @@ function convertPrimitiveExample({
                     })
                 );
             }
+
+            // remove initial \
+            const unescaped = example.startsWith(`\\${EXAMPLE_REFERENCE_PREFIX}`) ? example.slice(1) : example;
             return ExampleTypeReferenceShape.primitive(
                 ExamplePrimitive.string({
-                    original: example
+                    original: unescaped
                 })
             );
         },

--- a/packages/cli/generation/ir-generator/src/converters/type-declarations/convertExampleType.ts
+++ b/packages/cli/generation/ir-generator/src/converters/type-declarations/convertExampleType.ts
@@ -1,6 +1,7 @@
 import { FernWorkspace } from "@fern-api/api-workspace-commons";
 import { assertNever, Examples, isPlainObject } from "@fern-api/core-utils";
 import {
+    EXAMPLE_REFERENCE_PREFIX,
     isRawAliasDefinition,
     isRawObjectDefinition,
     RawSchemas,
@@ -395,6 +396,11 @@ function convertPrimitiveExample({
     example: RawSchemas.ExampleTypeReferenceSchema;
     typeBeingExemplified: PrimitiveTypeV1;
 }): ExampleTypeReferenceShape {
+    // Handle escaped dollar signs (e.g., "\$100" becomes "$100")
+    if (typeof example === "string" && example.startsWith(`\\${EXAMPLE_REFERENCE_PREFIX}`)) {
+        example = example.slice(1);
+    }
+
     return PrimitiveTypeV1._visit(typeBeingExemplified, {
         string: () => {
             if (typeof example !== "string") {

--- a/packages/cli/generation/ir-generator/src/resolvers/ExampleResolver.ts
+++ b/packages/cli/generation/ir-generator/src/resolvers/ExampleResolver.ts
@@ -109,6 +109,20 @@ export class ExampleResolverImpl implements ExampleResolver {
             };
         }
 
+        const resolved = this.resolveExampleReference(example, file);
+        if (resolved == null) {
+            // If example reference resolution fails, fallback to treating as literal string;
+            // this allows strings like $123.45 to still be used
+            // NOTE(patrick): should we throw a warning when doing this, or is that too messy?
+            return { resolvedExample: example, file };
+        }
+        return resolved;
+    }
+
+    private resolveExampleReference(
+        example: string,
+        file: FernFileContext
+    ): { resolvedExample: unknown; file: FernFileContext } | undefined {
         const parsedExampleReference = this.parseExampleReference(example);
         if (parsedExampleReference == null) {
             return undefined;

--- a/packages/cli/generation/ir-generator/src/resolvers/ExampleResolver.ts
+++ b/packages/cli/generation/ir-generator/src/resolvers/ExampleResolver.ts
@@ -94,14 +94,6 @@ export class ExampleResolverImpl implements ExampleResolver {
             };
         }
 
-        if (example.startsWith(`\\${EXAMPLE_REFERENCE_PREFIX}`)) {
-            return {
-                // remove backslash
-                resolvedExample: example.slice(1),
-                file
-            };
-        }
-
         if (!example.startsWith(EXAMPLE_REFERENCE_PREFIX)) {
             return {
                 resolvedExample: example,

--- a/packages/cli/generation/ir-generator/src/resolvers/ExampleResolver.ts
+++ b/packages/cli/generation/ir-generator/src/resolvers/ExampleResolver.ts
@@ -101,14 +101,7 @@ export class ExampleResolverImpl implements ExampleResolver {
             };
         }
 
-        const resolved = this.resolveExampleReference(example, file);
-        if (resolved == null) {
-            // If example reference resolution fails, fallback to treating as literal string;
-            // this allows strings like $123.45 to still be used
-            // NOTE(patrick): should we throw a warning when doing this, or is that too messy?
-            return { resolvedExample: example, file };
-        }
-        return resolved;
+        return this.resolveExampleReference(example, file);
     }
 
     private resolveExampleReference(

--- a/packages/cli/generation/ir-generator/src/resolvers/ExampleResolver.ts
+++ b/packages/cli/generation/ir-generator/src/resolvers/ExampleResolver.ts
@@ -38,9 +38,17 @@ export class ExampleResolverImpl implements ExampleResolver {
                 example,
                 file
             });
-            if (resolvedExample == null || typeof resolvedExample.resolvedExample === "string") {
+
+            if (resolvedExample == null) {
                 return resolvedExample;
             }
+            if (typeof resolvedExample.resolvedExample === "string") {
+                if (resolvedExample.resolvedExample.startsWith(`\\${EXAMPLE_REFERENCE_PREFIX}`)) {
+                    resolvedExample.resolvedExample = resolvedExample.resolvedExample.slice(1);
+                }
+                return resolvedExample;
+            }
+
             return this.resolveAllReferencesInExample({
                 example: resolvedExample.resolvedExample,
                 file: resolvedExample.file

--- a/test-definitions/fern/apis/examples/definition/types.yml
+++ b/test-definitions/fern/apis/examples/definition/types.yml
@@ -48,7 +48,7 @@ types:
               rottenTomatoes: 97
               imdb: 7.6
           revenue: 1000000
-          price: $12.34
+          price: \$12.34
       - name: LargeRating
         value:
           id: movie-large-123

--- a/test-definitions/fern/apis/examples/definition/types.yml
+++ b/test-definitions/fern/apis/examples/definition/types.yml
@@ -48,6 +48,7 @@ types:
               rottenTomatoes: 97
               imdb: 7.6
           revenue: 1000000
+          price: $12.34
       - name: LargeRating
         value:
           id: movie-large-123

--- a/test-definitions/fern/apis/examples/definition/types.yml
+++ b/test-definitions/fern/apis/examples/definition/types.yml
@@ -48,7 +48,6 @@ types:
               rottenTomatoes: 97
               imdb: 7.6
           revenue: 1000000
-          price: \$12.34
       - name: LargeRating
         value:
           id: movie-large-123


### PR DESCRIPTION
## Description
Linear ticket: Fixes FER-7358
Examples that began with `$` are treated as references to other examples; if these examples failed to parse, an error was thrown. ~~Now, we fall back to treating them as literal strings; this allows examples with values like `$12.34` to work without crashing the generator.~~ This error-throwing is correct; instead, this PR just fixes a case where the unescaping of escaped `$`s in the Fern Definition would accidentally happen more than once due to some weird recursion interactions.

This was a gnarly bug: essentially, we resolve referenced examples recursively, and there were cases where the first visit would strip the escape character from an escaped reference (`\$something` to `$something`) and then the second visit would then try and resolve the reference, which would break things. The fix involves placing the stripping of the escape character in strategic spots to avoid it getting unduly retriggered by recursive calls.

## Changes Made
Change to `ExampleResolver.ts` in the IR generator.

## Testing
Generating seed tests now, but works for Webflow.
- [X] Unit tests added/updated
- [X] Manual testing completed
