### PR TITLE
fix(typescript): add streaming tests, fix custom message terminators, fix multi-byte characters

### DIFF
--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -2,7 +2,7 @@
 - version: 3.12.2
   changelogEntry:
     - summary: |
-        Add streaming tests; fix custom message terminators in streams; fix multi-byte character handling in streams.
+        Add streaming tests; fix custom message terminators in streams; fix multi-byte character handling across chunk breaks in streams.
       type: fix
   createdAt: "2025-10-28"
   irVersion: 60

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,11 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.12.2
+  changelogEntry:
+    - summary: |
+        Add streaming tests; fix custom message terminators in streams; fix multi-byte character handling in streams.
+      type: fix
+  createdAt: "2025-10-28"
+  irVersion: 60
 
 - version: 3.12.1
   changelogEntry:

--- a/generators/typescript/utils/commons/src/core-utilities/Stream.ts
+++ b/generators/typescript/utils/commons/src/core-utilities/Stream.ts
@@ -47,7 +47,7 @@ export const MANIFEST: CoreUtility.Manifest = {
     },
     dependsOn: [RuntimeManifest],
     getFilesPatterns: () => {
-        return { patterns: "src/core/stream/**" };
+        return { patterns: ["src/core/stream/**", "tests/unit/stream/**"] };
     }
 };
 

