### PR TITLE
chore(internal): pin `@fern-api/generator-cli` version in generator Docker images

### DIFF
--- a/generators/csharp/sdk/Dockerfile
+++ b/generators/csharp/sdk/Dockerfile
@@ -22,6 +22,6 @@ RUN dotnet tool install -g csharpier --version "1.1.2"
 COPY generators/csharp/sdk/features.yml /assets/features.yml
 COPY generators/csharp/sdk/dist /dist
 
-RUN npm install -f -g @fern-api/generator-cli
+RUN npm install -f -g @fern-api/generator-cli@0.2.0
 
 ENTRYPOINT ["node", "--enable-source-maps", "/dist/cli.cjs", "csharp-sdk"]

--- a/generators/go/fiber/Dockerfile
+++ b/generators/go/fiber/Dockerfile
@@ -37,6 +37,6 @@ RUN CGO_ENABLED=0 go build -ldflags "-s -w" -trimpath -buildvcs=false -o /fern-g
 
 RUN test -f /bin/go-v2 || echo "go-v2 CLI not found or not executable"
 
-RUN npm install -f -g @fern-api/generator-cli
+RUN npm install -f -g @fern-api/generator-cli@0.2.0
 
 ENTRYPOINT ["/fern-go-fiber"]

--- a/generators/go/sdk/Dockerfile
+++ b/generators/go/sdk/Dockerfile
@@ -37,6 +37,6 @@ RUN CGO_ENABLED=0 go build -ldflags "-s -w" -trimpath -buildvcs=false -o /fern-g
 
 RUN test -f /bin/go-v2 || echo "go-v2 CLI not found or not executable"
 
-RUN npm install -f -g @fern-api/generator-cli
+RUN npm install -f -g @fern-api/generator-cli@0.2.0
 
 ENTRYPOINT ["/fern-go-sdk"]

--- a/generators/java/sdk/Dockerfile
+++ b/generators/java/sdk/Dockerfile
@@ -29,6 +29,6 @@ RUN git config --global user.email "115122769+fern-api[bot]@users.noreply.github
 
 RUN test -f /bin/java-v2 || echo "java-v2 CLI not found or not executable"
 
-RUN npm install -f -g @fern-api/generator-cli
+RUN npm install -f -g @fern-api/generator-cli@0.2.0
 
 ENTRYPOINT ["sh", "/init.sh"]

--- a/generators/php/sdk/Dockerfile
+++ b/generators/php/sdk/Dockerfile
@@ -18,6 +18,6 @@ RUN curl -L https://cs.symfony.com/download/php-cs-fixer-v3.phar -o /usr/local/b
 COPY generators/php/sdk/features.yml /assets/features.yml
 COPY generators/php/sdk/dist /dist
 
-RUN npm install -f -g @fern-api/generator-cli
+RUN npm install -f -g @fern-api/generator-cli@0.2.0
 
 ENTRYPOINT ["node", "--enable-source-maps", "/dist/cli.cjs"]

--- a/generators/python/sdk/Dockerfile
+++ b/generators/python/sdk/Dockerfile
@@ -48,6 +48,6 @@ COPY ./generators/python/src ./src
 RUN git config --global user.email "115122769+fern-api[bot]@users.noreply.github.com" && \
     git config --global user.name "fern-api"
 
-RUN npm install -f -g @fern-api/generator-cli
+RUN npm install -f -g @fern-api/generator-cli@0.2.0
 
 ENTRYPOINT ["python", "-m", "src.fern_python.generators.sdk.cli"]

--- a/generators/ruby-v2/sdk/Dockerfile
+++ b/generators/ruby-v2/sdk/Dockerfile
@@ -13,7 +13,7 @@ RUN gem install rubocop rubocop-minitest
 
 RUN git config --global user.name "fern" && git config --global user.email "hey@buildwithfern.com"
 
-RUN npm install -f -g @fern-api/generator-cli
+RUN npm install -f -g @fern-api/generator-cli@0.2.0
 
 COPY generators/ruby-v2/sdk/features.yml /assets/features.yml
 COPY generators/ruby-v2/sdk/dist /dist

--- a/generators/rust/model/Dockerfile
+++ b/generators/rust/model/Dockerfile
@@ -8,6 +8,6 @@ RUN rustfmt --version  # Verify rustfmt is available
 
 COPY generators/rust/model/dist /dist
 
-RUN npm install -f -g @fern-api/generator-cli
+RUN npm install -f -g @fern-api/generator-cli@0.2.0
 
 ENTRYPOINT ["node", "--enable-source-maps", "/dist/cli.cjs", "rust-model"]

--- a/generators/rust/sdk/Dockerfile
+++ b/generators/rust/sdk/Dockerfile
@@ -13,6 +13,6 @@ COPY generators/rust/sdk/dist /dist
 COPY generators/rust/sdk/dist/asIs /asIs
 COPY generators/rust/sdk/features.yml /assets/features.yml
 
-RUN npm install -f -g @fern-api/generator-cli
+RUN npm install -f -g @fern-api/generator-cli@0.2.0
 
 ENTRYPOINT ["node", "--enable-source-maps", "/dist/cli.cjs", "rust-sdk"]

--- a/generators/typescript/sdk/cli/Dockerfile
+++ b/generators/typescript/sdk/cli/Dockerfile
@@ -57,8 +57,7 @@ RUN rm -rf /tmp/cache-warm
 
 WORKDIR /
 
-
-RUN npm install -f -g @fern-api/generator-cli
+RUN npm install -f -g @fern-api/generator-cli@0.2.0
 
 COPY generators/typescript/sdk/cli/dist/ /
 


### PR DESCRIPTION
## Description
Linear ticket: n/a 
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
<!-- Provide a clear and concise description of the changes made in this PR -->

Generators currently install the latest `@fern-api/generator-cli` globally in their Dockerfiles, which makes builds non-deterministic. This PR switches those installs to an exact, pinned version per generator to ensure reproducible builds.

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Replaced `RUN npm install -f -g @fern-api/generator-cli` with `RUN npm install -f -g @fern-api/generator-cli@0.2.0` in each generator

## Testing
<!-- Describe how you tested these changes -->
- [ ] Unit tests added/updated
- [ ] Manual testing completed
