### PR TITLE
feat(cli): Add support for ignoring properties in OpenAPI schemas using the `x-fern-ignore` extension.

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/x-fern-ignore.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/x-fern-ignore.json
@@ -26,10 +26,11 @@
                       },
                       "users": [
                         {
-                          "age": 1,
-                          "email": "email",
-                          "id": "id",
-                          "name": "name",
+                          "age": 30,
+                          "email": "john@example.com",
+                          "id": "123e4567-e89b-12d3-a456-426614174000",
+                          "name": "John Doe",
+                          "not_ignored_field": "visible",
                         },
                       ],
                     },
@@ -87,6 +88,7 @@
                 },
               },
               "name": "optional<string>",
+              "not_ignored_field": "optional<string>",
             },
             "source": {
               "openapi": "../openapi.yml",
@@ -134,10 +136,11 @@
               meta:
                 hasMore: true
               users:
-                - id: id
-                  name: name
-                  email: email
-                  age: 1
+                - id: 123e4567-e89b-12d3-a456-426614174000
+                  name: John Doe
+                  email: john@example.com
+                  age: 30
+                  not_ignored_field: visible
   source:
     openapi: ../openapi.yml
 types:
@@ -161,6 +164,7 @@ types:
       name: optional<string>
       email: optional<string>
       age: optional<integer>
+      not_ignored_field: optional<string>
     source:
       openapi: ../openapi.yml
 ",

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/x-fern-ignore.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/x-fern-ignore.json
@@ -19,6 +19,21 @@
                 "application/json": {
                   "schema": {
                     "$ref": "#/components/schemas/UsersResponse"
+                  },
+                  "example": {
+                    "meta": {
+                      "hasMore": true
+                    },
+                    "users": [
+                      {
+                        "id": "123e4567-e89b-12d3-a456-426614174000",
+                        "name": "John Doe",
+                        "email": "john@example.com",
+                        "age": 30,
+                        "not_ignored_field": "visible",
+                        "ignored_field": "should-be-filtered-out"
+                      }
+                    ]
                   }
                 }
               }
@@ -30,14 +45,16 @@
               "name": "pageNumber",
               "schema": {
                 "type": "integer"
-              }
+              },
+              "example": 1
             },
             {
               "in": "query",
               "name": "limit",
               "schema": {
                 "type": "integer"
-              }
+              },
+              "example": 10
             },
             {
               "in": "query",
@@ -45,6 +62,7 @@
               "schema": {
                 "type": "string"
               },
+              "example": "should-be-ignored",
               "x-fern-ignore": true
             },
             {
@@ -53,6 +71,7 @@
               "schema": {
                 "type": "string"
               },
+              "example": "also-ignored",
               "x-fern-ignore": true
             }
           ]
@@ -77,7 +96,8 @@
         "Meta": {
           "properties": {
             "hasMore": {
-              "type": "boolean"
+              "type": "boolean",
+              "example": true
             }
           }
         },
@@ -86,7 +106,8 @@
           "type": "object",
           "properties": {
             "hasMore": {
-              "type": "boolean"
+              "type": "boolean",
+              "example": false
             }
           }
         },
@@ -102,6 +123,29 @@
                 "$ref": "#/components/schemas/User"
               }
             }
+          },
+          "example": {
+            "meta": {
+              "hasMore": true
+            },
+            "users": [
+              {
+                "id": "123e4567-e89b-12d3-a456-426614174000",
+                "name": "Alice Smith",
+                "email": "alice@example.com",
+                "age": 28,
+                "not_ignored_field": "value1",
+                "ignored_field": "should-be-filtered-out-1"
+              },
+              {
+                "id": "987fcdeb-51a2-43f7-9876-543210fedcba",
+                "name": "Bob Jones",
+                "email": "bob@example.com",
+                "age": 35,
+                "not_ignored_field": "value2",
+                "ignored_field": "should-be-filtered-out-2"
+              }
+            ]
           }
         },
         "User": {
@@ -109,16 +153,30 @@
           "properties": {
             "id": {
               "type": "string",
-              "format": "uuid"
+              "format": "uuid",
+              "example": "123e4567-e89b-12d3-a456-426614174000"
             },
             "name": {
-              "type": "string"
+              "type": "string",
+              "example": "Jane Doe"
             },
             "email": {
-              "type": "string"
+              "type": "string",
+              "example": "jane@example.com"
             },
             "age": {
-              "type": "integer"
+              "type": "integer",
+              "example": 25
+            },
+            "not_ignored_field": {
+              "type": "string",
+              "example": "this-field-is-visible",
+              "x-fern-ignore": false
+            },
+            "ignored_field": {
+              "type": "string",
+              "example": "this-should-be-ignored",
+              "x-fern-ignore": true
             }
           }
         }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/x-fern-ignore.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/x-fern-ignore.json
