### PR TITLE
fix(swift): remove `base-generator` dependency from `codegen`

### DIFF
--- a/generators/swift/codegen/package.json
+++ b/generators/swift/codegen/package.json
@@ -31,7 +31,6 @@
     "test:update": "vitest --run -u"
   },
   "dependencies": {
-    "@fern-api/base-generator": "workspace:*",
     "@fern-api/browser-compatible-base-generator": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
     "lodash-es": "^4.17.21",

--- a/generators/swift/codegen/src/ast/core/AstNode.ts
+++ b/generators/swift/codegen/src/ast/core/AstNode.ts
@@ -1,4 +1,4 @@
-import { AbstractAstNode } from "@fern-api/base-generator";
+import { AbstractAstNode } from "@fern-api/browser-compatible-base-generator";
 
 import { Writer } from "./Writer";
 

--- a/generators/swift/codegen/src/ast/core/Writer.ts
+++ b/generators/swift/codegen/src/ast/core/Writer.ts
@@ -1,4 +1,4 @@
-import { AbstractWriter } from "@fern-api/base-generator";
+import { AbstractWriter } from "@fern-api/browser-compatible-base-generator";
 
 export class Writer extends AbstractWriter {
     public toString(): string {

--- a/generators/swift/dynamic-snippets/build.cjs
+++ b/generators/swift/dynamic-snippets/build.cjs
@@ -18,7 +18,6 @@ async function main() {
     minify: true,
     dts: true,
     sourcemap: true,
-    external: ["@fern-api/swift-codegen"],
     esbuildPlugins: [
       NodeModulesPolyfillPlugin(),
       NodeGlobalsPolyfillPlugin({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2146,9 +2146,6 @@ importers:
 
   generators/swift/codegen:
     dependencies:
-      '@fern-api/base-generator':
-        specifier: workspace:*
-        version: link:../../base
       '@fern-api/browser-compatible-base-generator':
         specifier: workspace:*
         version: link:../../browser-compatible-base


### PR DESCRIPTION
## Description
Linear ticket: n/a 
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
<!-- Provide a clear and concise description of the changes made in this PR -->
Updates `@fern-api/swift-codegen` to rely only on `@fern-api/browser-compatible-base-generator` and remove the `@fern-api/base-generator` dependency and updates the bundling config in dynamic snippets to longer include `external`.

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Deleted `@fern-api/base-generator` from codegen dependencies
- `AbstractAstNode` and `AbstractWriter` are now imported from `@fern-api/browser-compatible-base-generator`
- Removed `external` config option from dynamic snippets bundling script

## Testing
<!-- Describe how you tested these changes -->
- [ ] Unit tests added/updated
- [x] Manual testing completed
