### PR TITLE
fix(typescript): Fix `.github/workflows/ci.yml` file when using OIDC for npm publishing

### DIFF
--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,15 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
-- version: 3.12.2
+- version: 3.12.3
   changelogEntry:
-    - summary: |
-        Add streaming tests; fix custom message terminators in streams; fix multi-byte character handling across chunk breaks in streams.
+    - summary: Fix `.github/workflows/ci.yml` file when using OIDC for npm publishing.
       type: fix
   createdAt: "2025-10-28"
   irVersion: 60
 
 - version: 3.12.2
   changelogEntry:
-    - summary: Fix `.github/workflows/ci.yml` file when using OIDC for npm publishing.
+    - summary: |
+        Add streaming tests; fix custom message terminators in streams; fix multi-byte character handling across chunk breaks in streams.
       type: fix
   createdAt: "2025-10-28"
   irVersion: 60

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,5 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 3.12.2
+  changelogEntry:
+    - summary: Fix `.github/workflows/ci.yml` file when using OIDC for npm publishing.
+      type: fix
+  createdAt: "2025-10-28"
+  irVersion: 60
+
 - version: 3.12.1
   changelogEntry:
     - summary: Update Biome to 2.3.1

--- a/generators/typescript/utils/abstract-generator-cli/src/writeGitHubWorkflows.ts
+++ b/generators/typescript/utils/abstract-generator-cli/src/writeGitHubWorkflows.ts
@@ -127,14 +127,6 @@ jobs:
 
       - name: Set up node
         uses: actions/setup-node@v4${
-            useOidc
-                ? `
-                
-      # Ensure npm 11.5.1 or later is installed for OIDC support
-      - name: Update npm
-        run: npm install -g npm@latest`
-                : ""
-        }${
             usePnpm
                 ? `
 
@@ -156,12 +148,15 @@ jobs:
                 : `
           npm config set //registry.npmjs.org/:_authToken \${NPM_TOKEN}`
         }
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ \${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access ${access} --tag alpha
+            publish --access ${access} --tag alpha
           elif [[ \${GITHUB_REF} == *beta* ]]; then
-            npm publish --access ${access} --tag beta
+            publish --access ${access} --tag beta
           else
-            npm publish --access ${access}
+            publish --access ${access}
           fi${
               useOidc
                   ? ""

--- a/seed/ts-sdk/accept-header/.github/workflows/ci.yml
+++ b/seed/ts-sdk/accept-header/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/alias-extends/.github/workflows/ci.yml
+++ b/seed/ts-sdk/alias-extends/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/alias/.github/workflows/ci.yml
+++ b/seed/ts-sdk/alias/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/any-auth/generate-endpoint-metadata/.github/workflows/ci.yml
+++ b/seed/ts-sdk/any-auth/generate-endpoint-metadata/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/any-auth/no-custom-config/.github/workflows/ci.yml
+++ b/seed/ts-sdk/any-auth/no-custom-config/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/api-wide-base-path/.github/workflows/ci.yml
+++ b/seed/ts-sdk/api-wide-base-path/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/audiences/no-custom-config/.github/workflows/ci.yml
+++ b/seed/ts-sdk/audiences/no-custom-config/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/audiences/with-partner-audience/.github/workflows/ci.yml
+++ b/seed/ts-sdk/audiences/with-partner-audience/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/auth-environment-variables/.github/workflows/ci.yml
+++ b/seed/ts-sdk/auth-environment-variables/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/basic-auth-environment-variables/.github/workflows/ci.yml
+++ b/seed/ts-sdk/basic-auth-environment-variables/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/basic-auth/.github/workflows/ci.yml
+++ b/seed/ts-sdk/basic-auth/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/bearer-token-environment-variable/.github/workflows/ci.yml
+++ b/seed/ts-sdk/bearer-token-environment-variable/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/bytes-upload/.github/workflows/ci.yml
+++ b/seed/ts-sdk/bytes-upload/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/circular-references-advanced/.github/workflows/ci.yml
+++ b/seed/ts-sdk/circular-references-advanced/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/circular-references/.github/workflows/ci.yml
+++ b/seed/ts-sdk/circular-references/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/client-side-params/.github/workflows/ci.yml
+++ b/seed/ts-sdk/client-side-params/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/content-type/.github/workflows/ci.yml
+++ b/seed/ts-sdk/content-type/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/cross-package-type-names/.github/workflows/ci.yml
+++ b/seed/ts-sdk/cross-package-type-names/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/custom-auth/.github/workflows/ci.yml
+++ b/seed/ts-sdk/custom-auth/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/empty-clients/.github/workflows/ci.yml
+++ b/seed/ts-sdk/empty-clients/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/enum/.github/workflows/ci.yml
+++ b/seed/ts-sdk/enum/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/error-property/no-custom-config/.github/workflows/ci.yml
+++ b/seed/ts-sdk/error-property/no-custom-config/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/error-property/union-utils/.github/workflows/ci.yml
+++ b/seed/ts-sdk/error-property/union-utils/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/errors/.github/workflows/ci.yml
+++ b/seed/ts-sdk/errors/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/examples/examples-with-api-reference/.github/workflows/ci.yml
+++ b/seed/ts-sdk/examples/examples-with-api-reference/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/examples/retain-original-casing/.github/workflows/ci.yml
+++ b/seed/ts-sdk/examples/retain-original-casing/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/.github/workflows/ci.yml
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/.github/workflows/ci.yml
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/exhaustive/bigint/.github/workflows/ci.yml
+++ b/seed/ts-sdk/exhaustive/bigint/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/.github/workflows/ci.yml
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/.github/workflows/ci.yml
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/exhaustive/never-throw-errors/.github/workflows/ci.yml
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/exhaustive/no-custom-config/.github/workflows/ci.yml
+++ b/seed/ts-sdk/exhaustive/no-custom-config/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/exhaustive/node-fetch/.github/workflows/ci.yml
+++ b/seed/ts-sdk/exhaustive/node-fetch/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/exhaustive/package-path/.github/workflows/ci.yml
+++ b/seed/ts-sdk/exhaustive/package-path/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/exhaustive/retain-original-casing/.github/workflows/ci.yml
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/exhaustive/serde-layer/.github/workflows/ci.yml
+++ b/seed/ts-sdk/exhaustive/serde-layer/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/exhaustive/use-jest/.github/workflows/ci.yml
+++ b/seed/ts-sdk/exhaustive/use-jest/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/.github/workflows/ci.yml
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/exhaustive/with-audiences/.github/workflows/ci.yml
+++ b/seed/ts-sdk/exhaustive/with-audiences/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/extends/.github/workflows/ci.yml
+++ b/seed/ts-sdk/extends/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/extra-properties/.github/workflows/ci.yml
+++ b/seed/ts-sdk/extra-properties/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/file-download/file-download-response-headers/.github/workflows/ci.yml
+++ b/seed/ts-sdk/file-download/file-download-response-headers/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/file-download/no-custom-config/.github/workflows/ci.yml
+++ b/seed/ts-sdk/file-download/no-custom-config/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/file-download/stream-wrapper/.github/workflows/ci.yml
+++ b/seed/ts-sdk/file-download/stream-wrapper/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/file-upload-openapi/.github/workflows/ci.yml
+++ b/seed/ts-sdk/file-upload-openapi/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/file-upload/form-data-node16/.github/workflows/ci.yml
+++ b/seed/ts-sdk/file-upload/form-data-node16/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/file-upload/inline/.github/workflows/ci.yml
+++ b/seed/ts-sdk/file-upload/inline/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/file-upload/no-custom-config/.github/workflows/ci.yml
+++ b/seed/ts-sdk/file-upload/no-custom-config/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/file-upload/serde/.github/workflows/ci.yml
+++ b/seed/ts-sdk/file-upload/serde/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/file-upload/use-jest/.github/workflows/ci.yml
+++ b/seed/ts-sdk/file-upload/use-jest/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/file-upload/wrapper/.github/workflows/ci.yml
+++ b/seed/ts-sdk/file-upload/wrapper/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/folders/.github/workflows/ci.yml
+++ b/seed/ts-sdk/folders/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/http-head/.github/workflows/ci.yml
+++ b/seed/ts-sdk/http-head/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/idempotency-headers/.github/workflows/ci.yml
+++ b/seed/ts-sdk/idempotency-headers/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/imdb/branded-string-aliases/.github/workflows/ci.yml
+++ b/seed/ts-sdk/imdb/branded-string-aliases/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/imdb/no-custom-config/.github/workflows/ci.yml
+++ b/seed/ts-sdk/imdb/no-custom-config/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/imdb/omit-undefined/.github/workflows/ci.yml
+++ b/seed/ts-sdk/imdb/omit-undefined/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/inferred-auth-explicit/.github/workflows/ci.yml
+++ b/seed/ts-sdk/inferred-auth-explicit/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/inferred-auth-implicit-no-expiry/.github/workflows/ci.yml
+++ b/seed/ts-sdk/inferred-auth-implicit-no-expiry/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/inferred-auth-implicit/.github/workflows/ci.yml
+++ b/seed/ts-sdk/inferred-auth-implicit/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/license/.github/workflows/ci.yml
+++ b/seed/ts-sdk/license/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/literal/.github/workflows/ci.yml
+++ b/seed/ts-sdk/literal/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/literals-unions/.github/workflows/ci.yml
+++ b/seed/ts-sdk/literals-unions/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/mixed-case/no-custom-config/.github/workflows/ci.yml
+++ b/seed/ts-sdk/mixed-case/no-custom-config/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/mixed-case/retain-original-casing/.github/workflows/ci.yml
+++ b/seed/ts-sdk/mixed-case/retain-original-casing/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/mixed-file-directory/.github/workflows/ci.yml
+++ b/seed/ts-sdk/mixed-file-directory/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/multi-line-docs/.github/workflows/ci.yml
+++ b/seed/ts-sdk/multi-line-docs/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/multi-url-environment-no-default/.github/workflows/ci.yml
+++ b/seed/ts-sdk/multi-url-environment-no-default/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/multi-url-environment/.github/workflows/ci.yml
+++ b/seed/ts-sdk/multi-url-environment/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/multiple-request-bodies/.github/workflows/ci.yml
+++ b/seed/ts-sdk/multiple-request-bodies/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/no-environment/.github/workflows/ci.yml
+++ b/seed/ts-sdk/no-environment/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/nullable-optional/.github/workflows/ci.yml
+++ b/seed/ts-sdk/nullable-optional/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/nullable/.github/workflows/ci.yml
+++ b/seed/ts-sdk/nullable/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/oauth-client-credentials-custom/.github/workflows/ci.yml
+++ b/seed/ts-sdk/oauth-client-credentials-custom/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/oauth-client-credentials-default/.github/workflows/ci.yml
+++ b/seed/ts-sdk/oauth-client-credentials-default/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/.github/workflows/ci.yml
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/.github/workflows/ci.yml
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/.github/workflows/ci.yml
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/oauth-client-credentials-with-variables/.github/workflows/ci.yml
+++ b/seed/ts-sdk/oauth-client-credentials-with-variables/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/oauth-client-credentials/no-custom-config/.github/workflows/ci.yml
+++ b/seed/ts-sdk/oauth-client-credentials/no-custom-config/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/oauth-client-credentials/serde/.github/workflows/ci.yml
+++ b/seed/ts-sdk/oauth-client-credentials/serde/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/object/.github/workflows/ci.yml
+++ b/seed/ts-sdk/object/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/objects-with-imports/.github/workflows/ci.yml
+++ b/seed/ts-sdk/objects-with-imports/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/optional/.github/workflows/ci.yml
+++ b/seed/ts-sdk/optional/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/package-yml/.github/workflows/ci.yml
+++ b/seed/ts-sdk/package-yml/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/pagination-custom/.github/workflows/ci.yml
+++ b/seed/ts-sdk/pagination-custom/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/pagination/.github/workflows/ci.yml
+++ b/seed/ts-sdk/pagination/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/path-parameters/inline-path-parameters-retain-original-casing/.github/workflows/ci.yml
+++ b/seed/ts-sdk/path-parameters/inline-path-parameters-retain-original-casing/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/path-parameters/inline-path-parameters-serde/.github/workflows/ci.yml
+++ b/seed/ts-sdk/path-parameters/inline-path-parameters-serde/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/path-parameters/inline-path-parameters/.github/workflows/ci.yml
+++ b/seed/ts-sdk/path-parameters/inline-path-parameters/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/path-parameters/no-custom-config/.github/workflows/ci.yml
+++ b/seed/ts-sdk/path-parameters/no-custom-config/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/path-parameters/retain-original-casing/.github/workflows/ci.yml
+++ b/seed/ts-sdk/path-parameters/retain-original-casing/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/plain-text/.github/workflows/ci.yml
+++ b/seed/ts-sdk/plain-text/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/property-access/generate-read-write-only-types/.github/workflows/ci.yml
+++ b/seed/ts-sdk/property-access/generate-read-write-only-types/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/property-access/no-custom-config/.github/workflows/ci.yml
+++ b/seed/ts-sdk/property-access/no-custom-config/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/public-object/.github/workflows/ci.yml
+++ b/seed/ts-sdk/public-object/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/query-parameters-openapi-as-objects/.github/workflows/ci.yml
+++ b/seed/ts-sdk/query-parameters-openapi-as-objects/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/query-parameters-openapi/.github/workflows/ci.yml
+++ b/seed/ts-sdk/query-parameters-openapi/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/query-parameters/no-custom-config/.github/workflows/ci.yml
+++ b/seed/ts-sdk/query-parameters/no-custom-config/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/query-parameters/serde/.github/workflows/ci.yml
+++ b/seed/ts-sdk/query-parameters/serde/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/request-parameters/flatten-request-parameters/.github/workflows/ci.yml
+++ b/seed/ts-sdk/request-parameters/flatten-request-parameters/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/request-parameters/no-custom-config/.github/workflows/ci.yml
+++ b/seed/ts-sdk/request-parameters/no-custom-config/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/.github/workflows/ci.yml
+++ b/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/request-parameters/use-default-request-parameter-values/.github/workflows/ci.yml
+++ b/seed/ts-sdk/request-parameters/use-default-request-parameter-values/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/required-nullable/.github/workflows/ci.yml
+++ b/seed/ts-sdk/required-nullable/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/reserved-keywords/.github/workflows/ci.yml
+++ b/seed/ts-sdk/reserved-keywords/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/response-property/.github/workflows/ci.yml
+++ b/seed/ts-sdk/response-property/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/server-sent-event-examples/.github/workflows/ci.yml
+++ b/seed/ts-sdk/server-sent-event-examples/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/server-sent-events/.github/workflows/ci.yml
+++ b/seed/ts-sdk/server-sent-events/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/simple-api/allow-custom-fetcher/.github/workflows/ci.yml
+++ b/seed/ts-sdk/simple-api/allow-custom-fetcher/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/simple-api/allow-extra-fields/.github/workflows/ci.yml
+++ b/seed/ts-sdk/simple-api/allow-extra-fields/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/simple-api/bundle/.github/workflows/ci.yml
+++ b/seed/ts-sdk/simple-api/bundle/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/simple-api/custom-package-json/.github/workflows/ci.yml
+++ b/seed/ts-sdk/simple-api/custom-package-json/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access restricted --tag alpha
+            publish --access restricted --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access restricted --tag beta
+            publish --access restricted --tag beta
           else
-            npm publish --access restricted
+            publish --access restricted
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/simple-api/jsr/.github/workflows/ci.yml
+++ b/seed/ts-sdk/simple-api/jsr/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/simple-api/legacy-exports/.github/workflows/ci.yml
+++ b/seed/ts-sdk/simple-api/legacy-exports/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/simple-api/no-custom-config/.github/workflows/ci.yml
+++ b/seed/ts-sdk/simple-api/no-custom-config/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/simple-api/no-linter/.github/workflows/ci.yml
+++ b/seed/ts-sdk/simple-api/no-linter/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/simple-api/no-scripts/.github/workflows/ci.yml
+++ b/seed/ts-sdk/simple-api/no-scripts/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/simple-api/oidc-token/.github/workflows/ci.yml
+++ b/seed/ts-sdk/simple-api/oidc-token/.github/workflows/ci.yml
@@ -53,10 +53,6 @@ jobs:
 
       - name: Set up node
         uses: actions/setup-node@v4
-                
-      # Ensure npm 11.5.1 or later is installed for OIDC support
-      - name: Update npm
-        run: npm install -g npm@latest
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -69,10 +65,13 @@ jobs:
 
       - name: Publish to npm
         run: |
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi

--- a/seed/ts-sdk/simple-api/omit-fern-headers/.github/workflows/ci.yml
+++ b/seed/ts-sdk/simple-api/omit-fern-headers/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/simple-api/use-prettier-no-linter/.github/workflows/ci.yml
+++ b/seed/ts-sdk/simple-api/use-prettier-no-linter/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
             - name: Publish to npm
               run: |
                   npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+                  publish() {  # use latest npm to ensure OIDC support
+                    npx -y npm@latest publish "$@"
+                  }
                   if [[ ${GITHUB_REF} == *alpha* ]]; then
-                    npm publish --access public --tag alpha
+                    publish --access public --tag alpha
                   elif [[ ${GITHUB_REF} == *beta* ]]; then
-                    npm publish --access public --tag beta
+                    publish --access public --tag beta
                   else
-                    npm publish --access public
+                    publish --access public
                   fi
               env:
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/simple-api/use-prettier/.github/workflows/ci.yml
+++ b/seed/ts-sdk/simple-api/use-prettier/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
             - name: Publish to npm
               run: |
                   npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+                  publish() {  # use latest npm to ensure OIDC support
+                    npx -y npm@latest publish "$@"
+                  }
                   if [[ ${GITHUB_REF} == *alpha* ]]; then
-                    npm publish --access public --tag alpha
+                    publish --access public --tag alpha
                   elif [[ ${GITHUB_REF} == *beta* ]]; then
-                    npm publish --access public --tag beta
+                    publish --access public --tag beta
                   else
-                    npm publish --access public
+                    publish --access public
                   fi
               env:
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/simple-api/use-yarn/.github/workflows/ci.yml
+++ b/seed/ts-sdk/simple-api/use-yarn/.github/workflows/ci.yml
@@ -55,12 +55,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/simple-fhir/.github/workflows/ci.yml
+++ b/seed/ts-sdk/simple-fhir/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/single-url-environment-default/.github/workflows/ci.yml
+++ b/seed/ts-sdk/single-url-environment-default/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/single-url-environment-no-default/.github/workflows/ci.yml
+++ b/seed/ts-sdk/single-url-environment-no-default/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/streaming-parameter/.github/workflows/ci.yml
+++ b/seed/ts-sdk/streaming-parameter/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/streaming/no-custom-config/.github/workflows/ci.yml
+++ b/seed/ts-sdk/streaming/no-custom-config/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/streaming/serde-layer/.github/workflows/ci.yml
+++ b/seed/ts-sdk/streaming/serde-layer/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/streaming/wrapper/.github/workflows/ci.yml
+++ b/seed/ts-sdk/streaming/wrapper/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/trace/exhaustive/.github/workflows/ci.yml
+++ b/seed/ts-sdk/trace/exhaustive/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/trace/no-custom-config/.github/workflows/ci.yml
+++ b/seed/ts-sdk/trace/no-custom-config/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/trace/serde-no-throwing/.github/workflows/ci.yml
+++ b/seed/ts-sdk/trace/serde-no-throwing/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/trace/serde/.github/workflows/ci.yml
+++ b/seed/ts-sdk/trace/serde/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/ts-express-casing/.github/workflows/ci.yml
+++ b/seed/ts-sdk/ts-express-casing/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/ts-inline-types/inline/.github/workflows/ci.yml
+++ b/seed/ts-sdk/ts-inline-types/inline/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/ts-inline-types/no-inline/.github/workflows/ci.yml
+++ b/seed/ts-sdk/ts-inline-types/no-inline/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/undiscriminated-union-with-response-property/.github/workflows/ci.yml
+++ b/seed/ts-sdk/undiscriminated-union-with-response-property/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/undiscriminated-unions/no-custom-config/.github/workflows/ci.yml
+++ b/seed/ts-sdk/undiscriminated-unions/no-custom-config/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/undiscriminated-unions/skip-response-validation/.github/workflows/ci.yml
+++ b/seed/ts-sdk/undiscriminated-unions/skip-response-validation/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/unions/.github/workflows/ci.yml
+++ b/seed/ts-sdk/unions/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/unknown/no-custom-config/.github/workflows/ci.yml
+++ b/seed/ts-sdk/unknown/no-custom-config/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/unknown/unknown-as-any/.github/workflows/ci.yml
+++ b/seed/ts-sdk/unknown/unknown-as-any/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/url-form-encoded/.github/workflows/ci.yml
+++ b/seed/ts-sdk/url-form-encoded/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/validation/.github/workflows/ci.yml
+++ b/seed/ts-sdk/validation/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/variables/.github/workflows/ci.yml
+++ b/seed/ts-sdk/variables/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/version-no-default/.github/workflows/ci.yml
+++ b/seed/ts-sdk/version-no-default/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/version/.github/workflows/ci.yml
+++ b/seed/ts-sdk/version/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/websocket-bearer-auth/websockets/.github/workflows/ci.yml
+++ b/seed/ts-sdk/websocket-bearer-auth/websockets/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/websocket-inferred-auth/websockets/.github/workflows/ci.yml
+++ b/seed/ts-sdk/websocket-inferred-auth/websockets/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/websocket/no-serde/.github/workflows/ci.yml
+++ b/seed/ts-sdk/websocket/no-serde/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/websocket/no-websocket-clients/.github/workflows/ci.yml
+++ b/seed/ts-sdk/websocket/no-websocket-clients/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/seed/ts-sdk/websocket/serde/.github/workflows/ci.yml
+++ b/seed/ts-sdk/websocket/serde/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "$@"
+          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            publish --access public
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Description
Unfortunately running `npm install -g npm@latest` leads to permission errors (thanks a lot npmjs docs :angry:) 
Instead, we're using `npx npm@latest` to run the latest npm when publishing.

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated
- [x] Manual testing completed
