### PR TITLE
Clean up raw response snippets

### DIFF
--- a/generators/python/sdk/features.yml
+++ b/generators/python/sdk/features.yml
@@ -24,7 +24,7 @@ features:
     advanced: true
     description: |
       The SDK provides access to raw response data, including headers, through the `.with_raw_response` property.
-      The `.with_raw_response` property returns a "raw" client that can be used to access the `.headers` and `.data` attributes.
+      The `.with_raw_response` property returns a "raw" client whose response objects have `.headers` and `.data` properties.
 
   - id: RETRIES
     description: |

--- a/generators/python/src/fern_python/generator_cli/readme_snippet_builder.py
+++ b/generators/python/src/fern_python/generator_cli/readme_snippet_builder.py
@@ -205,6 +205,7 @@ client.{endpoint.endpoint_package_path}{endpoint.method_name}({"..., " if has_pa
     def _build_access_raw_response_data_snippets(self) -> List[str]:
         def write(writer: AST.NodeWriter) -> None:
             writer.write_node(
+                # todo(tedks): Remove this
                 AST.VariableDeclaration(
                     name="client",
                     initializer=AST.Expression(
@@ -252,6 +253,7 @@ client.{endpoint.endpoint_package_path}{endpoint.method_name}({"..., " if has_pa
                         ),
                     )
                 )
+                # todo(tedks): Just manually fix this line
                 writer.write_line("print(response.headers)  # access the response headers")
                 writer.write_line("print(response.data)  # access the underlying object")
 

--- a/generators/python/src/fern_python/generator_cli/readme_snippet_builder.py
+++ b/generators/python/src/fern_python/generator_cli/readme_snippet_builder.py
@@ -204,18 +204,6 @@ client.{endpoint.endpoint_package_path}{endpoint.method_name}({"..., " if has_pa
 
     def _build_access_raw_response_data_snippets(self) -> List[str]:
         def write(writer: AST.NodeWriter) -> None:
-            writer.write_node(
-                # todo(tedks): Remove this
-                AST.VariableDeclaration(
-                    name="client",
-                    initializer=AST.Expression(
-                        AST.ClassInstantiation(
-                            class_=self._root_client.sync_client.class_reference,
-                            args=[AST.Expression("...")],
-                        )
-                    ),
-                )
-            )
 
             endpoints_with_pagination_feature = self._filter_endpoint_ids_by_feature(
                 ReadmeSnippetBuilder.PAGINATION_FEATURE_ID

--- a/generators/python/src/fern_python/generator_cli/readme_snippet_builder.py
+++ b/generators/python/src/fern_python/generator_cli/readme_snippet_builder.py
@@ -241,9 +241,8 @@ client.{endpoint.endpoint_package_path}{endpoint.method_name}({"..., " if has_pa
                         ),
                     )
                 )
-                # todo(tedks): Just manually fix this line
-                writer.write_line("print(response.headers)  # access the response headers")
-                writer.write_line("print(response.data)  # access the underlying object")
+                writer.write_line("print(response.headers)")
+                writer.write_line("print(response.data)")
 
             if pagination_endpoint_id and (
                 endpoint := self._endpoint_metadata.get_endpoint_metadata(pagination_endpoint_id)


### PR DESCRIPTION
## Description
Linear ticket: Closes FER-6936
This change rephrases the raw response snippet to be more explicit and understandable, and removes unnecessary comments and instantiations from the generated snippet.

## Changes Made
- [ ] Updated README.md generator

## Testing
- [x] Manual testing with kombo-config
