### PR TITLE
fix(java): use gradlew wrapper for spotless formatting instead of gradle

### DIFF
--- a/generators/java/generator-utils/src/main/java/com/fern/java/AbstractGeneratorCli.java
+++ b/generators/java/generator-utils/src/main/java/com/fern/java/AbstractGeneratorCli.java
@@ -37,6 +37,7 @@ import com.fern.java.output.gradle.GradlePublishingConfig;
 import com.fern.java.output.gradle.GradleRepository;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -246,7 +247,6 @@ public abstract class AbstractGeneratorCli<T extends ICustomConfig, K extends ID
             if (exitCode != 0) {
                 throw new RuntimeException("Command failed with non-zero exit code: " + Arrays.toString(command));
             }
-            process.waitFor();
         } catch (InterruptedException e) {
             throw new RuntimeException("Failed to run command", e);
         }
@@ -439,7 +439,11 @@ public abstract class AbstractGeneratorCli<T extends ICustomConfig, K extends ID
                 generatedFile -> generatedFile.write(outputDirectory, true, customConfig.packagePrefix()));
         if (publishResult.generateFullProject()) {
             runCommandBlocking(new String[] {"gradle", "wrapper"}, outputDirectory, Collections.emptyMap());
-            runCommandBlocking(new String[] {"gradle", "spotlessApply"}, outputDirectory, Collections.emptyMap());
+            Path gradlewPath = outputDirectory.resolve("gradlew");
+            if (Files.exists(gradlewPath)) {
+                runCommandBlocking(
+                        new String[] {"./gradlew", ":spotlessApply"}, outputDirectory, Collections.emptyMap());
+            }
         }
     }
 
@@ -481,7 +485,10 @@ public abstract class AbstractGeneratorCli<T extends ICustomConfig, K extends ID
         // write files to disk
         generatedFiles.forEach(generatedFile -> generatedFile.write(outputDirectory, false, Optional.empty()));
         runCommandBlocking(new String[] {"gradle", "wrapper"}, outputDirectory, Collections.emptyMap());
-        runCommandBlocking(new String[] {"gradle", "spotlessApply"}, outputDirectory, Collections.emptyMap());
+        Path gradlewPath = outputDirectory.resolve("gradlew");
+        if (Files.exists(gradlewPath)) {
+            runCommandBlocking(new String[] {"./gradlew", ":spotlessApply"}, outputDirectory, Collections.emptyMap());
+        }
     }
 
     public boolean customConfigPublishToCentral(GeneratorConfig _generatorConfig) {
@@ -524,7 +531,10 @@ public abstract class AbstractGeneratorCli<T extends ICustomConfig, K extends ID
 
         generatedFiles.forEach(generatedFile -> generatedFile.write(outputDirectory, false, Optional.empty()));
         runCommandBlocking(new String[] {"gradle", "wrapper"}, outputDirectory, Collections.emptyMap());
-        runCommandBlocking(new String[] {"gradle", "spotlessApply"}, outputDirectory, Collections.emptyMap());
+        Path gradlewPath = outputDirectory.resolve("gradlew");
+        if (Files.exists(gradlewPath)) {
+            runCommandBlocking(new String[] {"./gradlew", ":spotlessApply"}, outputDirectory, Collections.emptyMap());
+        }
 
         // run publish
         if (!generatorConfig.getDryRun()) {

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,3 +1,11 @@
+- version: 3.10.3
+  changelogEntry:
+    - summary: |
+        Use Gradle wrapper for Spotless formatting instead of requiring gradle in PATH.
+      type: fix
+  createdAt: "2025-10-29"
+  irVersion: 61
+
 - version: 3.10.2
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description
Linear ticket: Closes [FER-7452: \[Java, Auth0\] Spotless checks](https://linear.app/buildwithfern/issue/FER-7452/java-auth0-spotless-checks)
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
<!-- Provide a clear and concise description of the changes made in this PR -->

Fixes Spotless execution in Java v1 generator to use the Gradle wrapper instead of requiring gradle in PATH.

After running `gradle wrapper` to create gradlew, the generator now uses `./gradlew :spotlessApply` instead of `gradle spotlessApply`. This matches the fix already applied to Java v2 and prevents build failures when gradle is not globally installed.

## Testing
<!-- Describe how you tested these changes -->
- [x] Manual testing completed -- tested with auth0
