### PR TITLE
fix(swift): fix dynamic snippets package bundling

### DIFF
--- a/generators/swift/dynamic-snippets/build.cjs
+++ b/generators/swift/dynamic-snippets/build.cjs
@@ -18,6 +18,7 @@ async function main() {
     minify: true,
     dts: true,
     sourcemap: true,
+    external: ["@fern-api/swift-codegen"],
     esbuildPlugins: [
       NodeModulesPolyfillPlugin(),
       NodeGlobalsPolyfillPlugin({

--- a/generators/swift/dynamic-snippets/build.cjs
+++ b/generators/swift/dynamic-snippets/build.cjs
@@ -1,77 +1,78 @@
-const { NodeModulesPolyfillPlugin } = require('@esbuild-plugins/node-modules-polyfill');
-const { NodeGlobalsPolyfillPlugin } = require('@esbuild-plugins/node-globals-polyfill');
+const {
+  NodeModulesPolyfillPlugin,
+} = require("@esbuild-plugins/node-modules-polyfill");
+const {
+  NodeGlobalsPolyfillPlugin,
+} = require("@esbuild-plugins/node-globals-polyfill");
 const packageJson = require("./package.json");
-const tsup = require('tsup');
+const tsup = require("tsup");
 const { writeFile, mkdir } = require("fs/promises");
 const path = require("path");
 
 main();
 
 async function main() {
-    const config = {
-        entry: ['src/**/*.ts', '!src/__test__'],
-        target: "es2017",
-        minify: true,
-        dts: true,
-        sourcemap: true,
-        esbuildPlugins: [
-            NodeModulesPolyfillPlugin(),
-            NodeGlobalsPolyfillPlugin({
-                process: true,
-                buffer: true,
-                util: true
-            })
-        ],
-        tsconfig: "./build.tsconfig.json"
-    };
+  const config = {
+    entry: ["src/**/*.ts", "!src/__test__"],
+    target: "es2017",
+    minify: true,
+    dts: true,
+    sourcemap: true,
+    esbuildPlugins: [
+      NodeModulesPolyfillPlugin(),
+      NodeGlobalsPolyfillPlugin({
+        process: true,
+        buffer: true,
+        util: true,
+      }),
+    ],
+    tsconfig: "./build.tsconfig.json",
+  };
 
-    await tsup.build({
-        ...config,
-        format: ['cjs'],
-        outDir: 'dist/cjs',
-        clean: true,
-    });
+  await tsup.build({
+    ...config,
+    format: ["cjs"],
+    outDir: "dist/cjs",
+    clean: true,
+  });
 
-    await tsup.build({
-        ...config,
-        format: ['esm'],
-        outDir: 'dist/esm',
-        clean: false,
-    });
+  await tsup.build({
+    ...config,
+    format: ["esm"],
+    outDir: "dist/esm",
+    clean: false,
+  });
 
-    await mkdir(path.join(__dirname, "dist"), { recursive: true });
-    process.chdir(path.join(__dirname, "dist"));
+  await mkdir(path.join(__dirname, "dist"), { recursive: true });
+  process.chdir(path.join(__dirname, "dist"));
 
-    await writeFile(
-        "package.json",
-        JSON.stringify(
-            {
-                name: packageJson.name,
-                version: process.argv[2] || packageJson.version,
-                repository: packageJson.repository,
-                type: "module",
-                exports: {
-                    // Conditional exports for ESM and CJS.
-                    "import": {
-                        "types": "./esm/index.d.ts",
-                        "default": "./esm/index.js"
-                    },
-                    "require": {
-                        "types": "./cjs/index.d.cts",
-                        "default": "./cjs/index.cjs"
-                    }
-                },
-                // Fallback for older tooling or direct imports.
-                main: "./cjs/index.cjs",
-                module: "./esm/index.js",
-                types: "./cjs/index.d.cts",
-                files: [
-                    "cjs",
-                    "esm"
-                ]
-            },
-            undefined,
-            2
-        )
-    );
+  await writeFile(
+    "package.json",
+    JSON.stringify(
+      {
+        name: packageJson.name,
+        version: process.argv[2] || packageJson.version,
+        repository: packageJson.repository,
+        type: "module",
+        exports: {
+          // Conditional exports for ESM and CJS.
+          import: {
+            types: "./esm/index.d.ts",
+            default: "./esm/index.js",
+          },
+          require: {
+            types: "./cjs/index.d.cts",
+            default: "./cjs/index.cjs",
+          },
+        },
+        // Fallback for older tooling or direct imports.
+        main: "./cjs/index.cjs",
+        module: "./esm/index.js",
+        types: "./cjs/index.d.cts",
+        files: ["cjs", "esm"],
+      },
+      undefined,
+      2,
+    ),
+  );
 }


### PR DESCRIPTION
## Description
Linear ticket: [FER-7389](https://linear.app/buildwithfern/issue/FER-7389/fix-dynamic-snippets-package-bundling-error)
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
<!-- Provide a clear and concise description of the changes made in this PR -->

Adds an external dependency exclusion for `@fern-api/swift-codegen` in tsup config for dynamic snippets build script.

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Updated build.cjs to in dynamic snippets package to add `external: ["@fern-api/swift-codegen"]` and formatted the file.

## Testing
<!-- Describe how you tested these changes -->
- [ ] Unit tests added/updated
- [x] Manual testing completed
