### PR TITLE
chore(java): document `.withRawResponse` in README.md

### DIFF
--- a/generators/java-v2/sdk/features.yml
+++ b/generators/java-v2/sdk/features.yml
@@ -52,3 +52,10 @@ features:
     advanced: true
     description: |
       The SDK allows you to add custom headers to requests. You can configure headers at the client level or at the request level.
+
+  - id: ACCESS_RAW_RESPONSE_DATA
+    advanced: true
+    description: |
+      The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+      The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+      (A normal client's `response` is identical to a raw client's `response.body()`.)

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,3 +1,11 @@
+- version: 3.9.4
+  changelogEntry:
+    - summary: |
+        Documenting `.withRawResponse()` in `README.md`.
+      type: chore
+  createdAt: "2025-10-28"
+  irVersion: 61
+
 - version: 3.9.3
   changelogEntry:
     - summary: |

--- a/seed/java-sdk/accept-header/accept-header/README.md
+++ b/seed/java-sdk/accept-header/accept-header/README.md
@@ -175,6 +175,19 @@ client.service().endpoint(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+EndpointHttpResponse response = client.service().withRawResponse().endpoint(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/alias/README.md
+++ b/seed/java-sdk/alias/README.md
@@ -174,6 +174,19 @@ client.get(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+GetHttpResponse response = client.withRawResponse().get(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/any-auth/README.md
+++ b/seed/java-sdk/any-auth/README.md
@@ -185,6 +185,19 @@ client.auth().getToken(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+GetTokenHttpResponse response = client.auth().withRawResponse().getToken(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/api-wide-base-path/README.md
+++ b/seed/java-sdk/api-wide-base-path/README.md
@@ -174,6 +174,19 @@ client.service().post(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+PostHttpResponse response = client.service().withRawResponse().post(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/audiences/README.md
+++ b/seed/java-sdk/audiences/README.md
@@ -196,6 +196,19 @@ client.foo().find(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+FindHttpResponse response = client.foo().withRawResponse().find(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/auth-environment-variables/README.md
+++ b/seed/java-sdk/auth-environment-variables/README.md
@@ -175,6 +175,19 @@ client.service().getWithApiKey(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+GetWithApiKeyHttpResponse response = client.service().withRawResponse().getWithApiKey(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/basic-auth-environment-variables/README.md
+++ b/seed/java-sdk/basic-auth-environment-variables/README.md
@@ -178,6 +178,19 @@ client.basicAuth().postWithBasicAuth(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+PostWithBasicAuthHttpResponse response = client.basicAuth().withRawResponse().postWithBasicAuth(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/basic-auth/basic-auth/README.md
+++ b/seed/java-sdk/basic-auth/basic-auth/README.md
@@ -178,6 +178,19 @@ client.basicAuth().postWithBasicAuth(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+PostWithBasicAuthHttpResponse response = client.basicAuth().withRawResponse().postWithBasicAuth(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/bearer-token-environment-variable/README.md
+++ b/seed/java-sdk/bearer-token-environment-variable/README.md
@@ -175,6 +175,19 @@ client.service().getWithBearerToken(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+GetWithBearerTokenHttpResponse response = client.service().withRawResponse().getWithBearerToken(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/bytes-upload/README.md
+++ b/seed/java-sdk/bytes-upload/README.md
@@ -174,6 +174,19 @@ client.service().upload(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+UploadHttpResponse response = client.service().withRawResponse().upload(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/client-side-params/default/README.md
+++ b/seed/java-sdk/client-side-params/default/README.md
@@ -191,6 +191,19 @@ client.service().searchResources(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+SearchResourcesHttpResponse response = client.service().withRawResponse().searchResources(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/content-type/README.md
+++ b/seed/java-sdk/content-type/README.md
@@ -181,6 +181,19 @@ client.service().patch(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+PatchHttpResponse response = client.service().withRawResponse().patch(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/cross-package-type-names/README.md
+++ b/seed/java-sdk/cross-package-type-names/README.md
@@ -182,6 +182,19 @@ client.foo().find(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+FindHttpResponse response = client.foo().withRawResponse().find(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/custom-auth/custom-auth/README.md
+++ b/seed/java-sdk/custom-auth/custom-auth/README.md
@@ -178,6 +178,19 @@ client.customAuth().postWithCustomAuth(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+PostWithCustomAuthHttpResponse response = client.customAuth().withRawResponse().postWithCustomAuth(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/error-property/README.md
+++ b/seed/java-sdk/error-property/README.md
@@ -174,6 +174,19 @@ client.propertyBasedError().throwError(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+ThrowErrorHttpResponse response = client.propertyBasedError().withRawResponse().throwError(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/errors/README.md
+++ b/seed/java-sdk/errors/README.md
@@ -180,6 +180,19 @@ client.simple().fooWithoutEndpointError(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+FooWithoutEndpointErrorHttpResponse response = client.simple().withRawResponse().fooWithoutEndpointError(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/examples/default/README.md
+++ b/seed/java-sdk/examples/default/README.md
@@ -189,6 +189,19 @@ client.echo(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+EchoHttpResponse response = client.withRawResponse().echo(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/examples/inline-file-properties/README.md
+++ b/seed/java-sdk/examples/inline-file-properties/README.md
@@ -189,6 +189,19 @@ client.echo(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+EchoHttpResponse response = client.withRawResponse().echo(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/examples/no-custom-config/README.md
+++ b/seed/java-sdk/examples/no-custom-config/README.md
@@ -189,6 +189,19 @@ client.echo(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+EchoHttpResponse response = client.withRawResponse().echo(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/examples/readme-config/README.md
+++ b/seed/java-sdk/examples/readme-config/README.md
@@ -247,3 +247,16 @@ client.service().createMovie(
         .build()
 );
 ```
+
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+CreateMovieHttpResponse response = client.service().withRawResponse().createMovie(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```

--- a/seed/java-sdk/exhaustive/custom-client-class-name/README.md
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/README.md
@@ -178,6 +178,19 @@ client.endpoints().container().getAndReturnListOfPrimitives(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+GetAndReturnListOfPrimitivesHttpResponse response = client.endpoints().container().withRawResponse().getAndReturnListOfPrimitives(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/exhaustive/custom-dependency/README.md
+++ b/seed/java-sdk/exhaustive/custom-dependency/README.md
@@ -178,6 +178,19 @@ client.endpoints().container().getAndReturnListOfPrimitives(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+GetAndReturnListOfPrimitivesHttpResponse response = client.endpoints().container().withRawResponse().getAndReturnListOfPrimitives(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/exhaustive/custom-error-names/README.md
+++ b/seed/java-sdk/exhaustive/custom-error-names/README.md
@@ -178,6 +178,19 @@ client.endpoints().container().getAndReturnListOfPrimitives(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+GetAndReturnListOfPrimitivesHttpResponse response = client.endpoints().container().withRawResponse().getAndReturnListOfPrimitives(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/exhaustive/custom-license/README.md
+++ b/seed/java-sdk/exhaustive/custom-license/README.md
@@ -178,6 +178,19 @@ client.endpoints().container().getAndReturnListOfPrimitives(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+GetAndReturnListOfPrimitivesHttpResponse response = client.endpoints().container().withRawResponse().getAndReturnListOfPrimitives(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/exhaustive/enable-public-constructors/README.md
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/README.md
@@ -178,6 +178,19 @@ client.endpoints().container().getAndReturnListOfPrimitives(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+GetAndReturnListOfPrimitivesHttpResponse response = client.endpoints().container().withRawResponse().getAndReturnListOfPrimitives(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/exhaustive/flat-package-layout/README.md
+++ b/seed/java-sdk/exhaustive/flat-package-layout/README.md
@@ -178,6 +178,19 @@ client.endpoints().container().getAndReturnListOfPrimitives(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+GetAndReturnListOfPrimitivesHttpResponse response = client.endpoints().container().withRawResponse().getAndReturnListOfPrimitives(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/README.md
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/README.md
@@ -178,6 +178,19 @@ client.endpoints().container().getAndReturnListOfPrimitives(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+GetAndReturnListOfPrimitivesHttpResponse response = client.endpoints().container().withRawResponse().getAndReturnListOfPrimitives(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/exhaustive/json-include-non-empty/README.md
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/README.md
@@ -178,6 +178,19 @@ client.endpoints().container().getAndReturnListOfPrimitives(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+GetAndReturnListOfPrimitivesHttpResponse response = client.endpoints().container().withRawResponse().getAndReturnListOfPrimitives(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/exhaustive/local-files/README.md
+++ b/seed/java-sdk/exhaustive/local-files/README.md
@@ -153,6 +153,19 @@ client.endpoints().container().getAndReturnListOfPrimitives(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+GetAndReturnListOfPrimitivesHttpResponse response = client.endpoints().container().withRawResponse().getAndReturnListOfPrimitives(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/exhaustive/no-custom-config/README.md
+++ b/seed/java-sdk/exhaustive/no-custom-config/README.md
@@ -178,6 +178,19 @@ client.endpoints().container().getAndReturnListOfPrimitives(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+GetAndReturnListOfPrimitivesHttpResponse response = client.endpoints().container().withRawResponse().getAndReturnListOfPrimitives(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/exhaustive/publish-to/README.md
+++ b/seed/java-sdk/exhaustive/publish-to/README.md
@@ -178,6 +178,19 @@ client.endpoints().container().getAndReturnListOfPrimitives(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+GetAndReturnListOfPrimitivesHttpResponse response = client.endpoints().container().withRawResponse().getAndReturnListOfPrimitives(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/exhaustive/signed_publish/README.md
+++ b/seed/java-sdk/exhaustive/signed_publish/README.md
@@ -178,6 +178,19 @@ client.endpoints().container().getAndReturnListOfPrimitives(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+GetAndReturnListOfPrimitivesHttpResponse response = client.endpoints().container().withRawResponse().getAndReturnListOfPrimitives(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/extra-properties/README.md
+++ b/seed/java-sdk/extra-properties/README.md
@@ -182,6 +182,19 @@ client.user().createUser(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+CreateUserHttpResponse response = client.user().withRawResponse().createUser(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/file-download/README.md
+++ b/seed/java-sdk/file-download/README.md
@@ -174,6 +174,19 @@ client.service().simple(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+SimpleHttpResponse response = client.service().withRawResponse().simple(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/file-upload-openapi/README.md
+++ b/seed/java-sdk/file-upload-openapi/README.md
@@ -180,6 +180,19 @@ client.fileUploadExample().uploadFile(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+UploadFileHttpResponse response = client.fileUploadExample().withRawResponse().uploadFile(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/file-upload/inline-file-properties/README.md
+++ b/seed/java-sdk/file-upload/inline-file-properties/README.md
@@ -179,6 +179,19 @@ client.service().justFile(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+JustFileHttpResponse response = client.service().withRawResponse().justFile(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/file-upload/no-custom-config/README.md
+++ b/seed/java-sdk/file-upload/no-custom-config/README.md
@@ -179,6 +179,19 @@ client.service().justFile(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+JustFileHttpResponse response = client.service().withRawResponse().justFile(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/file-upload/wrapped-aliases/README.md
+++ b/seed/java-sdk/file-upload/wrapped-aliases/README.md
@@ -179,6 +179,19 @@ client.service().justFile(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+JustFileHttpResponse response = client.service().withRawResponse().justFile(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/folders/README.md
+++ b/seed/java-sdk/folders/README.md
@@ -174,6 +174,19 @@ client.foo(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+FooHttpResponse response = client.withRawResponse().foo(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/http-head/README.md
+++ b/seed/java-sdk/http-head/README.md
@@ -174,6 +174,19 @@ client.user().head(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+HeadHttpResponse response = client.user().withRawResponse().head(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/idempotency-headers/README.md
+++ b/seed/java-sdk/idempotency-headers/README.md
@@ -183,6 +183,19 @@ client.payment().create(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+CreateHttpResponse response = client.payment().withRawResponse().create(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/imdb/disable-required-property-builder-checks/README.md
+++ b/seed/java-sdk/imdb/disable-required-property-builder-checks/README.md
@@ -182,6 +182,19 @@ client.imdb().createMovie(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+CreateMovieHttpResponse response = client.imdb().withRawResponse().createMovie(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/imdb/flat-package-layout/README.md
+++ b/seed/java-sdk/imdb/flat-package-layout/README.md
@@ -182,6 +182,19 @@ client.imdb().createMovie(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+CreateMovieHttpResponse response = client.imdb().withRawResponse().createMovie(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/java-builder-extension/base-client/README.md
+++ b/seed/java-sdk/java-builder-extension/base-client/README.md
@@ -189,6 +189,19 @@ client.service().hello(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+HelloHttpResponse response = client.service().withRawResponse().hello(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/java-builder-extension/extensible-builders/README.md
+++ b/seed/java-sdk/java-builder-extension/extensible-builders/README.md
@@ -189,6 +189,19 @@ client.service().hello(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+HelloHttpResponse response = client.service().withRawResponse().hello(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/java-custom-package-prefix/java-custom-package-prefix/README.md
+++ b/seed/java-sdk/java-custom-package-prefix/java-custom-package-prefix/README.md
@@ -182,6 +182,19 @@ client.imdb().createMovie(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+CreateMovieHttpResponse response = client.imdb().withRawResponse().createMovie(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/java-inline-types/enable-forward-compatible-enums/README.md
+++ b/seed/java-sdk/java-inline-types/enable-forward-compatible-enums/README.md
@@ -187,6 +187,19 @@ client.getRoot(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+GetRootHttpResponse response = client.withRawResponse().getRoot(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/java-inline-types/inline/README.md
+++ b/seed/java-sdk/java-inline-types/inline/README.md
@@ -187,6 +187,19 @@ client.getRoot(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+GetRootHttpResponse response = client.withRawResponse().getRoot(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/java-inline-types/no-inline/README.md
+++ b/seed/java-sdk/java-inline-types/no-inline/README.md
@@ -187,6 +187,19 @@ client.getRoot(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+GetRootHttpResponse response = client.withRawResponse().getRoot(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/java-inline-types/no-wrapped-aliases/README.md
+++ b/seed/java-sdk/java-inline-types/no-wrapped-aliases/README.md
@@ -187,6 +187,19 @@ client.getRoot(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+GetRootHttpResponse response = client.withRawResponse().getRoot(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/java-nullable-named-request-types/custom-config/README.md
+++ b/seed/java-sdk/java-nullable-named-request-types/custom-config/README.md
@@ -189,6 +189,19 @@ client.postWithNullableNamedRequestBodyType(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+PostWithNullableNamedRequestBodyTypeHttpResponse response = client.withRawResponse().postWithNullableNamedRequestBodyType(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/java-pagination-deep-cursor-path/java-pagination-deep-cursor-path/README.md
+++ b/seed/java-sdk/java-pagination-deep-cursor-path/java-pagination-deep-cursor-path/README.md
@@ -237,6 +237,19 @@ client.deepCursorPath().doThing(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+DoThingHttpResponse response = client.deepCursorPath().withRawResponse().doThing(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/java-pagination-deep-cursor-path/wire-tests/README.md
+++ b/seed/java-sdk/java-pagination-deep-cursor-path/wire-tests/README.md
@@ -237,6 +237,19 @@ client.deepCursorPath().doThing(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+DoThingHttpResponse response = client.deepCursorPath().withRawResponse().doThing(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/java-single-property-endpoint/java-single-property-endpoint/README.md
+++ b/seed/java-sdk/java-single-property-endpoint/java-single-property-endpoint/README.md
@@ -181,6 +181,19 @@ client.singleProperty().doThing(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+DoThingHttpResponse response = client.singleProperty().withRawResponse().doThing(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/license/README.md
+++ b/seed/java-sdk/license/README.md
@@ -174,6 +174,19 @@ client.get(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+GetHttpResponse response = client.withRawResponse().get(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/literal/README.md
+++ b/seed/java-sdk/literal/README.md
@@ -182,6 +182,19 @@ client.headers().send(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+SendHttpResponse response = client.headers().withRawResponse().send(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/mixed-case/README.md
+++ b/seed/java-sdk/mixed-case/README.md
@@ -174,6 +174,19 @@ client.service().getResource(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+GetResourceHttpResponse response = client.service().withRawResponse().getResource(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/mixed-file-directory/README.md
+++ b/seed/java-sdk/mixed-file-directory/README.md
@@ -180,6 +180,19 @@ client.organization().create(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+CreateHttpResponse response = client.organization().withRawResponse().create(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/multi-line-docs/README.md
+++ b/seed/java-sdk/multi-line-docs/README.md
@@ -181,6 +181,19 @@ client.user().createUser(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+CreateUserHttpResponse response = client.user().withRawResponse().createUser(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/multi-url-environment-no-default/README.md
+++ b/seed/java-sdk/multi-url-environment-no-default/README.md
@@ -195,6 +195,19 @@ client.ec2().bootInstance(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+BootInstanceHttpResponse response = client.ec2().withRawResponse().bootInstance(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/multi-url-environment/README.md
+++ b/seed/java-sdk/multi-url-environment/README.md
@@ -195,6 +195,19 @@ client.ec2().bootInstance(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+BootInstanceHttpResponse response = client.ec2().withRawResponse().bootInstance(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/multiple-request-bodies/README.md
+++ b/seed/java-sdk/multiple-request-bodies/README.md
@@ -203,6 +203,19 @@ client.uploadJsonDocument(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+UploadJsonDocumentHttpResponse response = client.withRawResponse().uploadJsonDocument(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/no-environment/README.md
+++ b/seed/java-sdk/no-environment/README.md
@@ -175,6 +175,19 @@ client.dummy().getDummy(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+GetDummyHttpResponse response = client.dummy().withRawResponse().getDummy(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/nullable-optional/legacy/README.md
+++ b/seed/java-sdk/nullable-optional/legacy/README.md
@@ -195,6 +195,19 @@ client.nullableOptional().createUser(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+CreateUserHttpResponse response = client.nullableOptional().withRawResponse().createUser(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/nullable-optional/with-nullable-annotation/README.md
+++ b/seed/java-sdk/nullable-optional/with-nullable-annotation/README.md
@@ -195,6 +195,19 @@ client.nullableOptional().createUser(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+CreateUserHttpResponse response = client.nullableOptional().withRawResponse().createUser(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/nullable/no-custom-config/README.md
+++ b/seed/java-sdk/nullable/no-custom-config/README.md
@@ -209,6 +209,19 @@ client.nullable().createUser(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+CreateUserHttpResponse response = client.nullable().withRawResponse().createUser(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/nullable/wrapped-aliases/README.md
+++ b/seed/java-sdk/nullable/wrapped-aliases/README.md
@@ -209,6 +209,19 @@ client.nullable().createUser(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+CreateUserHttpResponse response = client.nullable().withRawResponse().createUser(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/oauth-client-credentials-custom/README.md
+++ b/seed/java-sdk/oauth-client-credentials-custom/README.md
@@ -188,6 +188,19 @@ client.auth().getTokenWithClientCredentials(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+GetTokenWithClientCredentialsHttpResponse response = client.auth().withRawResponse().getTokenWithClientCredentials(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/oauth-client-credentials-default/README.md
+++ b/seed/java-sdk/oauth-client-credentials-default/README.md
@@ -184,6 +184,19 @@ client.auth().getToken(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+GetTokenHttpResponse response = client.auth().withRawResponse().getToken(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/oauth-client-credentials-environment-variables/README.md
+++ b/seed/java-sdk/oauth-client-credentials-environment-variables/README.md
@@ -186,6 +186,19 @@ client.auth().getTokenWithClientCredentials(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+GetTokenWithClientCredentialsHttpResponse response = client.auth().withRawResponse().getTokenWithClientCredentials(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/oauth-client-credentials-nested-root/README.md
+++ b/seed/java-sdk/oauth-client-credentials-nested-root/README.md
@@ -186,6 +186,19 @@ client.auth().getToken(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+GetTokenHttpResponse response = client.auth().withRawResponse().getToken(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/oauth-client-credentials-with-variables/README.md
+++ b/seed/java-sdk/oauth-client-credentials-with-variables/README.md
@@ -186,6 +186,19 @@ client.auth().getTokenWithClientCredentials(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+GetTokenWithClientCredentialsHttpResponse response = client.auth().withRawResponse().getTokenWithClientCredentials(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/oauth-client-credentials/oauth-client-credentials/README.md
+++ b/seed/java-sdk/oauth-client-credentials/oauth-client-credentials/README.md
@@ -186,6 +186,19 @@ client.auth().getTokenWithClientCredentials(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+GetTokenWithClientCredentialsHttpResponse response = client.auth().withRawResponse().getTokenWithClientCredentials(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/optional/README.md
+++ b/seed/java-sdk/optional/README.md
@@ -184,6 +184,19 @@ client.optional().sendOptionalBody(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+SendOptionalBodyHttpResponse response = client.optional().withRawResponse().sendOptionalBody(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/package-yml/README.md
+++ b/seed/java-sdk/package-yml/README.md
@@ -182,6 +182,19 @@ client.echo(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+EchoHttpResponse response = client.withRawResponse().echo(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/pagination/default/README.md
+++ b/seed/java-sdk/pagination/default/README.md
@@ -242,6 +242,19 @@ client.complex().search(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+SearchHttpResponse response = client.complex().withRawResponse().search(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/path-parameters/README.md
+++ b/seed/java-sdk/path-parameters/README.md
@@ -185,6 +185,19 @@ client.user().createUser(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+CreateUserHttpResponse response = client.user().withRawResponse().createUser(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/plain-text/README.md
+++ b/seed/java-sdk/plain-text/README.md
@@ -174,6 +174,19 @@ client.service().getText(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+GetTextHttpResponse response = client.service().withRawResponse().getText(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/property-access/README.md
+++ b/seed/java-sdk/property-access/README.md
@@ -197,6 +197,19 @@ client.createUser(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+CreateUserHttpResponse response = client.withRawResponse().createUser(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/public-object/README.md
+++ b/seed/java-sdk/public-object/README.md
@@ -170,6 +170,19 @@ client.service().get(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+GetHttpResponse response = client.service().withRawResponse().get(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/query-parameters-openapi-as-objects/README.md
+++ b/seed/java-sdk/query-parameters-openapi-as-objects/README.md
@@ -297,6 +297,19 @@ client.search(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+SearchHttpResponse response = client.withRawResponse().search(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/query-parameters-openapi/README.md
+++ b/seed/java-sdk/query-parameters-openapi/README.md
@@ -294,6 +294,19 @@ client.search(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+SearchHttpResponse response = client.withRawResponse().search(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/query-parameters/README.md
+++ b/seed/java-sdk/query-parameters/README.md
@@ -262,6 +262,19 @@ client.user().getUsername(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+GetUsernameHttpResponse response = client.user().withRawResponse().getUsername(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/request-parameters/README.md
+++ b/seed/java-sdk/request-parameters/README.md
@@ -186,6 +186,19 @@ client.user().createUsername(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+CreateUsernameHttpResponse response = client.user().withRawResponse().createUsername(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/required-nullable/README.md
+++ b/seed/java-sdk/required-nullable/README.md
@@ -183,6 +183,19 @@ client.getFoo(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+GetFooHttpResponse response = client.withRawResponse().getFoo(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/reserved-keywords/README.md
+++ b/seed/java-sdk/reserved-keywords/README.md
@@ -180,6 +180,19 @@ client.package_().test(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+TestHttpResponse response = client.package_().withRawResponse().test(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/response-property/README.md
+++ b/seed/java-sdk/response-property/README.md
@@ -174,6 +174,19 @@ client.service().getMovie(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+GetMovieHttpResponse response = client.service().withRawResponse().getMovie(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/server-sent-event-examples/README.md
+++ b/seed/java-sdk/server-sent-event-examples/README.md
@@ -180,6 +180,19 @@ client.completions().stream(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+StreamHttpResponse response = client.completions().withRawResponse().stream(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/server-sent-events/README.md
+++ b/seed/java-sdk/server-sent-events/README.md
@@ -180,6 +180,19 @@ client.completions().stream(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+StreamHttpResponse response = client.completions().withRawResponse().stream(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/simple-api/README.md
+++ b/seed/java-sdk/simple-api/README.md
@@ -189,6 +189,19 @@ client.user().get(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+GetHttpResponse response = client.user().withRawResponse().get(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/simple-fhir/README.md
+++ b/seed/java-sdk/simple-fhir/README.md
@@ -174,6 +174,19 @@ client.getAccount(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+GetAccountHttpResponse response = client.withRawResponse().getAccount(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/single-url-environment-default/README.md
+++ b/seed/java-sdk/single-url-environment-default/README.md
@@ -189,6 +189,19 @@ client.dummy().getDummy(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+GetDummyHttpResponse response = client.dummy().withRawResponse().getDummy(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/single-url-environment-no-default/README.md
+++ b/seed/java-sdk/single-url-environment-no-default/README.md
@@ -189,6 +189,19 @@ client.dummy().getDummy(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+GetDummyHttpResponse response = client.dummy().withRawResponse().getDummy(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/streaming/README.md
+++ b/seed/java-sdk/streaming/README.md
@@ -181,6 +181,19 @@ client.dummy().generateStream(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+GenerateStreamHttpResponse response = client.dummy().withRawResponse().generateStream(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/trace/README.md
+++ b/seed/java-sdk/trace/README.md
@@ -194,6 +194,19 @@ client.admin().updateTestSubmissionStatus(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+UpdateTestSubmissionStatusHttpResponse response = client.admin().withRawResponse().updateTestSubmissionStatus(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/undiscriminated-union-with-response-property/README.md
+++ b/seed/java-sdk/undiscriminated-union-with-response-property/README.md
@@ -174,6 +174,19 @@ client.getUnion(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+GetUnionHttpResponse response = client.withRawResponse().getUnion(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/undiscriminated-unions/README.md
+++ b/seed/java-sdk/undiscriminated-unions/README.md
@@ -177,6 +177,19 @@ client.union().get(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+GetHttpResponse response = client.union().withRawResponse().get(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/unions/default/README.md
+++ b/seed/java-sdk/unions/default/README.md
@@ -174,6 +174,19 @@ client.bigunion().get(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+GetHttpResponse response = client.bigunion().withRawResponse().get(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/unknown/README.md
+++ b/seed/java-sdk/unknown/README.md
@@ -177,6 +177,19 @@ client.unknown().post(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+PostHttpResponse response = client.unknown().withRawResponse().post(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/url-form-encoded/README.md
+++ b/seed/java-sdk/url-form-encoded/README.md
@@ -181,6 +181,19 @@ client.submitFormData(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+SubmitFormDataHttpResponse response = client.withRawResponse().submitFormData(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/validation/README.md
+++ b/seed/java-sdk/validation/README.md
@@ -184,6 +184,19 @@ client.create(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+CreateHttpResponse response = client.withRawResponse().create(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/variables/README.md
+++ b/seed/java-sdk/variables/README.md
@@ -175,6 +175,19 @@ client.service().post(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+PostHttpResponse response = client.service().withRawResponse().post(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/version-no-default/README.md
+++ b/seed/java-sdk/version-no-default/README.md
@@ -174,6 +174,19 @@ client.user().getUser(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+GetUserHttpResponse response = client.user().withRawResponse().getUser(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/version/forward-compatible-enums/README.md
+++ b/seed/java-sdk/version/forward-compatible-enums/README.md
@@ -174,6 +174,19 @@ client.user().getUser(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+GetUserHttpResponse response = client.user().withRawResponse().getUser(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.

--- a/seed/java-sdk/version/no-custom-config/README.md
+++ b/seed/java-sdk/version/no-custom-config/README.md
@@ -174,6 +174,19 @@ client.user().getUser(
 );
 ```
 
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `withRawResponse()` method.
+The `withRawResponse()` method returns a raw client that wraps all responses with `body()` and `headers()` methods.
+(A normal client's `response` is identical to a raw client's `response.body()`.)
+
+```java
+GetUserHttpResponse response = client.user().withRawResponse().getUser(...);
+
+System.out.println(response.body());
+System.out.println(response.headers().get("X-My-Header"));
+```
+
 ## Contributing
 
 While we value open-source contributions to this SDK, this library is generated programmatically.


### PR DESCRIPTION
## Description
Linear ticket: Closes FER-7462
Documents `.withRawResponse()` in Java.

## Changes Made
Exclusively:
- [X] Updated README.md generator (if applicable)
