### PR TITLE
chore(ci): update CI workflows to use OIDC for npm publishing

### DIFF
--- a/.github/workflows/publish-csharp-dynamic-snippets.yml
+++ b/.github/workflows/publish-csharp-dynamic-snippets.yml
@@ -11,7 +11,10 @@ on:
 env:
   PACKAGE_NAME: "@fern-api/csharp-dynamic-snippets"
   GITHUB_TOKEN: ${{ secrets.FERN_GITHUB_TOKEN }}
-  NPM_TOKEN: ${{ secrets.FERN_NPM_TOKEN }}
+
+permissions:
+  id-token: write # Required for OIDC
+  contents: read
 
 jobs:
   run:
@@ -25,6 +28,9 @@ jobs:
 
       - name: 📥 Install
         uses: ./.github/actions/install
+
+      - name: Update npm
+        run: npm install -g npm@latest
 
       - uses: bufbuild/buf-setup-action@v1.34.0
         with:
@@ -48,8 +54,7 @@ jobs:
           cd generators/csharp/dynamic-snippets
           pnpm --filter=${{ env.PACKAGE_NAME }} dist ${{ inputs.version }}
           cd dist
-          echo "//registry.npmjs.org/:_authToken=${{ env.NPM_TOKEN }}" > ~/.npmrc
-          npm publish --access public
+          npm publish --access public --tag latest
 
       - name: Update fern-platform dependency
         uses: ./.github/actions/update-fern-platform-dependency

--- a/.github/workflows/publish-go-dynamic-snippets.yml
+++ b/.github/workflows/publish-go-dynamic-snippets.yml
@@ -11,7 +11,10 @@ on:
 env:
   PACKAGE_NAME: "@fern-api/go-dynamic-snippets"
   GITHUB_TOKEN: ${{ secrets.FERN_GITHUB_TOKEN }}
-  NPM_TOKEN: ${{ secrets.FERN_NPM_TOKEN }}
+
+permissions:
+  id-token: write # Required for OIDC
+  contents: read
 
 jobs:
   run:
@@ -25,6 +28,9 @@ jobs:
 
       - name: 📥 Install
         uses: ./.github/actions/install
+
+      - name: Update npm
+        run: npm install -g npm@latest
 
       - uses: bufbuild/buf-setup-action@v1.34.0
         with:
@@ -48,8 +54,7 @@ jobs:
           cd generators/go-v2/dynamic-snippets
           pnpm --filter=${{ env.PACKAGE_NAME }} dist ${{ inputs.version }}
           cd dist
-          echo "//registry.npmjs.org/:_authToken=${{ env.NPM_TOKEN }}" > ~/.npmrc
-          npm publish --access public
+          npm publish --access public --tag latest
 
       - name: Update fern-platform dependency
         uses: ./.github/actions/update-fern-platform-dependency

--- a/.github/workflows/publish-java-dynamic-snippets.yml
+++ b/.github/workflows/publish-java-dynamic-snippets.yml
@@ -11,7 +11,10 @@ on:
 env:
   PACKAGE_NAME: "@fern-api/java-dynamic-snippets"
   GITHUB_TOKEN: ${{ secrets.FERN_GITHUB_TOKEN }}
-  NPM_TOKEN: ${{ secrets.FERN_NPM_TOKEN }}
+
+permissions:
+  id-token: write # Required for OIDC
+  contents: read
 
 jobs:
   run:
@@ -25,6 +28,9 @@ jobs:
 
       - name: 📥 Install
         uses: ./.github/actions/install
+
+      - name: Update npm
+        run: npm install -g npm@latest
 
       - uses: bufbuild/buf-setup-action@v1.34.0
         with:
@@ -48,8 +54,7 @@ jobs:
           cd generators/java-v2/dynamic-snippets
           pnpm --filter=${{ env.PACKAGE_NAME }} dist ${{ inputs.version }}
           cd dist
-          echo "//registry.npmjs.org/:_authToken=${{ env.NPM_TOKEN }}" > ~/.npmrc
-          npm publish --access public
+          npm publish --access public --tag latest
 
       - name: Update fern-platform dependency
         uses: ./.github/actions/update-fern-platform-dependency

