### PR TITLE
fix(cli): refactor docs fern check

### DIFF
--- a/packages/cli/api-importers/openapi-to-ir/src/3.1/paths/operations/OperationConverter.ts
+++ b/packages/cli/api-importers/openapi-to-ir/src/3.1/paths/operations/OperationConverter.ts
@@ -544,26 +544,20 @@ export class OperationConverter extends AbstractOperationConverter {
                     this.getExampleName({ example, exampleIndex }),
                     {
                         displayName: undefined,
-                        request:
-                            example.request != null ||
-                            example["path-parameters"] != null ||
-                            example["query-parameters"] != null ||
-                            example.headers != null
-                                ? {
-                                      docs: undefined,
-                                      endpoint: {
-                                          method: httpMethod,
-                                          path: this.buildExamplePath(httpPath, example["path-parameters"] ?? {})
-                                      },
-                                      baseUrl: undefined,
-                                      environment: baseUrl,
-                                      auth: undefined,
-                                      pathParameters: example["path-parameters"] ?? {},
-                                      queryParameters: example["query-parameters"] ?? {},
-                                      headers: example.headers ?? {},
-                                      requestBody: example.request ?? undefined
-                                  }
-                                : undefined,
+                        request: {
+                            docs: undefined,
+                            endpoint: {
+                                method: httpMethod,
+                                path: this.buildExamplePath(httpPath, example["path-parameters"] ?? {})
+                            },
+                            baseUrl: undefined,
+                            environment: baseUrl,
+                            auth: undefined,
+                            pathParameters: example["path-parameters"] ?? {},
+                            queryParameters: example["query-parameters"] ?? {},
+                            headers: example.headers ?? {},
+                            requestBody: example.request ?? undefined
+                        },
                         response:
                             example.response != null
                                 ? {

--- a/packages/cli/api-importers/openapi-to-ir/src/3.1/paths/operations/OperationConverter.ts
+++ b/packages/cli/api-importers/openapi-to-ir/src/3.1/paths/operations/OperationConverter.ts
@@ -544,20 +544,26 @@ export class OperationConverter extends AbstractOperationConverter {
                     this.getExampleName({ example, exampleIndex }),
                     {
                         displayName: undefined,
-                        request: {
-                            docs: undefined,
-                            endpoint: {
-                                method: httpMethod,
-                                path: this.buildExamplePath(httpPath, example["path-parameters"] ?? {})
-                            },
-                            baseUrl: undefined,
-                            environment: baseUrl,
-                            auth: undefined,
-                            pathParameters: example["path-parameters"] ?? {},
-                            queryParameters: example["query-parameters"] ?? {},
-                            headers: example.headers ?? {},
-                            requestBody: example.request ?? undefined
-                        },
+                        request:
+                            example.request != null ||
+                            example["path-parameters"] != null ||
+                            example["query-parameters"] != null ||
+                            example.headers != null
+                                ? {
+                                      docs: undefined,
+                                      endpoint: {
+                                          method: httpMethod,
+                                          path: this.buildExamplePath(httpPath, example["path-parameters"] ?? {})
+                                      },
+                                      baseUrl: undefined,
+                                      environment: baseUrl,
+                                      auth: undefined,
+                                      pathParameters: example["path-parameters"] ?? {},
+                                      queryParameters: example["query-parameters"] ?? {},
+                                      headers: example.headers ?? {},
+                                      requestBody: example.request ?? undefined
+                                  }
+                                : undefined,
                         response:
                             example.response != null
                                 ? {

--- a/packages/cli/cli/src/commands/validate/validateAPIWorkspaceAndLogIssues.ts
+++ b/packages/cli/cli/src/commands/validate/validateAPIWorkspaceAndLogIssues.ts
@@ -26,7 +26,7 @@ export async function validateAPIWorkspaceWithoutExiting({
     const generatorViolations = await validateGeneratorsWorkspace(workspace, context.logger);
     const violations = [...apiViolations, ...generatorViolations];
     if (ossWorkspace) {
-        violations.concat(await validateOSSWorkspace(ossWorkspace, context));
+        violations.push(...(await validateOSSWorkspace(ossWorkspace, context)));
     }
     const elapsedMillis = performance.now() - startTime;
     const { hasErrors } = logViolations({

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -63,7 +63,7 @@
 - changelogEntry:
     - summary: |
         Restore support for x-fern-examples path parameters if there is no request body.
-      type: feat
+      type: fix
   irVersion: 61
   createdAt: "2025-10-23"
   version: 0.94.4

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- changelogEntry:
+    - summary: |
+        Reformat how docs fern check errors are displayed, and error on:
+        - OpenAPI v2.0 in docs
+        - Non-component local refs in docs
+      type: fix
+  irVersion: 61
+  createdAt: "2025-10-25"
+  version: 0.96.1
 
 - changelogEntry:
     - summary: |
@@ -51,14 +60,6 @@
   irVersion: 61
   createdAt: "2025-10-23"
   version: 0.94.5
-
-- changelogEntry:
-    - summary: |
-        Restore support for x-fern-examples path parameters if there is no request body.
-      type: fix
-  irVersion: 61
-  createdAt: "2025-10-23"
-  version: 0.94.4
 
 - changelogEntry:
     - summary: |

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -62,6 +62,14 @@
 
 - changelogEntry:
     - summary: |
+        Restore support for x-fern-examples path parameters if there is no request body.
+      type: feat
+  irVersion: 61
+  createdAt: "2025-10-23"
+  version: 0.94.4
+
+- changelogEntry:
+    - summary: |
         Fix broken recursive unescaping of \ during handling of \$ in IR generation.
       type: fix
   irVersion: 61

--- a/packages/cli/yaml/docs-validator/src/getAllRules.ts
+++ b/packages/cli/yaml/docs-validator/src/getAllRules.ts
@@ -2,6 +2,8 @@ import { Rule } from "./Rule";
 import { AccentColorContrastRule } from "./rules/accent-color-contrast";
 import { AllRolesMustBeDeclaredRule } from "./rules/all-roles-must-be-declared";
 import { FilepathsExistRule } from "./rules/filepaths-exist";
+import { NoNonComponentRefsRule } from "./rules/no-non-component-refs";
+import { NoOpenApiV2InDocsRule } from "./rules/no-openapi-v2-in-docs";
 import { OnlyVersionedNavigation } from "./rules/only-versioned-navigation";
 import { ValidDocsEndpoints } from "./rules/valid-docs-endpoints";
 import { ValidFileTypes } from "./rules/valid-file-types";
@@ -12,6 +14,8 @@ import { ValidateVersionFileRule } from "./rules/validate-version-file";
 
 const allRules = [
     FilepathsExistRule,
+    NoOpenApiV2InDocsRule, // Check OpenAPI v2 first (more fundamental issue)
+    NoNonComponentRefsRule, // Check non-component references (will skip v2 files)
     OnlyVersionedNavigation,
     ValidateVersionFileRule,
     ValidateProductFileRule,

--- a/packages/cli/yaml/docs-validator/src/rules/no-non-component-refs/index.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/no-non-component-refs/index.ts
@@ -1,0 +1,1 @@
+export { NoNonComponentRefsRule } from "./no-non-component-refs";

--- a/packages/cli/yaml/docs-validator/src/rules/no-non-component-refs/no-non-component-refs.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/no-non-component-refs/no-non-component-refs.ts
@@ -47,7 +47,7 @@ export const NoNonComponentRefsRule: Rule = {
                                             severity: "error",
                                             name: "Invalid OpenAPI reference",
                                             message: `Reference "${ref}" points to a non-component location. OpenAPI references should point to reusable components under #/components/ (e.g., #/components/schemas/MySchema, #/components/responses/MyResponse). Direct references to paths, operations, or other spec sections are not supported.`,
-                                            relativeFilepath: relativePath as any
+                                            relativeFilepath: relativePath
                                         });
                                     }
                                 }

--- a/packages/cli/yaml/docs-validator/src/rules/no-non-component-refs/no-non-component-refs.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/no-non-component-refs/no-non-component-refs.ts
@@ -1,0 +1,66 @@
+import { relative } from "@fern-api/fs-utils";
+import { readFile } from "fs/promises";
+
+import { Rule, RuleViolation } from "../../Rule";
+
+export const NoNonComponentRefsRule: Rule = {
+    name: "no-non-component-refs",
+    create: ({ ossWorkspaces, logger, workspace: docsWorkspace }) => {
+        return {
+            file: async () => {
+                const violations: RuleViolation[] = [];
+                const processedFiles = new Set<string>(); // Track processed files to avoid duplicates
+
+                for (const workspace of ossWorkspaces) {
+                    for (const spec of workspace.specs) {
+                        if (spec.type === "openapi" && !processedFiles.has(spec.absoluteFilepath)) {
+                            processedFiles.add(spec.absoluteFilepath);
+                            try {
+                                const contents = (await readFile(spec.absoluteFilepath)).toString();
+
+                                // Use the docs workspace as reference point for more descriptive path
+                                const relativePath = relative(docsWorkspace.absoluteFilePath, spec.absoluteFilepath);
+
+                                // Skip OpenAPI v2 files - they should be handled by the v2 rule first
+                                const isOpenApiV2 =
+                                    contents.includes("swagger:") &&
+                                    (contents.includes('swagger: "2.0"') ||
+                                        contents.includes("swagger: '2.0'") ||
+                                        contents.includes("swagger: 2.0"));
+
+                                if (isOpenApiV2) {
+                                    continue; // Skip v2 files
+                                }
+
+                                // Find all $ref references in the OpenAPI spec
+                                const refMatches = contents.matchAll(/["']?\$ref["']?\s*:\s*["']([^"']+)["']/g);
+
+                                for (const match of refMatches) {
+                                    const ref = match[1];
+                                    if (!ref) {
+                                        continue;
+                                    }
+
+                                    // Check if the reference is pointing to a non-component location
+                                    if (ref.startsWith("#/") && !ref.startsWith("#/components/")) {
+                                        violations.push({
+                                            severity: "error",
+                                            name: "Invalid OpenAPI reference",
+                                            message: `Reference "${ref}" points to a non-component location. OpenAPI references should point to reusable components under #/components/ (e.g., #/components/schemas/MySchema, #/components/responses/MyResponse). Direct references to paths, operations, or other spec sections are not supported.`,
+                                            relativeFilepath: relativePath as any
+                                        });
+                                    }
+                                }
+                            } catch (error) {
+                                logger.warn(`Could not read OpenAPI spec file: ${spec.absoluteFilepath}`);
+                                continue;
+                            }
+                        }
+                    }
+                }
+
+                return violations;
+            }
+        };
+    }
+};

--- a/packages/cli/yaml/docs-validator/src/rules/no-openapi-v2-in-docs/index.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/no-openapi-v2-in-docs/index.ts
@@ -1,0 +1,1 @@
+export { NoOpenApiV2InDocsRule } from "./no-openapi-v2-in-docs";

--- a/packages/cli/yaml/docs-validator/src/rules/no-openapi-v2-in-docs/no-openapi-v2-in-docs.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/no-openapi-v2-in-docs/no-openapi-v2-in-docs.ts
@@ -1,0 +1,50 @@
+import { relative } from "@fern-api/fs-utils";
+import { readFile } from "fs/promises";
+
+import { Rule, RuleViolation } from "../../Rule";
+
+export const NoOpenApiV2InDocsRule: Rule = {
+    name: "no-openapi-v2-in-docs",
+    create: ({ ossWorkspaces, logger, workspace: docsWorkspace }) => {
+        return {
+            file: async () => {
+                const violations: RuleViolation[] = [];
+                const processedFiles = new Set<string>(); // Track processed files to avoid duplicates
+
+                for (const workspace of ossWorkspaces) {
+                    for (const spec of workspace.specs) {
+                        if (spec.type === "openapi" && !processedFiles.has(spec.absoluteFilepath)) {
+                            processedFiles.add(spec.absoluteFilepath);
+                            try {
+                                const contents = (await readFile(spec.absoluteFilepath)).toString();
+
+                                // Use the docs workspace as reference point for more descriptive path
+                                const relativePath = relative(docsWorkspace.absoluteFilePath, spec.absoluteFilepath);
+
+                                // Simple check for OpenAPI v2 by looking for "swagger: " pattern
+                                if (
+                                    contents.includes("swagger:") &&
+                                    (contents.includes('swagger: "2.0"') ||
+                                        contents.includes("swagger: '2.0'") ||
+                                        contents.includes("swagger: 2.0"))
+                                ) {
+                                    violations.push({
+                                        severity: "error",
+                                        name: "OpenAPI v2.0 not supported",
+                                        message: `OpenAPI version 2.0 (Swagger) is not supported in docs generation. Please upgrade to OpenAPI 3.0 or later.`,
+                                        relativeFilepath: relativePath as any
+                                    });
+                                }
+                            } catch (error) {
+                                logger.warn(`Could not read OpenAPI spec file: ${spec.absoluteFilepath}`);
+                                continue;
+                            }
+                        }
+                    }
+                }
+
+                return violations;
+            }
+        };
+    }
+};

--- a/packages/cli/yaml/docs-validator/src/rules/no-openapi-v2-in-docs/no-openapi-v2-in-docs.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/no-openapi-v2-in-docs/no-openapi-v2-in-docs.ts
@@ -32,7 +32,7 @@ export const NoOpenApiV2InDocsRule: Rule = {
                                         severity: "error",
                                         name: "OpenAPI v2.0 not supported",
                                         message: `OpenAPI version 2.0 (Swagger) is not supported in docs generation. Please upgrade to OpenAPI 3.0 or later.`,
-                                        relativeFilepath: relativePath as any
+                                        relativeFilepath: relativePath
                                     });
                                 }
                             } catch (error) {


### PR DESCRIPTION
Changes:
- add 2 error types to docs (openapi v2, and non-component references, e.g. $ref: path/....)
- refactor how we group errors by file, to show 1 error per filepath. This shows filepath errors

current:

<img width="1727" height="144" alt="image" src="https://github.com/user-attachments/assets/ce78d7e6-3a06-4b56-ad82-4017023a63bb" />

with new error types:

<img width="1728" height="271" alt="Screenshot 2025-10-26 at 4 14 26 PM" src="https://github.com/user-attachments/assets/75e7547c-7442-4cba-89ce-1cfc933ec28f" />

after reformatting errors by filepath:

<img width="1728" height="657" alt="Screenshot 2025-10-26 at 4 14 05 PM" src="https://github.com/user-attachments/assets/76a2c1dc-d122-44dd-86ad-a9e623d7c7c9" />
