### PR TITLE
fix(ci): Update path filtering for seed and update-seed workflows

### DIFF
--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -70,6 +70,7 @@ jobs:
             generator-name: openapi
           - files: |
               generators/python/
+              generators/python-v2/
               seed/pydantic/seed.yml
               seed/pydantic-v2/seed.yml
               seed/python-sdk/seed.yml
@@ -81,17 +82,20 @@ jobs:
             generator-name: postman
           - files: |
               generators/java/
+              generators/java-v2/
               seed/java-sdk/seed.yml
               seed/java-model/seed.yml
               seed/java-spring/seed.yml
             generator-name: java
           - files: |
               generators/typescript/
+              generators/typescript-v2/
               seed/ts-sdk/seed.yml
               seed/ts-express/seed.yml
             generator-name: typescript
           - files: |
               generators/go/
+              generators/go-v2/
               seed/go-sdk/seed.yml
               seed/go-model/seed.yml
               seed/go-fiber/seed.yml
@@ -400,7 +404,7 @@ jobs:
         uses: ./.github/actions/run-seed-process
         with:
           sdk-name: pydantic
-          generator-path: generators/python
+          generator-path: generators/python generators/python-v2
           fixtures-to-run: ${{toJson(matrix.fixtures)}}
           job-index: ${{ strategy.job-index }}
           collect-metrics: ${{ needs.setup.outputs.post-metrics }}
@@ -430,7 +434,7 @@ jobs:
         uses: ./.github/actions/run-seed-process
         with:
           sdk-name: python-sdk
-          generator-path: generators/python
+          generator-path: generators/python generators/python-v2
           fixtures-to-run: ${{toJson(matrix.fixtures)}}
           job-index: ${{ strategy.job-index }}
           collect-metrics: ${{ needs.setup.outputs.post-metrics }}
@@ -461,7 +465,7 @@ jobs:
         uses: ./.github/actions/run-seed-process
         with:
           sdk-name: fastapi
-          generator-path: generators/python
+          generator-path: generators/python generators/python-v2
           fixtures-to-run: ${{toJson(matrix.fixtures)}}
           job-index: ${{ strategy.job-index }}
           collect-metrics: ${{ needs.setup.outputs.post-metrics }}
@@ -581,7 +585,7 @@ jobs:
         uses: ./.github/actions/run-seed-process
         with:
           sdk-name: java-model
-          generator-path: generators/java
+          generator-path: generators/java generators/java-v2
           fixtures-to-run: ${{toJson(matrix.fixtures)}}
           job-index: ${{ strategy.job-index }}
           collect-metrics: ${{ needs.setup.outputs.post-metrics }}
@@ -611,7 +615,7 @@ jobs:
         uses: ./.github/actions/run-seed-process
         with:
           sdk-name: java-spring
-          generator-path: generators/java
+          generator-path: generators/java generators/java-v2
           fixtures-to-run: ${{toJson(matrix.fixtures)}}
           job-index: ${{ strategy.job-index }}
           collect-metrics: ${{ needs.setup.outputs.post-metrics }}
@@ -641,7 +645,7 @@ jobs:
         uses: ./.github/actions/run-seed-process
         with:
           sdk-name: ts-sdk
-          generator-path: generators/typescript
+          generator-path: generators/typescript generators/typescript-v2
           fixtures-to-run: ${{toJson(matrix.fixtures)}}
           job-index: ${{ strategy.job-index }}
           collect-metrics: ${{ needs.setup.outputs.post-metrics }}
@@ -672,7 +676,7 @@ jobs:
         uses: ./.github/actions/run-seed-process
         with:
           sdk-name: ts-express
-          generator-path: generators/typescript
+          generator-path: generators/typescript generators/typescript-v2
           fixtures-to-run: ${{toJson(matrix.fixtures)}}
           job-index: ${{ strategy.job-index }}
           collect-metrics: ${{ needs.setup.outputs.post-metrics }}

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -73,6 +73,7 @@ jobs:
             generator-name: openapi
           - files: |
               generators/python/
+              generators/python-v2/
               seed/pydantic/
               seed/pydantic-v2/
               seed/python-sdk/
@@ -84,17 +85,20 @@ jobs:
             generator-name: postman
           - files: |
               generators/java/
