### PR TITLE
chore(go): Run reserved-keywords fixture for go-sdk but allow it to fail

### DIFF
--- a/seed/go-sdk/seed.yml
+++ b/seed/go-sdk/seed.yml
@@ -198,7 +198,6 @@ fixtures:
     - outputFolder: default-values
       customConfig:
         useDefaultRequestParameterValues: true
-  reserved-keywords: []
 scripts:
   - docker: fernapi/go-seed:1.0.0
     commands:
@@ -214,6 +213,7 @@ allowedFailures:
   - mixed-case:default-values
   - pagination-custom
   - request-parameters
+  - reserved-keywords
   - server-sent-event-examples
   - server-sent-events
   - streaming-parameter


### PR DESCRIPTION
## Description
Linear ticket: Closes FER-7040
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
<!-- Provide a clear and concise description of the changes made in this PR -->
In Go, the reserved-keywords fixture was being overrode to skip all tests instead of running them and allowing a failure. This moves them back to being run

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Remove the reserved-keywords fixture override and add it to the allowedFailures list

## Testing
<!-- Describe how you tested these changes -->
- Will verify on this PR's CI