--- a/.github/workflows/publish-php-dynamic-snippets.yml
+++ b/.github/workflows/publish-php-dynamic-snippets.yml
@@ -11,7 +11,10 @@ on:
 env:
   PACKAGE_NAME: "@fern-api/php-dynamic-snippets"
   GITHUB_TOKEN: ${{ secrets.FERN_GITHUB_TOKEN }}
-  NPM_TOKEN: ${{ secrets.FERN_NPM_TOKEN }}
+
+permissions:
+  id-token: write # Required for OIDC
+  contents: read
 
 jobs:
   run:
@@ -25,6 +28,9 @@ jobs:
 
       - name: 📥 Install
         uses: ./.github/actions/install
+
+      - name: Update npm
+        run: npm install -g npm@latest
 
       - uses: bufbuild/buf-setup-action@v1.34.0
         with:
@@ -48,8 +54,7 @@ jobs:
           cd generators/php/dynamic-snippets
           pnpm --filter=${{ env.PACKAGE_NAME }} dist ${{ inputs.version }}
           cd dist
-          echo "//registry.npmjs.org/:_authToken=${{ env.NPM_TOKEN }}" > ~/.npmrc
-          npm publish --access public
+          npm publish --access public --tag latest
 
       - name: Update fern-platform dependency
         uses: ./.github/actions/update-fern-platform-dependency

--- a/.github/workflows/publish-python-dynamic-snippets.yml
+++ b/.github/workflows/publish-python-dynamic-snippets.yml
@@ -11,7 +11,10 @@ on:
 env:
   PACKAGE_NAME: "@fern-api/python-dynamic-snippets"
   GITHUB_TOKEN: ${{ secrets.FERN_GITHUB_TOKEN }}
-  NPM_TOKEN: ${{ secrets.FERN_NPM_TOKEN }}
+
+permissions:
+  id-token: write # Required for OIDC
+  contents: read
 
 jobs:
   run:
@@ -25,6 +28,9 @@ jobs:
 
       - name: 📥 Install
         uses: ./.github/actions/install
+
+      - name: Update npm
+        run: npm install -g npm@latest
 
       - uses: bufbuild/buf-setup-action@v1.34.0
         with:
@@ -48,8 +54,7 @@ jobs:
           cd generators/python-v2/dynamic-snippets
           pnpm --filter=${{ env.PACKAGE_NAME }} dist ${{ inputs.version }}
           cd dist
-          echo "//registry.npmjs.org/:_authToken=${{ env.NPM_TOKEN }}" > ~/.npmrc
-          npm publish --access public
+          npm publish --access public -tag latest
 
       - name: Update fern-platform dependency
         uses: ./.github/actions/update-fern-platform-dependency

--- a/.github/workflows/publish-ruby-dynamic-snippets.yml
+++ b/.github/workflows/publish-ruby-dynamic-snippets.yml
@@ -11,7 +11,10 @@ on:
 env:
   PACKAGE_NAME: "@fern-api/ruby-dynamic-snippets"
   GITHUB_TOKEN: ${{ secrets.FERN_GITHUB_TOKEN }}
-  NPM_TOKEN: ${{ secrets.FERN_NPM_TOKEN }}
+
+permissions:
+  id-token: write # Required for OIDC
+  contents: read
 
 jobs:
   run:
@@ -25,6 +28,9 @@ jobs:
 
       - name: 📥 Install
         uses: ./.github/actions/install
+
+      - name: Update npm
+        run: npm install -g npm@latest
 
       - uses: bufbuild/buf-setup-action@v1.34.0
         with:
@@ -48,8 +54,7 @@ jobs:
           cd generators/ruby-v2/dynamic-snippets
           pnpm --filter=${{ env.PACKAGE_NAME }} dist ${{ inputs.version }}
           cd dist
-          echo "//registry.npmjs.org/:_authToken=${{ env.NPM_TOKEN }}" > ~/.npmrc
-          npm publish --access public
+          npm publish --access public --tag latest
 
       - name: Update fern-platform dependency
         uses: ./.github/actions/update-fern-platform-dependency

--- a/.github/workflows/publish-snippets-core.yml
+++ b/.github/workflows/publish-snippets-core.yml
@@ -11,7 +11,10 @@ on:
 env:
   PACKAGE_NAME: "@fern-api/snippets-core"
   GITHUB_TOKEN: ${{ secrets.FERN_GITHUB_TOKEN }}