+              generators/java-v2/
               seed/java-sdk/
               seed/java-model/
               seed/java-spring/
             generator-name: java
           - files: |
               generators/typescript/
+              generators/typescript-v2/
               seed/ts-sdk/
               seed/ts-express/
             generator-name: typescript
           - files: |
               generators/go/
+              generators/go-v2/
               seed/go-sdk/
               seed/go-model/
               seed/go-fiber/
@@ -434,7 +438,7 @@ jobs:
         uses: ./.github/actions/auto-update-seed
         with:
           generator-name: pydantic
-          generator-path: generators/python
+          generator-path: generators/python generators/python-v2
           allow-unexpected-failures: true
           fixtures-to-run: ${{ toJson(matrix.fixtures) }}
           index: ${{ strategy.job-index }}
@@ -599,7 +603,7 @@ jobs:
         uses: ./.github/actions/auto-update-seed
         with:
           generator-name: java-sdk
-          generator-path: generators/java
+          generator-path: generators/java generators/java-v2
           allow-unexpected-failures: true
           fixtures-to-run: ${{ toJson(matrix.fixtures) }}
           index: ${{ strategy.job-index }}
@@ -632,7 +636,7 @@ jobs:
         uses: ./.github/actions/auto-update-seed
         with:
           generator-name: java-model
-          generator-path: generators/java
+          generator-path: generators/java generators/java-v2
           allow-unexpected-failures: true
           fixtures-to-run: ${{ toJson(matrix.fixtures) }}
           index: ${{ strategy.job-index }}
@@ -665,7 +669,7 @@ jobs:
         uses: ./.github/actions/auto-update-seed
         with:
           generator-name: java-spring
-          generator-path: generators/java
+          generator-path: generators/java generators/java-v2
           allow-unexpected-failures: true
           fixtures-to-run: ${{ toJson(matrix.fixtures) }}
           index: ${{ strategy.job-index }}
@@ -698,7 +702,7 @@ jobs:
         uses: ./.github/actions/auto-update-seed
         with:
           generator-name: ts-sdk
-          generator-path: generators/typescript
+          generator-path: generators/typescript generators/typescript-v2
           allow-unexpected-failures: true
           fixtures-to-run: ${{ toJson(matrix.fixtures) }}
           index: ${{ strategy.job-index }}
@@ -731,7 +735,7 @@ jobs:
         uses: ./.github/actions/auto-update-seed
         with:
           generator-name: ts-express
-          generator-path: generators/typescript
+          generator-path: generators/typescript generators/typescript-v2
           allow-unexpected-failures: true
           fixtures-to-run: ${{ toJson(matrix.fixtures) }}
           index: ${{ strategy.job-index }}
@@ -764,7 +768,7 @@ jobs:
         uses: ./.github/actions/auto-update-seed
         with:
           generator-name: go-fiber
-          generator-path: generators/go
+          generator-path: generators/go generators/go-v2
           allow-unexpected-failures: true
           fixtures-to-run: ${{ toJson(matrix.fixtures) }}
           index: ${{ strategy.job-index }}
@@ -797,7 +801,7 @@ jobs:
         uses: ./.github/actions/auto-update-seed
         with:
           generator-name: go-model
-          generator-path: generators/go
+          generator-path: generators/go generators/go-v2
           allow-unexpected-failures: true
           fixtures-to-run: ${{ toJson(matrix.fixtures) }}
           index: ${{ strategy.job-index }}
@@ -830,7 +834,7 @@ jobs:
         uses: ./.github/actions/auto-update-seed
         with:
           generator-name: go-sdk
-          generator-path: generators/go
+          generator-path: generators/go generators/go-v2
           allow-unexpected-failures: true
           fixtures-to-run: ${{ toJson(matrix.fixtures) }}
           index: ${{ strategy.job-index }}


### PR DESCRIPTION
## Description
Linear ticket: Closes FER-7465
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
<!-- Provide a clear and concise description of the changes made in this PR -->
Updating file filtering to be more inclusive for -v2 paths

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Updating seed.yml and update-seed.yml workflows so they include v2 folders for generators

## Testing
<!-- Describe how you tested these changes -->
- Verified in CI here: https://github.com/fern-api/fern/actions/runs/18858743480