--- a/generators/typescript/utils/core-utilities/src/core/stream/Stream.template.ts
+++ b/generators/typescript/utils/core-utilities/src/core/stream/Stream.template.ts
@@ -76,7 +76,7 @@ export class Stream<T> implements AsyncIterable<T> {
 
             let terminatorIndex: number;
             while ((terminatorIndex = buf.indexOf(this.messageTerminator)) >= 0) {
-                let line = buf.slice(0, terminatorIndex + 1);
+                let line = buf.slice(0, terminatorIndex);
                 buf = buf.slice(terminatorIndex + this.messageTerminator.length);
 
                 if (!line.trim()) {

--- a/generators/typescript/utils/core-utilities/tests/unit/stream/Stream.test.template.ts
+++ b/generators/typescript/utils/core-utilities/tests/unit/stream/Stream.test.template.ts
@@ -1,0 +1,371 @@
+<% if (streamType === "wrapper") { %>
+import { Readable } from "stream";
+<% } %>
+import { Stream } from "../../../src/core/stream/Stream";
+
+describe("Stream", () => {
+    describe("JSON streaming", () => {
+        it("should parse single JSON message", async () => {
+            const mockStream = createReadableStream(['{"value": 1}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+        });
+
+        it("should parse multiple JSON messages", async () => {
+            const mockStream = createReadableStream(['{"value": 1}\n{"value": 2}\n{"value": 3}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
+        });
+
+        it("should handle messages split across chunks", async () => {
+            const mockStream = createReadableStream(['{"val', 'ue": 1}\n{"value":', ' 2}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+        });
+
+        it("should skip empty lines", async () => {
+            const mockStream = createReadableStream(['{"value": 1}\n\n\n{"value": 2}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+        });
+
+        it("should handle custom message terminator", async () => {
+            const mockStream = createReadableStream(['{"value": 1}|||{"value": 2}|||']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "|||" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+        });
+    });
+
+    describe("SSE streaming", () => {
+        it("should parse SSE data with prefix", async () => {
+            const mockStream = createReadableStream(['data: {"value": 1}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+        });
+
+        it("should parse multiple SSE events", async () => {
+            const mockStream = createReadableStream([
+                'data: {"value": 1}\ndata: {"value": 2}\ndata: {"value": 3}\n',
+            ]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
+        });
+
+        it("should stop at stream terminator", async () => {
+            const mockStream = createReadableStream([
+                'data: {"value": 1}\ndata: [DONE]\ndata: {"value": 2}\n',
+            ]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+        });
+
+        it("should skip lines without data prefix", async () => {
+            const mockStream = createReadableStream([
+                'event: message\ndata: {"value": 1}\nid: 123\ndata: {"value": 2}\n',
+            ]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+        });
+    });
+
+    describe("encoding and decoding", () => {
+        it("should decode UTF-8 text using TextDecoder", async () => {
+            const encoder = new TextEncoder();
+            const mockStream = createReadableStream([encoder.encode('{"text": "café"}\n')]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { text: string },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ text: "café" }]);
+        });
+
+        it("should decode emoji correctly", async () => {
+            const encoder = new TextEncoder();
+            const mockStream = createReadableStream([encoder.encode('{"emoji": "🎉"}\n')]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { emoji: string },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ emoji: "🎉" }]);
+        });
+
+        it("should handle binary data chunks", async () => {
+            const encoder = new TextEncoder();
+            const mockStream = createReadableStream([
+                encoder.encode('{"val'),
+                encoder.encode('ue": 1}\n'),
+            ]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+        });
+
+        it("should handle multi-byte UTF-8 characters split across chunk boundaries", async () => {
+            // Test string with Japanese (3 bytes), Russian (2 bytes), German (2 bytes), and Chinese (3 bytes)
+            const testString = '{"text": "こんにちは Привет Größe 你好"}\n';
+            const fullBytes = new TextEncoder().encode(testString);
+
+            // Split the bytes in the middle of multi-byte characters
+            // Japanese "こ" starts at byte 11, is 3 bytes (E3 81 93)
+            // Split after first byte of "こ" to test mid-character splitting
+            const splitPoint = 12; // This splits "こ" in the middle
+            const chunk1 = fullBytes.slice(0, splitPoint);
+            const chunk2 = fullBytes.slice(splitPoint);
+
+            const mockStream = createReadableStream([chunk1, chunk2]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { text: string },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ text: "こんにちは Привет Größe 你好" }]);
+        });
+    });
+
+    describe("abort signal", () => {
+        it("should handle abort signal", async () => {
+            const controller = new AbortController();
+            const mockStream = createReadableStream(['{"value": 1}\n{"value": 2}\n{"value": 3}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+                signal: controller.signal,
+            });
+
+            const messages: unknown[] = [];
+            let count = 0;
+            for await (const message of stream) {
+                messages.push(message);
+                count++;
+                if (count === 2) {
+                    controller.abort();
+                    break;
+                }
+            }
+
+            expect(messages.length).toBe(2);
+        });
+    });
+
+    describe("async iteration", () => {
+        it("should support async iterator protocol", async () => {
+            const mockStream = createReadableStream(['{"value": 1}\n{"value": 2}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const iterator = stream[Symbol.asyncIterator]();
+            const first = await iterator.next();
+            expect(first.done).toBe(false);
+            expect(first.value).toEqual({ value: 1 });
+
+            const second = await iterator.next();
+            expect(second.done).toBe(false);
+            expect(second.value).toEqual({ value: 2 });
+
+            const third = await iterator.next();
+            expect(third.done).toBe(true);
+        });
+    });
+
+    describe("edge cases", () => {
+        it("should handle empty stream", async () => {
+            const mockStream = createReadableStream([]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([]);
+        });
+
+        it("should handle stream with only whitespace", async () => {
+            const mockStream = createReadableStream(['   \n\n\t\n   ']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([]);
+        });
+
+        it("should handle incomplete message at end of stream", async () => {
+            const mockStream = createReadableStream(['{"value": 1}\n{"incomplete']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+        });
+    });
+});
+
+// Helper function to create a ReadableStream from string chunks
+function createReadableStream(chunks: (string | Uint8Array)[]): <% if (streamType === "wrapper") { %>Readable | <% } %>ReadableStream {
+<% if (streamType === "wrapper") { %>
+    // For wrapper type, return Node.js Readable stream
+    const readable = new Readable({
+        read() {
+            for (const chunk of chunks) {
+                this.push(typeof chunk === "string" ? chunk : Buffer.from(chunk));
+            }
+            this.push(null);
+        },
+    });
+    return readable;
+<% } else { %>
+    // For standard type, return ReadableStream
+    let index = 0;
+    return new ReadableStream({
+        pull(controller) {
+            if (index < chunks.length) {
+                const chunk = chunks[index++];
+                controller.enqueue(typeof chunk === "string" ? new TextEncoder().encode(chunk) : chunk);
+            } else {
+                controller.close();
+            }
+        },
+    });
+<% } %>
+}

--- a/seed/ts-sdk/server-sent-event-examples/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/server-sent-event-examples/src/core/stream/Stream.ts
@@ -43,6 +43,7 @@ export class Stream<T> implements AsyncIterable<T> {
     private messageTerminator: string;
     private streamTerminator: string | undefined;
     private controller: AbortController = new AbortController();
+    private decoder: TextDecoder | undefined;
 
     constructor({ stream, parse, eventShape, signal }: Stream.Args & { parse: (val: unknown) => Promise<T> }) {
         this.stream = stream;
@@ -55,6 +56,11 @@ export class Stream<T> implements AsyncIterable<T> {
             this.messageTerminator = eventShape.messageTerminator;
         }
         signal?.addEventListener("abort", () => this.controller.abort());
+
+        // Initialize shared TextDecoder
+        if (typeof TextDecoder !== "undefined") {
+            this.decoder = new TextDecoder("utf-8");
+        }
     }
 
     private async *iterMessages(): AsyncGenerator<T, void> {
@@ -67,7 +73,7 @@ export class Stream<T> implements AsyncIterable<T> {
 
             let terminatorIndex: number;
             while ((terminatorIndex = buf.indexOf(this.messageTerminator)) >= 0) {
-                let line = buf.slice(0, terminatorIndex + 1);
+                let line = buf.slice(0, terminatorIndex);
                 buf = buf.slice(terminatorIndex + this.messageTerminator.length);
 
                 if (!line.trim()) {
@@ -101,10 +107,9 @@ export class Stream<T> implements AsyncIterable<T> {
 
     private decodeChunk(chunk: any): string {
         let decoded = "";
-        // If TextDecoder is present, use it
-        if (typeof TextDecoder !== "undefined") {
-            const decoder = new TextDecoder("utf8");
-            decoded += decoder.decode(chunk);
+        // If TextDecoder is available, use the streaming decoder instance
+        if (this.decoder != null) {
+            decoded += this.decoder.decode(chunk, { stream: true });
         }
         // Buffer is present in Node.js environment
         else if (RUNTIME.type === "node" && typeof chunk !== "undefined") {

--- a/seed/ts-sdk/server-sent-event-examples/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/server-sent-event-examples/tests/unit/stream/Stream.test.ts
@@ -1,0 +1,348 @@
+import { Stream } from "../../../src/core/stream/Stream";
+
+describe("Stream", () => {
+    describe("JSON streaming", () => {
+        it("should parse single JSON message", async () => {
+            const mockStream = createReadableStream(['{"value": 1}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+        });
+
+        it("should parse multiple JSON messages", async () => {
+            const mockStream = createReadableStream(['{"value": 1}\n{"value": 2}\n{"value": 3}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
+        });
+
+        it("should handle messages split across chunks", async () => {
+            const mockStream = createReadableStream(['{"val', 'ue": 1}\n{"value":', " 2}\n"]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+        });
+
+        it("should skip empty lines", async () => {
+            const mockStream = createReadableStream(['{"value": 1}\n\n\n{"value": 2}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+        });
+
+        it("should handle custom message terminator", async () => {
+            const mockStream = createReadableStream(['{"value": 1}|||{"value": 2}|||']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "|||" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+        });
+    });
+
+    describe("SSE streaming", () => {
+        it("should parse SSE data with prefix", async () => {
+            const mockStream = createReadableStream(['data: {"value": 1}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+        });
+
+        it("should parse multiple SSE events", async () => {
+            const mockStream = createReadableStream(['data: {"value": 1}\ndata: {"value": 2}\ndata: {"value": 3}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
+        });
+
+        it("should stop at stream terminator", async () => {
+            const mockStream = createReadableStream(['data: {"value": 1}\ndata: [DONE]\ndata: {"value": 2}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+        });
+
+        it("should skip lines without data prefix", async () => {
+            const mockStream = createReadableStream([
+                'event: message\ndata: {"value": 1}\nid: 123\ndata: {"value": 2}\n',
+            ]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+        });
+    });
+
+    describe("encoding and decoding", () => {
+        it("should decode UTF-8 text using TextDecoder", async () => {
+            const encoder = new TextEncoder();
+            const mockStream = createReadableStream([encoder.encode('{"text": "café"}\n')]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { text: string },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ text: "café" }]);
+        });
+
+        it("should decode emoji correctly", async () => {
+            const encoder = new TextEncoder();
+            const mockStream = createReadableStream([encoder.encode('{"emoji": "🎉"}\n')]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { emoji: string },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ emoji: "🎉" }]);
+        });
+
+        it("should handle binary data chunks", async () => {
+            const encoder = new TextEncoder();
+            const mockStream = createReadableStream([encoder.encode('{"val'), encoder.encode('ue": 1}\n')]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+        });
+
+        it("should handle multi-byte UTF-8 characters split across chunk boundaries", async () => {
+            // Test string with Japanese (3 bytes), Russian (2 bytes), German (2 bytes), and Chinese (3 bytes)
+            const testString = '{"text": "こんにちは Привет Größe 你好"}\n';
+            const fullBytes = new TextEncoder().encode(testString);
+
+            // Split the bytes in the middle of multi-byte characters
+            // Japanese "こ" starts at byte 11, is 3 bytes (E3 81 93)
+            // Split after first byte of "こ" to test mid-character splitting
+            const splitPoint = 12; // This splits "こ" in the middle
+            const chunk1 = fullBytes.slice(0, splitPoint);
+            const chunk2 = fullBytes.slice(splitPoint);
+
+            const mockStream = createReadableStream([chunk1, chunk2]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { text: string },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ text: "こんにちは Привет Größe 你好" }]);
+        });
+    });
+
+    describe("abort signal", () => {
+        it("should handle abort signal", async () => {
+            const controller = new AbortController();
+            const mockStream = createReadableStream(['{"value": 1}\n{"value": 2}\n{"value": 3}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+                signal: controller.signal,
+            });
+
+            const messages: unknown[] = [];
+            let count = 0;
+            for await (const message of stream) {
+                messages.push(message);
+                count++;
+                if (count === 2) {
+                    controller.abort();
+                    break;
+                }
+            }
+
+            expect(messages.length).toBe(2);
+        });
+    });
+
+    describe("async iteration", () => {
+        it("should support async iterator protocol", async () => {
+            const mockStream = createReadableStream(['{"value": 1}\n{"value": 2}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const iterator = stream[Symbol.asyncIterator]();
+            const first = await iterator.next();
+            expect(first.done).toBe(false);
+            expect(first.value).toEqual({ value: 1 });
+
+            const second = await iterator.next();
+            expect(second.done).toBe(false);
+            expect(second.value).toEqual({ value: 2 });
+
+            const third = await iterator.next();
+            expect(third.done).toBe(true);
+        });
+    });
+
+    describe("edge cases", () => {
+        it("should handle empty stream", async () => {
+            const mockStream = createReadableStream([]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([]);
+        });
+
+        it("should handle stream with only whitespace", async () => {
+            const mockStream = createReadableStream(["   \n\n\t\n   "]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([]);
+        });
+
+        it("should handle incomplete message at end of stream", async () => {
+            const mockStream = createReadableStream(['{"value": 1}\n{"incomplete']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+        });
+    });
+});
+
+// Helper function to create a ReadableStream from string chunks
+function createReadableStream(chunks: (string | Uint8Array)[]): ReadableStream {
+    // For standard type, return ReadableStream
+    let index = 0;
+    return new ReadableStream({
+        pull(controller) {
+            if (index < chunks.length) {
+                const chunk = chunks[index++];
+                controller.enqueue(typeof chunk === "string" ? new TextEncoder().encode(chunk) : chunk);
+            } else {
+                controller.close();
+            }
+        },
+    });
+}

--- a/seed/ts-sdk/server-sent-events/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/server-sent-events/src/core/stream/Stream.ts
@@ -43,6 +43,7 @@ export class Stream<T> implements AsyncIterable<T> {
     private messageTerminator: string;
     private streamTerminator: string | undefined;
     private controller: AbortController = new AbortController();
+    private decoder: TextDecoder | undefined;
 
     constructor({ stream, parse, eventShape, signal }: Stream.Args & { parse: (val: unknown) => Promise<T> }) {
         this.stream = stream;
@@ -55,6 +56,11 @@ export class Stream<T> implements AsyncIterable<T> {
             this.messageTerminator = eventShape.messageTerminator;
         }
         signal?.addEventListener("abort", () => this.controller.abort());
+
+        // Initialize shared TextDecoder
+        if (typeof TextDecoder !== "undefined") {
+            this.decoder = new TextDecoder("utf-8");
+        }
     }
 
     private async *iterMessages(): AsyncGenerator<T, void> {
@@ -67,7 +73,7 @@ export class Stream<T> implements AsyncIterable<T> {
 
             let terminatorIndex: number;
             while ((terminatorIndex = buf.indexOf(this.messageTerminator)) >= 0) {
-                let line = buf.slice(0, terminatorIndex + 1);
+                let line = buf.slice(0, terminatorIndex);
                 buf = buf.slice(terminatorIndex + this.messageTerminator.length);
 
                 if (!line.trim()) {
@@ -101,10 +107,9 @@ export class Stream<T> implements AsyncIterable<T> {
 
     private decodeChunk(chunk: any): string {
         let decoded = "";
-        // If TextDecoder is present, use it
-        if (typeof TextDecoder !== "undefined") {
-            const decoder = new TextDecoder("utf8");
-            decoded += decoder.decode(chunk);
+        // If TextDecoder is available, use the streaming decoder instance
+        if (this.decoder != null) {
+            decoded += this.decoder.decode(chunk, { stream: true });
         }
         // Buffer is present in Node.js environment
         else if (RUNTIME.type === "node" && typeof chunk !== "undefined") {

--- a/seed/ts-sdk/server-sent-events/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/server-sent-events/tests/unit/stream/Stream.test.ts
@@ -1,0 +1,348 @@
+import { Stream } from "../../../src/core/stream/Stream";
+
+describe("Stream", () => {
+    describe("JSON streaming", () => {
+        it("should parse single JSON message", async () => {
+            const mockStream = createReadableStream(['{"value": 1}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+        });
+
+        it("should parse multiple JSON messages", async () => {
+            const mockStream = createReadableStream(['{"value": 1}\n{"value": 2}\n{"value": 3}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
+        });
+
+        it("should handle messages split across chunks", async () => {
+            const mockStream = createReadableStream(['{"val', 'ue": 1}\n{"value":', " 2}\n"]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+        });
+
+        it("should skip empty lines", async () => {
+            const mockStream = createReadableStream(['{"value": 1}\n\n\n{"value": 2}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+        });
+
+        it("should handle custom message terminator", async () => {
+            const mockStream = createReadableStream(['{"value": 1}|||{"value": 2}|||']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "|||" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+        });
+    });
+
+    describe("SSE streaming", () => {
+        it("should parse SSE data with prefix", async () => {
+            const mockStream = createReadableStream(['data: {"value": 1}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+        });
+
+        it("should parse multiple SSE events", async () => {
+            const mockStream = createReadableStream(['data: {"value": 1}\ndata: {"value": 2}\ndata: {"value": 3}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
+        });
+
+        it("should stop at stream terminator", async () => {
+            const mockStream = createReadableStream(['data: {"value": 1}\ndata: [DONE]\ndata: {"value": 2}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+        });
+
+        it("should skip lines without data prefix", async () => {
+            const mockStream = createReadableStream([
+                'event: message\ndata: {"value": 1}\nid: 123\ndata: {"value": 2}\n',
+            ]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+        });
+    });
+
+    describe("encoding and decoding", () => {
+        it("should decode UTF-8 text using TextDecoder", async () => {
+            const encoder = new TextEncoder();
+            const mockStream = createReadableStream([encoder.encode('{"text": "café"}\n')]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { text: string },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ text: "café" }]);
+        });
+
+        it("should decode emoji correctly", async () => {
+            const encoder = new TextEncoder();
+            const mockStream = createReadableStream([encoder.encode('{"emoji": "🎉"}\n')]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { emoji: string },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ emoji: "🎉" }]);
+        });
+
+        it("should handle binary data chunks", async () => {
+            const encoder = new TextEncoder();
+            const mockStream = createReadableStream([encoder.encode('{"val'), encoder.encode('ue": 1}\n')]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+        });
+
+        it("should handle multi-byte UTF-8 characters split across chunk boundaries", async () => {
+            // Test string with Japanese (3 bytes), Russian (2 bytes), German (2 bytes), and Chinese (3 bytes)
+            const testString = '{"text": "こんにちは Привет Größe 你好"}\n';
+            const fullBytes = new TextEncoder().encode(testString);
+
+            // Split the bytes in the middle of multi-byte characters
+            // Japanese "こ" starts at byte 11, is 3 bytes (E3 81 93)
+            // Split after first byte of "こ" to test mid-character splitting
+            const splitPoint = 12; // This splits "こ" in the middle
+            const chunk1 = fullBytes.slice(0, splitPoint);
+            const chunk2 = fullBytes.slice(splitPoint);
+
+            const mockStream = createReadableStream([chunk1, chunk2]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { text: string },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ text: "こんにちは Привет Größe 你好" }]);
+        });
+    });
+
+    describe("abort signal", () => {
+        it("should handle abort signal", async () => {
+            const controller = new AbortController();
+            const mockStream = createReadableStream(['{"value": 1}\n{"value": 2}\n{"value": 3}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+                signal: controller.signal,
+            });
+
+            const messages: unknown[] = [];
+            let count = 0;
+            for await (const message of stream) {
+                messages.push(message);
+                count++;
+                if (count === 2) {
+                    controller.abort();
+                    break;
+                }
+            }
+
+            expect(messages.length).toBe(2);
+        });
+    });
+
+    describe("async iteration", () => {
+        it("should support async iterator protocol", async () => {
+            const mockStream = createReadableStream(['{"value": 1}\n{"value": 2}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const iterator = stream[Symbol.asyncIterator]();
+            const first = await iterator.next();
+            expect(first.done).toBe(false);
+            expect(first.value).toEqual({ value: 1 });
+
+            const second = await iterator.next();
+            expect(second.done).toBe(false);
+            expect(second.value).toEqual({ value: 2 });
+
+            const third = await iterator.next();
+            expect(third.done).toBe(true);
+        });
+    });
+
+    describe("edge cases", () => {
+        it("should handle empty stream", async () => {
+            const mockStream = createReadableStream([]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([]);
+        });
+
+        it("should handle stream with only whitespace", async () => {
+            const mockStream = createReadableStream(["   \n\n\t\n   "]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([]);
+        });
+
+        it("should handle incomplete message at end of stream", async () => {
+            const mockStream = createReadableStream(['{"value": 1}\n{"incomplete']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+        });
+    });
+});
+
+// Helper function to create a ReadableStream from string chunks
+function createReadableStream(chunks: (string | Uint8Array)[]): ReadableStream {
+    // For standard type, return ReadableStream
+    let index = 0;
+    return new ReadableStream({
+        pull(controller) {
+            if (index < chunks.length) {
+                const chunk = chunks[index++];
+                controller.enqueue(typeof chunk === "string" ? new TextEncoder().encode(chunk) : chunk);
+            } else {
+                controller.close();
+            }
+        },
+    });
+}

--- a/seed/ts-sdk/streaming-parameter/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/streaming-parameter/src/core/stream/Stream.ts
@@ -43,6 +43,7 @@ export class Stream<T> implements AsyncIterable<T> {
     private messageTerminator: string;
     private streamTerminator: string | undefined;
     private controller: AbortController = new AbortController();
+    private decoder: TextDecoder | undefined;
 
     constructor({ stream, parse, eventShape, signal }: Stream.Args & { parse: (val: unknown) => Promise<T> }) {
         this.stream = stream;
@@ -55,6 +56,11 @@ export class Stream<T> implements AsyncIterable<T> {
             this.messageTerminator = eventShape.messageTerminator;
         }
         signal?.addEventListener("abort", () => this.controller.abort());
+
+        // Initialize shared TextDecoder
+        if (typeof TextDecoder !== "undefined") {
+            this.decoder = new TextDecoder("utf-8");
+        }
     }
 
     private async *iterMessages(): AsyncGenerator<T, void> {
@@ -67,7 +73,7 @@ export class Stream<T> implements AsyncIterable<T> {
 
             let terminatorIndex: number;
             while ((terminatorIndex = buf.indexOf(this.messageTerminator)) >= 0) {
-                let line = buf.slice(0, terminatorIndex + 1);
+                let line = buf.slice(0, terminatorIndex);
                 buf = buf.slice(terminatorIndex + this.messageTerminator.length);
 
                 if (!line.trim()) {
@@ -101,10 +107,9 @@ export class Stream<T> implements AsyncIterable<T> {
 
     private decodeChunk(chunk: any): string {
         let decoded = "";
-        // If TextDecoder is present, use it
-        if (typeof TextDecoder !== "undefined") {
-            const decoder = new TextDecoder("utf8");
-            decoded += decoder.decode(chunk);
+        // If TextDecoder is available, use the streaming decoder instance
+        if (this.decoder != null) {
+            decoded += this.decoder.decode(chunk, { stream: true });
         }
         // Buffer is present in Node.js environment
         else if (RUNTIME.type === "node" && typeof chunk !== "undefined") {

--- a/seed/ts-sdk/streaming-parameter/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/streaming-parameter/tests/unit/stream/Stream.test.ts
@@ -1,0 +1,348 @@
+import { Stream } from "../../../src/core/stream/Stream";
+
+describe("Stream", () => {
+    describe("JSON streaming", () => {
+        it("should parse single JSON message", async () => {
+            const mockStream = createReadableStream(['{"value": 1}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+        });
+
+        it("should parse multiple JSON messages", async () => {
+            const mockStream = createReadableStream(['{"value": 1}\n{"value": 2}\n{"value": 3}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
+        });
+
+        it("should handle messages split across chunks", async () => {
+            const mockStream = createReadableStream(['{"val', 'ue": 1}\n{"value":', " 2}\n"]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+        });
+
+        it("should skip empty lines", async () => {
+            const mockStream = createReadableStream(['{"value": 1}\n\n\n{"value": 2}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+        });
+
+        it("should handle custom message terminator", async () => {
+            const mockStream = createReadableStream(['{"value": 1}|||{"value": 2}|||']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "|||" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+        });
+    });
+
+    describe("SSE streaming", () => {
+        it("should parse SSE data with prefix", async () => {
+            const mockStream = createReadableStream(['data: {"value": 1}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+        });
+
+        it("should parse multiple SSE events", async () => {
+            const mockStream = createReadableStream(['data: {"value": 1}\ndata: {"value": 2}\ndata: {"value": 3}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
+        });
+
+        it("should stop at stream terminator", async () => {
+            const mockStream = createReadableStream(['data: {"value": 1}\ndata: [DONE]\ndata: {"value": 2}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+        });
+
+        it("should skip lines without data prefix", async () => {
+            const mockStream = createReadableStream([
+                'event: message\ndata: {"value": 1}\nid: 123\ndata: {"value": 2}\n',
+            ]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+        });
+    });
+
+    describe("encoding and decoding", () => {
+        it("should decode UTF-8 text using TextDecoder", async () => {
+            const encoder = new TextEncoder();
+            const mockStream = createReadableStream([encoder.encode('{"text": "café"}\n')]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { text: string },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ text: "café" }]);
+        });
+
+        it("should decode emoji correctly", async () => {
+            const encoder = new TextEncoder();
+            const mockStream = createReadableStream([encoder.encode('{"emoji": "🎉"}\n')]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { emoji: string },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ emoji: "🎉" }]);
+        });
+
+        it("should handle binary data chunks", async () => {
+            const encoder = new TextEncoder();
+            const mockStream = createReadableStream([encoder.encode('{"val'), encoder.encode('ue": 1}\n')]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+        });
+
+        it("should handle multi-byte UTF-8 characters split across chunk boundaries", async () => {
+            // Test string with Japanese (3 bytes), Russian (2 bytes), German (2 bytes), and Chinese (3 bytes)
+            const testString = '{"text": "こんにちは Привет Größe 你好"}\n';
+            const fullBytes = new TextEncoder().encode(testString);
+
+            // Split the bytes in the middle of multi-byte characters
+            // Japanese "こ" starts at byte 11, is 3 bytes (E3 81 93)
+            // Split after first byte of "こ" to test mid-character splitting
+            const splitPoint = 12; // This splits "こ" in the middle
+            const chunk1 = fullBytes.slice(0, splitPoint);
+            const chunk2 = fullBytes.slice(splitPoint);
+
+            const mockStream = createReadableStream([chunk1, chunk2]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { text: string },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ text: "こんにちは Привет Größe 你好" }]);
+        });
+    });
+
+    describe("abort signal", () => {
+        it("should handle abort signal", async () => {
+            const controller = new AbortController();
+            const mockStream = createReadableStream(['{"value": 1}\n{"value": 2}\n{"value": 3}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+                signal: controller.signal,
+            });
+
+            const messages: unknown[] = [];
+            let count = 0;
+            for await (const message of stream) {
+                messages.push(message);
+                count++;
+                if (count === 2) {
+                    controller.abort();
+                    break;
+                }
+            }
+
+            expect(messages.length).toBe(2);
+        });
+    });
+
+    describe("async iteration", () => {
+        it("should support async iterator protocol", async () => {
+            const mockStream = createReadableStream(['{"value": 1}\n{"value": 2}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const iterator = stream[Symbol.asyncIterator]();
+            const first = await iterator.next();
+            expect(first.done).toBe(false);
+            expect(first.value).toEqual({ value: 1 });
+
+            const second = await iterator.next();
+            expect(second.done).toBe(false);
+            expect(second.value).toEqual({ value: 2 });
+
+            const third = await iterator.next();
+            expect(third.done).toBe(true);
+        });
+    });
+
+    describe("edge cases", () => {
+        it("should handle empty stream", async () => {
+            const mockStream = createReadableStream([]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([]);
+        });
+
+        it("should handle stream with only whitespace", async () => {
+            const mockStream = createReadableStream(["   \n\n\t\n   "]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([]);
+        });
+
+        it("should handle incomplete message at end of stream", async () => {
+            const mockStream = createReadableStream(['{"value": 1}\n{"incomplete']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+        });
+    });
+});
+
+// Helper function to create a ReadableStream from string chunks
+function createReadableStream(chunks: (string | Uint8Array)[]): ReadableStream {
+    // For standard type, return ReadableStream
+    let index = 0;
+    return new ReadableStream({
+        pull(controller) {
+            if (index < chunks.length) {
+                const chunk = chunks[index++];
+                controller.enqueue(typeof chunk === "string" ? new TextEncoder().encode(chunk) : chunk);
+            } else {
+                controller.close();
+            }
+        },
+    });
+}

--- a/seed/ts-sdk/streaming/no-custom-config/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/streaming/no-custom-config/src/core/stream/Stream.ts
@@ -43,6 +43,7 @@ export class Stream<T> implements AsyncIterable<T> {
     private messageTerminator: string;
     private streamTerminator: string | undefined;
     private controller: AbortController = new AbortController();
+    private decoder: TextDecoder | undefined;
 
     constructor({ stream, parse, eventShape, signal }: Stream.Args & { parse: (val: unknown) => Promise<T> }) {
         this.stream = stream;
@@ -55,6 +56,11 @@ export class Stream<T> implements AsyncIterable<T> {
             this.messageTerminator = eventShape.messageTerminator;
         }
         signal?.addEventListener("abort", () => this.controller.abort());
+
+        // Initialize shared TextDecoder
+        if (typeof TextDecoder !== "undefined") {
+            this.decoder = new TextDecoder("utf-8");
+        }
     }
 
     private async *iterMessages(): AsyncGenerator<T, void> {
@@ -67,7 +73,7 @@ export class Stream<T> implements AsyncIterable<T> {
 
             let terminatorIndex: number;
             while ((terminatorIndex = buf.indexOf(this.messageTerminator)) >= 0) {
-                let line = buf.slice(0, terminatorIndex + 1);
+                let line = buf.slice(0, terminatorIndex);
                 buf = buf.slice(terminatorIndex + this.messageTerminator.length);
 
                 if (!line.trim()) {
@@ -101,10 +107,9 @@ export class Stream<T> implements AsyncIterable<T> {
 
     private decodeChunk(chunk: any): string {
         let decoded = "";
-        // If TextDecoder is present, use it
-        if (typeof TextDecoder !== "undefined") {
-            const decoder = new TextDecoder("utf8");
-            decoded += decoder.decode(chunk);
+        // If TextDecoder is available, use the streaming decoder instance
+        if (this.decoder != null) {
+            decoded += this.decoder.decode(chunk, { stream: true });
         }
         // Buffer is present in Node.js environment
         else if (RUNTIME.type === "node" && typeof chunk !== "undefined") {

--- a/seed/ts-sdk/streaming/no-custom-config/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/streaming/no-custom-config/tests/unit/stream/Stream.test.ts
@@ -1,0 +1,348 @@
+import { Stream } from "../../../src/core/stream/Stream";
+
+describe("Stream", () => {
+    describe("JSON streaming", () => {
+        it("should parse single JSON message", async () => {
+            const mockStream = createReadableStream(['{"value": 1}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+        });
+
+        it("should parse multiple JSON messages", async () => {
+            const mockStream = createReadableStream(['{"value": 1}\n{"value": 2}\n{"value": 3}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
+        });
+
+        it("should handle messages split across chunks", async () => {
+            const mockStream = createReadableStream(['{"val', 'ue": 1}\n{"value":', " 2}\n"]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+        });
+
+        it("should skip empty lines", async () => {
+            const mockStream = createReadableStream(['{"value": 1}\n\n\n{"value": 2}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+        });
+
+        it("should handle custom message terminator", async () => {
+            const mockStream = createReadableStream(['{"value": 1}|||{"value": 2}|||']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "|||" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+        });
+    });
+
+    describe("SSE streaming", () => {
+        it("should parse SSE data with prefix", async () => {
+            const mockStream = createReadableStream(['data: {"value": 1}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+        });
+
+        it("should parse multiple SSE events", async () => {
+            const mockStream = createReadableStream(['data: {"value": 1}\ndata: {"value": 2}\ndata: {"value": 3}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
+        });
+
+        it("should stop at stream terminator", async () => {
+            const mockStream = createReadableStream(['data: {"value": 1}\ndata: [DONE]\ndata: {"value": 2}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+        });
+
+        it("should skip lines without data prefix", async () => {
+            const mockStream = createReadableStream([
+                'event: message\ndata: {"value": 1}\nid: 123\ndata: {"value": 2}\n',
+            ]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+        });
+    });
+
+    describe("encoding and decoding", () => {
+        it("should decode UTF-8 text using TextDecoder", async () => {
+            const encoder = new TextEncoder();
+            const mockStream = createReadableStream([encoder.encode('{"text": "café"}\n')]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { text: string },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ text: "café" }]);
+        });
+
+        it("should decode emoji correctly", async () => {
+            const encoder = new TextEncoder();
+            const mockStream = createReadableStream([encoder.encode('{"emoji": "🎉"}\n')]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { emoji: string },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ emoji: "🎉" }]);
+        });
+
+        it("should handle binary data chunks", async () => {
+            const encoder = new TextEncoder();
+            const mockStream = createReadableStream([encoder.encode('{"val'), encoder.encode('ue": 1}\n')]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+        });
+
+        it("should handle multi-byte UTF-8 characters split across chunk boundaries", async () => {
+            // Test string with Japanese (3 bytes), Russian (2 bytes), German (2 bytes), and Chinese (3 bytes)
+            const testString = '{"text": "こんにちは Привет Größe 你好"}\n';
+            const fullBytes = new TextEncoder().encode(testString);
+
+            // Split the bytes in the middle of multi-byte characters
+            // Japanese "こ" starts at byte 11, is 3 bytes (E3 81 93)
+            // Split after first byte of "こ" to test mid-character splitting
+            const splitPoint = 12; // This splits "こ" in the middle
+            const chunk1 = fullBytes.slice(0, splitPoint);
+            const chunk2 = fullBytes.slice(splitPoint);
+
+            const mockStream = createReadableStream([chunk1, chunk2]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { text: string },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ text: "こんにちは Привет Größe 你好" }]);
+        });
+    });
+
+    describe("abort signal", () => {
+        it("should handle abort signal", async () => {
+            const controller = new AbortController();
+            const mockStream = createReadableStream(['{"value": 1}\n{"value": 2}\n{"value": 3}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+                signal: controller.signal,
+            });
+
+            const messages: unknown[] = [];
+            let count = 0;
+            for await (const message of stream) {
+                messages.push(message);
+                count++;
+                if (count === 2) {
+                    controller.abort();
+                    break;
+                }
+            }
+
+            expect(messages.length).toBe(2);
+        });
+    });
+
+    describe("async iteration", () => {
+        it("should support async iterator protocol", async () => {
+            const mockStream = createReadableStream(['{"value": 1}\n{"value": 2}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const iterator = stream[Symbol.asyncIterator]();
+            const first = await iterator.next();
+            expect(first.done).toBe(false);
+            expect(first.value).toEqual({ value: 1 });
+
+            const second = await iterator.next();
+            expect(second.done).toBe(false);
+            expect(second.value).toEqual({ value: 2 });
+
+            const third = await iterator.next();
+            expect(third.done).toBe(true);
+        });
+    });
+
+    describe("edge cases", () => {
+        it("should handle empty stream", async () => {
+            const mockStream = createReadableStream([]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([]);
+        });
+
+        it("should handle stream with only whitespace", async () => {
+            const mockStream = createReadableStream(["   \n\n\t\n   "]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([]);
+        });
+
+        it("should handle incomplete message at end of stream", async () => {
+            const mockStream = createReadableStream(['{"value": 1}\n{"incomplete']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+        });
+    });
+});
+
+// Helper function to create a ReadableStream from string chunks
+function createReadableStream(chunks: (string | Uint8Array)[]): ReadableStream {
+    // For standard type, return ReadableStream
+    let index = 0;
+    return new ReadableStream({
+        pull(controller) {
+            if (index < chunks.length) {
+                const chunk = chunks[index++];
+                controller.enqueue(typeof chunk === "string" ? new TextEncoder().encode(chunk) : chunk);
+            } else {
+                controller.close();
+            }
+        },
+    });
+}

--- a/seed/ts-sdk/streaming/serde-layer/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/streaming/serde-layer/src/core/stream/Stream.ts
@@ -43,6 +43,7 @@ export class Stream<T> implements AsyncIterable<T> {
     private messageTerminator: string;
     private streamTerminator: string | undefined;
     private controller: AbortController = new AbortController();
+    private decoder: TextDecoder | undefined;
 
     constructor({ stream, parse, eventShape, signal }: Stream.Args & { parse: (val: unknown) => Promise<T> }) {
         this.stream = stream;
@@ -55,6 +56,11 @@ export class Stream<T> implements AsyncIterable<T> {
             this.messageTerminator = eventShape.messageTerminator;
         }
         signal?.addEventListener("abort", () => this.controller.abort());
+
+        // Initialize shared TextDecoder
+        if (typeof TextDecoder !== "undefined") {
+            this.decoder = new TextDecoder("utf-8");
+        }
     }
 
     private async *iterMessages(): AsyncGenerator<T, void> {
@@ -67,7 +73,7 @@ export class Stream<T> implements AsyncIterable<T> {
 
             let terminatorIndex: number;
             while ((terminatorIndex = buf.indexOf(this.messageTerminator)) >= 0) {
-                let line = buf.slice(0, terminatorIndex + 1);
+                let line = buf.slice(0, terminatorIndex);
                 buf = buf.slice(terminatorIndex + this.messageTerminator.length);
 
                 if (!line.trim()) {
@@ -101,10 +107,9 @@ export class Stream<T> implements AsyncIterable<T> {
 
     private decodeChunk(chunk: any): string {
         let decoded = "";
-        // If TextDecoder is present, use it
-        if (typeof TextDecoder !== "undefined") {
-            const decoder = new TextDecoder("utf8");
-            decoded += decoder.decode(chunk);
+        // If TextDecoder is available, use the streaming decoder instance
+        if (this.decoder != null) {
+            decoded += this.decoder.decode(chunk, { stream: true });
         }
         // Buffer is present in Node.js environment
         else if (RUNTIME.type === "node" && typeof chunk !== "undefined") {

--- a/seed/ts-sdk/streaming/serde-layer/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/streaming/serde-layer/tests/unit/stream/Stream.test.ts
@@ -1,0 +1,348 @@
+import { Stream } from "../../../src/core/stream/Stream";
+
+describe("Stream", () => {
+    describe("JSON streaming", () => {
+        it("should parse single JSON message", async () => {
+            const mockStream = createReadableStream(['{"value": 1}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+        });
+
+        it("should parse multiple JSON messages", async () => {
+            const mockStream = createReadableStream(['{"value": 1}\n{"value": 2}\n{"value": 3}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
+        });
+
+        it("should handle messages split across chunks", async () => {
+            const mockStream = createReadableStream(['{"val', 'ue": 1}\n{"value":', " 2}\n"]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+        });
+
+        it("should skip empty lines", async () => {
+            const mockStream = createReadableStream(['{"value": 1}\n\n\n{"value": 2}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+        });
+
+        it("should handle custom message terminator", async () => {
+            const mockStream = createReadableStream(['{"value": 1}|||{"value": 2}|||']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "|||" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+        });
+    });
+
+    describe("SSE streaming", () => {
+        it("should parse SSE data with prefix", async () => {
+            const mockStream = createReadableStream(['data: {"value": 1}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+        });
+
+        it("should parse multiple SSE events", async () => {
+            const mockStream = createReadableStream(['data: {"value": 1}\ndata: {"value": 2}\ndata: {"value": 3}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
+        });
+
+        it("should stop at stream terminator", async () => {
+            const mockStream = createReadableStream(['data: {"value": 1}\ndata: [DONE]\ndata: {"value": 2}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+        });
+
+        it("should skip lines without data prefix", async () => {
+            const mockStream = createReadableStream([
+                'event: message\ndata: {"value": 1}\nid: 123\ndata: {"value": 2}\n',
+            ]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+        });
+    });
+
+    describe("encoding and decoding", () => {
+        it("should decode UTF-8 text using TextDecoder", async () => {
+            const encoder = new TextEncoder();
+            const mockStream = createReadableStream([encoder.encode('{"text": "café"}\n')]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { text: string },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ text: "café" }]);
+        });
+
+        it("should decode emoji correctly", async () => {
+            const encoder = new TextEncoder();
+            const mockStream = createReadableStream([encoder.encode('{"emoji": "🎉"}\n')]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { emoji: string },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ emoji: "🎉" }]);
+        });
+
+        it("should handle binary data chunks", async () => {
+            const encoder = new TextEncoder();
+            const mockStream = createReadableStream([encoder.encode('{"val'), encoder.encode('ue": 1}\n')]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+        });
+
+        it("should handle multi-byte UTF-8 characters split across chunk boundaries", async () => {
+            // Test string with Japanese (3 bytes), Russian (2 bytes), German (2 bytes), and Chinese (3 bytes)
+            const testString = '{"text": "こんにちは Привет Größe 你好"}\n';
+            const fullBytes = new TextEncoder().encode(testString);
+
+            // Split the bytes in the middle of multi-byte characters
+            // Japanese "こ" starts at byte 11, is 3 bytes (E3 81 93)
+            // Split after first byte of "こ" to test mid-character splitting
+            const splitPoint = 12; // This splits "こ" in the middle
+            const chunk1 = fullBytes.slice(0, splitPoint);
+            const chunk2 = fullBytes.slice(splitPoint);
+
+            const mockStream = createReadableStream([chunk1, chunk2]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { text: string },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ text: "こんにちは Привет Größe 你好" }]);
+        });
+    });
+
+    describe("abort signal", () => {
+        it("should handle abort signal", async () => {
+            const controller = new AbortController();
+            const mockStream = createReadableStream(['{"value": 1}\n{"value": 2}\n{"value": 3}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+                signal: controller.signal,
+            });
+
+            const messages: unknown[] = [];
+            let count = 0;
+            for await (const message of stream) {
+                messages.push(message);
+                count++;
+                if (count === 2) {
+                    controller.abort();
+                    break;
+                }
+            }
+
+            expect(messages.length).toBe(2);
+        });
+    });
+
+    describe("async iteration", () => {
+        it("should support async iterator protocol", async () => {
+            const mockStream = createReadableStream(['{"value": 1}\n{"value": 2}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const iterator = stream[Symbol.asyncIterator]();
+            const first = await iterator.next();
+            expect(first.done).toBe(false);
+            expect(first.value).toEqual({ value: 1 });
+
+            const second = await iterator.next();
+            expect(second.done).toBe(false);
+            expect(second.value).toEqual({ value: 2 });
+
+            const third = await iterator.next();
+            expect(third.done).toBe(true);
+        });
+    });
+
+    describe("edge cases", () => {
+        it("should handle empty stream", async () => {
+            const mockStream = createReadableStream([]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([]);
+        });
+
+        it("should handle stream with only whitespace", async () => {
+            const mockStream = createReadableStream(["   \n\n\t\n   "]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([]);
+        });
+
+        it("should handle incomplete message at end of stream", async () => {
+            const mockStream = createReadableStream(['{"value": 1}\n{"incomplete']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+        });
+    });
+});
+
+// Helper function to create a ReadableStream from string chunks
+function createReadableStream(chunks: (string | Uint8Array)[]): ReadableStream {
+    // For standard type, return ReadableStream
+    let index = 0;
+    return new ReadableStream({
+        pull(controller) {
+            if (index < chunks.length) {
+                const chunk = chunks[index++];
+                controller.enqueue(typeof chunk === "string" ? new TextEncoder().encode(chunk) : chunk);
+            } else {
+                controller.close();
+            }
+        },
+    });
+}

--- a/seed/ts-sdk/streaming/wrapper/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/streaming/wrapper/src/core/stream/Stream.ts
@@ -45,6 +45,7 @@ export class Stream<T> implements AsyncIterable<T> {
     private messageTerminator: string;
     private streamTerminator: string | undefined;
     private controller: AbortController = new AbortController();
+    private decoder: TextDecoder | undefined;
 
     constructor({ stream, parse, eventShape, signal }: Stream.Args & { parse: (val: unknown) => Promise<T> }) {
         this.stream = stream;
@@ -57,6 +58,11 @@ export class Stream<T> implements AsyncIterable<T> {
             this.messageTerminator = eventShape.messageTerminator;
         }
         signal?.addEventListener("abort", () => this.controller.abort());
+
+        // Initialize shared TextDecoder
+        if (typeof TextDecoder !== "undefined") {
+            this.decoder = new TextDecoder("utf-8");
+        }
     }
 
     private async *iterMessages(): AsyncGenerator<T, void> {
@@ -69,7 +75,7 @@ export class Stream<T> implements AsyncIterable<T> {
 
             let terminatorIndex: number;
             while ((terminatorIndex = buf.indexOf(this.messageTerminator)) >= 0) {
-                let line = buf.slice(0, terminatorIndex + 1);
+                let line = buf.slice(0, terminatorIndex);
                 buf = buf.slice(terminatorIndex + this.messageTerminator.length);
 
                 if (!line.trim()) {
@@ -103,10 +109,9 @@ export class Stream<T> implements AsyncIterable<T> {
 
     private decodeChunk(chunk: any): string {
         let decoded = "";
-        // If TextDecoder is present, use it
-        if (typeof TextDecoder !== "undefined") {
-            const decoder = new TextDecoder("utf8");
-            decoded += decoder.decode(chunk);
+        // If TextDecoder is available, use the streaming decoder instance
+        if (this.decoder != null) {
+            decoded += this.decoder.decode(chunk, { stream: true });
         }
         // Buffer is present in Node.js environment
         else if (RUNTIME.type === "node" && typeof chunk !== "undefined") {

--- a/seed/ts-sdk/streaming/wrapper/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/streaming/wrapper/tests/unit/stream/Stream.test.ts
@@ -1,0 +1,348 @@
+import { Readable } from "stream";
+
+import { Stream } from "../../../src/core/stream/Stream";
+
+describe("Stream", () => {
+    describe("JSON streaming", () => {
+        it("should parse single JSON message", async () => {
+            const mockStream = createReadableStream(['{"value": 1}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+        });
+
+        it("should parse multiple JSON messages", async () => {
+            const mockStream = createReadableStream(['{"value": 1}\n{"value": 2}\n{"value": 3}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
+        });
+
+        it("should handle messages split across chunks", async () => {
+            const mockStream = createReadableStream(['{"val', 'ue": 1}\n{"value":', " 2}\n"]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+        });
+
+        it("should skip empty lines", async () => {
+            const mockStream = createReadableStream(['{"value": 1}\n\n\n{"value": 2}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+        });
+
+        it("should handle custom message terminator", async () => {
+            const mockStream = createReadableStream(['{"value": 1}|||{"value": 2}|||']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "|||" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+        });
+    });
+
+    describe("SSE streaming", () => {
+        it("should parse SSE data with prefix", async () => {
+            const mockStream = createReadableStream(['data: {"value": 1}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+        });
+
+        it("should parse multiple SSE events", async () => {
+            const mockStream = createReadableStream(['data: {"value": 1}\ndata: {"value": 2}\ndata: {"value": 3}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
+        });
+
+        it("should stop at stream terminator", async () => {
+            const mockStream = createReadableStream(['data: {"value": 1}\ndata: [DONE]\ndata: {"value": 2}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+        });
+
+        it("should skip lines without data prefix", async () => {
+            const mockStream = createReadableStream([
+                'event: message\ndata: {"value": 1}\nid: 123\ndata: {"value": 2}\n',
+            ]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+        });
+    });
+
+    describe("encoding and decoding", () => {
+        it("should decode UTF-8 text using TextDecoder", async () => {
+            const encoder = new TextEncoder();
+            const mockStream = createReadableStream([encoder.encode('{"text": "café"}\n')]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { text: string },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ text: "café" }]);
+        });
+
+        it("should decode emoji correctly", async () => {
+            const encoder = new TextEncoder();
+            const mockStream = createReadableStream([encoder.encode('{"emoji": "🎉"}\n')]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { emoji: string },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ emoji: "🎉" }]);
+        });
+
+        it("should handle binary data chunks", async () => {
+            const encoder = new TextEncoder();
+            const mockStream = createReadableStream([encoder.encode('{"val'), encoder.encode('ue": 1}\n')]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+        });
+
+        it("should handle multi-byte UTF-8 characters split across chunk boundaries", async () => {
+            // Test string with Japanese (3 bytes), Russian (2 bytes), German (2 bytes), and Chinese (3 bytes)
+            const testString = '{"text": "こんにちは Привет Größe 你好"}\n';
+            const fullBytes = new TextEncoder().encode(testString);
+
+            // Split the bytes in the middle of multi-byte characters
+            // Japanese "こ" starts at byte 11, is 3 bytes (E3 81 93)
+            // Split after first byte of "こ" to test mid-character splitting
+            const splitPoint = 12; // This splits "こ" in the middle
+            const chunk1 = fullBytes.slice(0, splitPoint);
+            const chunk2 = fullBytes.slice(splitPoint);
+
+            const mockStream = createReadableStream([chunk1, chunk2]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { text: string },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ text: "こんにちは Привет Größe 你好" }]);
+        });
+    });
+
+    describe("abort signal", () => {
+        it("should handle abort signal", async () => {
+            const controller = new AbortController();
+            const mockStream = createReadableStream(['{"value": 1}\n{"value": 2}\n{"value": 3}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+                signal: controller.signal,
+            });
+
+            const messages: unknown[] = [];
+            let count = 0;
+            for await (const message of stream) {
+                messages.push(message);
+                count++;
+                if (count === 2) {
+                    controller.abort();
+                    break;
+                }
+            }
+
+            expect(messages.length).toBe(2);
+        });
+    });
+
+    describe("async iteration", () => {
+        it("should support async iterator protocol", async () => {
+            const mockStream = createReadableStream(['{"value": 1}\n{"value": 2}\n']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const iterator = stream[Symbol.asyncIterator]();
+            const first = await iterator.next();
+            expect(first.done).toBe(false);
+            expect(first.value).toEqual({ value: 1 });
+
+            const second = await iterator.next();
+            expect(second.done).toBe(false);
+            expect(second.value).toEqual({ value: 2 });
+
+            const third = await iterator.next();
+            expect(third.done).toBe(true);
+        });
+    });
+
+    describe("edge cases", () => {
+        it("should handle empty stream", async () => {
+            const mockStream = createReadableStream([]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([]);
+        });
+
+        it("should handle stream with only whitespace", async () => {
+            const mockStream = createReadableStream(["   \n\n\t\n   "]);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([]);
+        });
+
+        it("should handle incomplete message at end of stream", async () => {
+            const mockStream = createReadableStream(['{"value": 1}\n{"incomplete']);
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "json", messageTerminator: "\n" },
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+        });
+    });
+});
+
+// Helper function to create a ReadableStream from string chunks
+function createReadableStream(chunks: (string | Uint8Array)[]): Readable | ReadableStream {
+    // For wrapper type, return Node.js Readable stream
+    const readable = new Readable({
+        read() {
+            for (const chunk of chunks) {
+                this.push(typeof chunk === "string" ? chunk : Buffer.from(chunk));
+            }
+            this.push(null);
+        },
+    });
+    return readable;
+}


### PR DESCRIPTION
## Description
Linear ticket: Closes FER-7475.
Resolves https://github.com/fern-api/fern/issues/9812 in the suggested manner; also adds a `Stream.test.ts` that generates when `Stream.ts` generates, which caught an entirely different issue related to custom message terminators that is also fixed.

## Changes Made
Fixes to `Stream.template.ts`; added `Stream.test.template.ts` which generates an 18-test, ~350 line test file in `tests/unit/stream`.

## Testing
Regenerating seed tests now, but you can see through the commits that the number of failing tests goes down commit by commit until it's 0.
- [X] Unit tests added/updated
- [X] Manual testing completed
