### PR TITLE
chore(ci): Add file-upload-openapi to allowedFailure list for generators with file-upload as allowedFailures

### DIFF
--- a/seed/go-sdk/seed.yml
+++ b/seed/go-sdk/seed.yml
@@ -237,3 +237,4 @@ allowedFailures:
   # Will include these back in once we fix dynamic snippets for inline file properties
   - file-upload:no-custom-config 
   - file-upload:package-name 
+  - file-upload-openapi

--- a/seed/java-sdk/seed.yml
+++ b/seed/java-sdk/seed.yml
@@ -321,3 +321,4 @@ allowedFailures:
   - file-upload:no-custom-config
   - file-upload:wrapped-aliases
   - file-upload:inline-file-properties
+  - file-upload-openapi

--- a/seed/java-spring/seed.yml
+++ b/seed/java-spring/seed.yml
@@ -52,6 +52,7 @@ defaultOutputMode: local_files
 allowedFailures:
   - file-download
   - file-upload
+  - file-upload-openapi
   - plain-text
   - response-property
   - streaming

--- a/seed/ruby-sdk/seed.yml
+++ b/seed/ruby-sdk/seed.yml
@@ -135,6 +135,7 @@ allowedFailures:
   - streaming-parameter
   - trace
   - undiscriminated-unions
+  - undiscriminated-union-with-response-property
   - unions
   - unknown
   - url-form-encoded

--- a/seed/ruby-sdk/seed.yml
+++ b/seed/ruby-sdk/seed.yml
@@ -81,6 +81,7 @@ allowedFailures:
   - extra-properties
   - file-download
   - file-upload
+  - file-upload-openapi
   - folders
   - http-head
   - idempotency-headers

--- a/seed/ts-express/seed.yml
+++ b/seed/ts-express/seed.yml
@@ -93,6 +93,7 @@ allowedFailures:
   - bytes-upload
   - file-download
   - file-upload
+  - file-upload-openapi
   - multiple-request-bodies
   - plain-text
   - public-object


### PR DESCRIPTION
## Description
Linear ticket: Closes FER-7448
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
<!-- Provide a clear and concise description of the changes made in this PR -->
Updates any seed.yml allowedFailures list where file-upload was also allowed to fail (the new test leverages file-upload)

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Added to specific generators allowedFailures lists

## Testing
<!-- Describe how you tested these changes -->
- Will test via CI