-  NPM_TOKEN: ${{ secrets.FERN_NPM_TOKEN }}
+
+permissions:
+  id-token: write # Required for OIDC
+  contents: read
 
 jobs:
   run:
@@ -25,6 +28,9 @@ jobs:
 
       - name: 📥 Install
         uses: ./.github/actions/install
+
+      - name: Update npm
+        run: npm install -g npm@latest
 
       - uses: bufbuild/buf-setup-action@v1.34.0
         with:
@@ -48,5 +54,4 @@ jobs:
           cd packages/snippets/core
           pnpm --filter=${{ env.PACKAGE_NAME }} dist ${{ inputs.version }}
           cd dist
-          echo "//registry.npmjs.org/:_authToken=${{ env.NPM_TOKEN }}" > ~/.npmrc
-          npm publish --access public
+          npm publish --access public --tag latest

--- a/.github/workflows/publish-swift-dynamic-snippets.yml
+++ b/.github/workflows/publish-swift-dynamic-snippets.yml
@@ -11,7 +11,10 @@ on:
 env:
   PACKAGE_NAME: "@fern-api/swift-dynamic-snippets"
   GITHUB_TOKEN: ${{ secrets.FERN_GITHUB_TOKEN }}
-  NPM_TOKEN: ${{ secrets.FERN_NPM_TOKEN }}
+
+permissions:
+  id-token: write # Required for OIDC
+  contents: read
 
 jobs:
   run:
@@ -25,6 +28,9 @@ jobs:
 
       - name: 📥 Install
         uses: ./.github/actions/install
+
+      - name: Update npm
+        run: npm install -g npm@latest
 
       - uses: bufbuild/buf-setup-action@v1.34.0
         with:
@@ -48,8 +54,7 @@ jobs:
           cd generators/swift/dynamic-snippets
           pnpm --filter=${{ env.PACKAGE_NAME }} dist ${{ inputs.version }}
           cd dist
-          echo "//registry.npmjs.org/:_authToken=${{ env.NPM_TOKEN }}" > ~/.npmrc
-          npm publish --access public
+          npm publish --access public --tag latest
 
       - name: Update fern-platform dependency
         uses: ./.github/actions/update-fern-platform-dependency

--- a/.github/workflows/publish-ts-dynamic-snippets.yml
+++ b/.github/workflows/publish-ts-dynamic-snippets.yml
@@ -11,7 +11,10 @@ on:
 env:
   PACKAGE_NAME: "@fern-api/typescript-dynamic-snippets"
   GITHUB_TOKEN: ${{ secrets.FERN_GITHUB_TOKEN }}
-  NPM_TOKEN: ${{ secrets.FERN_NPM_TOKEN }}
+
+permissions:
+  id-token: write # Required for OIDC
+  contents: read
 
 jobs:
   run:
@@ -25,6 +28,9 @@ jobs:
 
       - name: 📥 Install
         uses: ./.github/actions/install
+
+      - name: Update npm
+        run: npm install -g npm@latest
 
       - uses: bufbuild/buf-setup-action@v1.34.0
         with:
@@ -48,8 +54,7 @@ jobs:
           cd generators/typescript-v2/dynamic-snippets
           pnpm --filter=${{ env.PACKAGE_NAME }} dist ${{ inputs.version }}
           cd dist
-          echo "//registry.npmjs.org/:_authToken=${{ env.NPM_TOKEN }}" > ~/.npmrc
-          npm publish --access public
+          npm publish --access public --tag latest
 
       - name: Update fern-platform dependency
         uses: ./.github/actions/update-fern-platform-dependency


### PR DESCRIPTION
## Description
Linear ticket: FER-7208

## Changes Made
- Migrate snippets CI workflows to use OIDC
- Updated NPM package settings to allow publishing from the associated CI workflow file

## Testing
Identical to work in these `fern-platform` PRs that has been tested in CI there post-publishing
- use [oidc to publish](https://github.com/fern-api/fern-platform/pull/4236/files)
- add missing [tag](https://github.com/fern-api/fern-platform/pull/4289/files) (required with OIDC for some reason)