@@ -68,7 +68,25 @@
           },
           "type": "reference"
         },
-        "fullExamples": [],
+        "fullExamples": [
+          {
+            "value": {
+              "meta": {
+                "hasMore": true
+              },
+              "users": [
+                {
+                  "id": "123e4567-e89b-12d3-a456-426614174000",
+                  "name": "John Doe",
+                  "email": "john@example.com",
+                  "age": 30,
+                  "not_ignored_field": "visible",
+                  "ignored_field": "should-be-filtered-out"
+                }
+              ]
+            }
+          }
+        ],
         "source": {
           "file": "../openapi.yml",
           "type": "openapi"
@@ -130,29 +148,36 @@
                       "properties": {
                         "id": {
                           "value": {
-                            "value": "id",
+                            "value": "123e4567-e89b-12d3-a456-426614174000",
                             "type": "string"
                           },
                           "type": "primitive"
                         },
                         "name": {
                           "value": {
-                            "value": "name",
+                            "value": "John Doe",
                             "type": "string"
                           },
                           "type": "primitive"
                         },
                         "email": {
                           "value": {
-                            "value": "email",
+                            "value": "john@example.com",
                             "type": "string"
                           },
                           "type": "primitive"
                         },
                         "age": {
                           "value": {
-                            "value": 1,
+                            "value": 30,
                             "type": "int"
+                          },
+                          "type": "primitive"
+                        },
+                        "not_ignored_field": {
+                          "value": {
+                            "value": "visible",
+                            "type": "string"
                           },
                           "type": "primitive"
                         }
@@ -192,6 +217,7 @@
               "generatedName": "MetaHasMore",
               "value": {
                 "schema": {
+                  "example": true,
                   "type": "boolean"
                 },
                 "generatedName": "MetaHasMore",
@@ -286,6 +312,7 @@
               "value": {
                 "schema": {
                   "format": "uuid",
+                  "example": "123e4567-e89b-12d3-a456-426614174000",
                   "type": "string"
                 },
                 "generatedName": "UserId",
@@ -305,6 +332,7 @@
               "generatedName": "UserName",
               "value": {
                 "schema": {
+                  "example": "Jane Doe",
                   "type": "string"
                 },
                 "generatedName": "UserName",
@@ -324,6 +352,7 @@
               "generatedName": "UserEmail",
               "value": {
                 "schema": {
+                  "example": "jane@example.com",
                   "type": "string"
                 },
                 "generatedName": "UserEmail",
@@ -343,9 +372,30 @@
               "generatedName": "UserAge",
               "value": {
                 "schema": {
+                  "example": 25,
                   "type": "int"
                 },
                 "generatedName": "UserAge",
+                "groupName": [],
+                "type": "primitive"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "audiences": []
+          },
+          {
+            "conflict": {},
+            "generatedName": "userNotIgnoredField",
+            "key": "not_ignored_field",
+            "schema": {
+              "generatedName": "UserNotIgnoredField",
+              "value": {
+                "schema": {
+                  "example": "this-field-is-visible",
+                  "type": "string"
+                },
+                "generatedName": "UserNotIgnoredField",
                 "groupName": [],
                 "type": "primitive"
               },

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/x-fern-ignore.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/x-fern-ignore.json
@@ -26,10 +26,11 @@
                       },
                       "users": [
                         {
-                          "age": 1,
-                          "email": "email",
-                          "id": "id",
-                          "name": "name",
+                          "age": 30,
+                          "email": "john@example.com",
+                          "id": "123e4567-e89b-12d3-a456-426614174000",
+                          "name": "John Doe",
+                          "not_ignored_field": "visible",
                         },
                       ],
                     },
@@ -87,6 +88,7 @@
                 },
               },
               "name": "optional<string>",
+              "not_ignored_field": "optional<string>",
             },
             "source": {
               "openapi": "../openapi.yml",
@@ -134,10 +136,11 @@
               meta:
                 hasMore: true
               users:
-                - id: id
-                  name: name
-                  email: email
-                  age: 1
+                - id: 123e4567-e89b-12d3-a456-426614174000
+                  name: John Doe
+                  email: john@example.com
+                  age: 30
+                  not_ignored_field: visible
   source:
     openapi: ../openapi.yml
 types:
@@ -161,6 +164,7 @@ types:
       name: optional<string>
       email: optional<string>
       age: optional<integer>
+      not_ignored_field: optional<string>
     source:
       openapi: ../openapi.yml
 ",

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/x-fern-ignore/openapi.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/x-fern-ignore/openapi.yml
@@ -15,24 +15,38 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/UsersResponse"
+              example:
+                meta:
+                  hasMore: true
+                users:
+                  - id: "123e4567-e89b-12d3-a456-426614174000"
+                    name: "John Doe"
+                    email: "john@example.com"
+                    age: 30
+                    not_ignored_field: "visible"
+                    ignored_field: "should-be-filtered-out"
       parameters:
         - in: query
           name: pageNumber
           schema:
             type: integer
+          example: 1
         - in: query
           name: limit
           schema:
             type: integer
+          example: 10
         - in: query
           name: ignoredParam1
           schema:
             type: string
+          example: "should-be-ignored"
           x-fern-ignore: true
         - in: query
           name: ignoredParam2
           schema:
             type: string
+          example: "also-ignored"
           x-fern-ignore: true
   /ignored-operation:
     get:
@@ -49,12 +63,14 @@ components:
       properties:
         hasMore:
           type: boolean
+          example: true
     IgnoredSchema:
       x-fern-ignore: true
       type: object
       properties:
         hasMore:
           type: boolean
+          example: false
     UsersResponse:
       type: object
       properties:
@@ -64,15 +80,43 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/User"
+      example:
+        meta:
+          hasMore: true
+        users:
+          - id: "123e4567-e89b-12d3-a456-426614174000"
+            name: "Alice Smith"
+            email: "alice@example.com"
+            age: 28
+            not_ignored_field: "value1"
+            ignored_field: "should-be-filtered-out-1"
+          - id: "987fcdeb-51a2-43f7-9876-543210fedcba"
+            name: "Bob Jones"
+            email: "bob@example.com"
+            age: 35
+            not_ignored_field: "value2"
+            ignored_field: "should-be-filtered-out-2"
     User:
       type: object
       properties:
         id:
           type: string
           format: uuid
+          example: "123e4567-e89b-12d3-a456-426614174000"
         name:
           type: string
+          example: "Jane Doe"
         email:
           type: string
+          example: "jane@example.com"
         age:
           type: integer
+          example: 25
+        not_ignored_field:
+          type: string
+          example: "this-field-is-visible"
+          x-fern-ignore: false
+        ignored_field:
+          type: string
+          example: "this-should-be-ignored"
+          x-fern-ignore: true

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Add support for ignoring properties in OpenAPI schemas using the `x-fern-ignore` extension.
+      type: feat
+  irVersion: 61
+  createdAt: "2025-10-27"
+  version: 0.97.0
+
+- changelogEntry:
+    - summary: |
         Reformat how docs fern check errors are displayed, and error on:
         - OpenAPI v2.0 in docs
         - Non-component local refs in docs


### PR DESCRIPTION
## Description
Add support for ignoring properties in OpenAPI schemas using the `x-fern-ignore` extension.

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated
- [x] Manual testing completed
