### PR TITLE
feat(java): fix nullable field serialization for PATCH requests

### DIFF
--- a/generators/java/generator-utils/src/main/java/com/fern/java/ICustomConfig.java
+++ b/generators/java/generator-utils/src/main/java/com/fern/java/ICustomConfig.java
@@ -95,6 +95,12 @@ public interface ICustomConfig {
         return false;
     }
 
+    @Value.Default
+    @JsonProperty("use-nullable-for-optional-fields")
+    default Boolean useNullableForOptionalFields() {
+        return false;
+    }
+
     @JsonProperty("package-prefix")
     Optional<String> packagePrefix();
 

--- a/generators/java/generator-utils/src/main/java/com/fern/java/PoetTypeNameMapper.java
+++ b/generators/java/generator-utils/src/main/java/com/fern/java/PoetTypeNameMapper.java
@@ -280,6 +280,28 @@ public final class PoetTypeNameMapper {
 
         @Override
         public TypeName visitOptional(TypeReference typeReference) {
+            // When use-nullable-for-optional-fields is enabled, use Nullable<T> instead of Optional<T>
+            // This provides three-state support for PATCH requests (value, null, omitted)
+            if (customConfig.useNullableForOptionalFields()) {
+                // Special handling for optional<nullable<T>> pattern - avoid double-wrapping
+                // Just return Nullable<T> instead of Nullable<Nullable<T>>
+                if (typeReference.isContainer()
+                        && typeReference.getContainer().get().isNullable()) {
+                    // Visit the inner nullable type directly, which will return the unwrapped type
+                    TypeReference innerNullable =
+                            typeReference.getContainer().get().getNullable().get();
+                    TypeName innerTypeName = innerNullable.visit(primitiveDisAllowedTypeReferenceConverter);
+                    ClassName nullableClassName = poetClassNameFactory.getNullableClassName();
+                    return ParameterizedTypeName.get(nullableClassName, innerTypeName);
+                }
+
+                // For regular optional<T>, convert to Nullable<T>
+                TypeName typeName = typeReference.visit(primitiveDisAllowedTypeReferenceConverter);
+                ClassName nullableClassName = poetClassNameFactory.getNullableClassName();
+                return ParameterizedTypeName.get(nullableClassName, typeName);
+            }
+
+            // Default behavior when config is not enabled - use Optional<T>
             TypeName typeName = typeReference.visit(primitiveDisAllowedTypeReferenceConverter);
             if (typeName instanceof ParameterizedTypeName) {
                 // Optional should not be re-wrapped in Optional

--- a/generators/java/generator-utils/src/main/java/com/fern/java/generators/object/EnrichedObjectProperty.java
+++ b/generators/java/generator-utils/src/main/java/com/fern/java/generators/object/EnrichedObjectProperty.java
@@ -84,9 +84,24 @@ public interface EnrichedObjectProperty {
         }
 
         if (nullable() && !shouldUseNullableAnnotation) {
+            // Determine the correct empty type based on the field's actual type
+            TypeName emptyType;
+            if (poetTypeName() instanceof com.squareup.javapoet.ParameterizedTypeName) {
+                com.squareup.javapoet.ParameterizedTypeName paramType =
+                        (com.squareup.javapoet.ParameterizedTypeName) poetTypeName();
+                // Check if this is a Nullable type by comparing the class name
+                if (paramType.rawType.simpleName().equals("Nullable")) {
+                    // Use the actual Nullable class from the field type
+                    emptyType = paramType.rawType;
+                } else {
+                    emptyType = ClassName.get(Optional.class);
+                }
+            } else {
+                emptyType = ClassName.get(Optional.class);
+            }
             getterBuilder
                     .beginControlFlow("if ($L == null)", fieldSpec().get().name)
-                    .addStatement("return $T.empty()", Optional.class)
+                    .addStatement("return $T.empty()", emptyType)
                     .endControlFlow();
         } else if (aliasOfNullable() && wrappedAliases()) {
             getterBuilder

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,3 +1,13 @@
+- version: 3.10.0
+  changelogEntry:
+    - summary: |
+        Add support for three-state nullable fields in PATCH requests via `use-nullable-for-optional-fields` config.
+        When enabled, optional fields use `Nullable<T>` instead of `Optional<T>` to distinguish between
+        omitted fields, explicit null values, and actual values.
+      type: feat
+  createdAt: "2025-10-28"
+  irVersion: 61
+
 - version: 3.9.4
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description
Linear ticket: Closes [FER-7386: \[Intuit, Java\] Intuit null issues in PATCH endpoints](https://linear.app/buildwithfern/issue/FER-7386/intuit-java-intuit-null-issues-in-patch-endpoints)


Replace Optional<T> with Nullable<T> for proper three-state semantics in PATCH operations. Optional<T> can't distinguish "explicitly null" from "not provided", preventing intuit from clearing fields via PATCH.

## Changes Made
<!-- List the main changes and updates implemented in this PR -->

- Generate Nullable<T> for nullable fields with three states:
   - empty() → omitted from JSON
   - of(null) → `{"field": null}`
   - of(value) → `{"field": "value"}`
- Update serialization logic and add `hashCode()` implementation
- Maintain backward compatibility with Optional<T> APIs

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated
- [x] Manual testing completed
