### PR TITLE
chore(internal): Make config optional in generators.yml

### DIFF
--- a/fern/apis/generators-yml/definition/group.yml
+++ b/fern/apis/generators-yml/definition/group.yml
@@ -22,7 +22,7 @@ types:
       version: string
       output: optional<GeneratorOutputSchema>
       github: optional<GithubConfigurationSchema>
-      config: unknown
+      config: optional<unknown>
       metadata: optional<GeneratorPublishMetadataSchema>
       keywords:
         type: optional<list<string>>

--- a/generators-yml.schema.json
+++ b/generators-yml.schema.json
@@ -3205,13 +3205,20 @@
           ]
         },
         "config": {
-          "type": [
-            "string",
-            "number",
-            "boolean",
-            "object",
-            "array",
-            "null"
+          "oneOf": [
+            {
+              "type": [
+                "string",
+                "number",
+                "boolean",
+                "object",
+                "array",
+                "null"
+              ]
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "metadata": {
@@ -3300,8 +3307,7 @@
       },
       "required": [
         "name",
-        "version",
-        "config"
+        "version"
       ],
       "additionalProperties": false
     },

--- a/packages/cli/configuration/src/generators-yml/schemas/serialization/resources/group/types/GeneratorInvocationSchema.ts
+++ b/packages/cli/configuration/src/generators-yml/schemas/serialization/resources/group/types/GeneratorInvocationSchema.ts
@@ -19,7 +19,7 @@ export const GeneratorInvocationSchema: core.serialization.ObjectSchema<
     version: core.serialization.string(),
     output: GeneratorOutputSchema.optional(),
     github: GithubConfigurationSchema.optional(),
-    config: core.serialization.unknown(),
+    config: core.serialization.unknown().optional(),
     metadata: GeneratorPublishMetadataSchema.optional(),
     keywords: core.serialization.list(core.serialization.string()).optional(),
     snippets: GeneratorSnippetsSchema.optional(),
@@ -36,7 +36,7 @@ export declare namespace GeneratorInvocationSchema {
         version: string;
         output?: GeneratorOutputSchema.Raw | null;
         github?: GithubConfigurationSchema.Raw | null;
-        config?: unknown;
+        config?: unknown | null;
         metadata?: GeneratorPublishMetadataSchema.Raw | null;
         keywords?: string[] | null;
         snippets?: GeneratorSnippetsSchema.Raw | null;


### PR DESCRIPTION
## Description
Make config optional in generators.yml

Since customers use the jsonschema in their generators.yml file, the missing `config` property is often reported as an error, when it can in fact be omitted.

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated
- [x] Manual testing completed
