### PR TITLE
fix(go): expose raw paginated response on core.Page

### DIFF
--- a/generators/go-v2/base/src/AsIs.ts
+++ b/generators/go-v2/base/src/AsIs.ts
@@ -12,6 +12,7 @@ export enum AsIsFiles {
     CallerTest = "internal/caller_test.go_",
     Retrier = "internal/retrier.go_",
     RetrierTest = "internal/retrier_test.go_",
+    Page = "core/page.go_",
     Pager = "internal/pager.go_",
     PagerTest = "internal/pager_test.go_",
     Streamer = "internal/streamer.go_"

--- a/generators/go-v2/base/src/asIs/core/page.go_
+++ b/generators/go-v2/base/src/asIs/core/page.go_
@@ -11,28 +11,44 @@ import (
 // a non-actionable error.
 var ErrNoPages = errors.New("no pages remain")
 
+// PageRequest represents the information required to identify a single page.
+type PageRequest[Cursor comparable] struct {
+	Cursor Cursor
+
+	// Holds the value of the response type (populated by the *Caller).
+	Response any
+}
+
+// PageResponse represents the information associated with a single page.
+type PageResponse[Cursor comparable, Result any] struct {
+	Results []Result
+	Next    Cursor
+	Done    bool
+}
+
 // Page represents a single page of results.
-type Page[T any] struct {
+type Page[Cursor comparable, T any] struct {
 	Results      []T
-	NextPageFunc func(context.Context) (*Page[T], error)
+	RawResponse  PageResponse[Cursor, T]
+	NextPageFunc func(context.Context) (*Page[Cursor, T], error)
 }
 
 // GetNextPage fetches the next page, if any. If no pages remain,
 // the ErrNoPages error is returned.
-func (p *Page[T]) GetNextPage(ctx context.Context) (*Page[T], error) {
+func (p *Page[Cursor, T]) GetNextPage(ctx context.Context) (*Page[Cursor, T], error) {
 	return p.NextPageFunc(ctx)
 }
 
 // Iterator returns an iterator that starts at the current page.
-func (p *Page[T]) Iterator() *PageIterator[T] {
-	return &PageIterator[T]{
+func (p *Page[Cursor, T]) Iterator() *PageIterator[Cursor, T] {
+	return &PageIterator[Cursor, T]{
 		page: p,
 	}
 }
 
 // PageIterator is an auto-iterator for paginated endpoints.
-type PageIterator[T any] struct {
-	page    *Page[T]
+type PageIterator[Cursor comparable, T any] struct {
+	page    *Page[Cursor, T]
 	current T
 	index   int
 	err     error
@@ -40,7 +56,7 @@ type PageIterator[T any] struct {
 
 // Next returns true if the given iterator has more results,
 // fetching the next page as needed.
-func (p *PageIterator[T]) Next(ctx context.Context) bool {
+func (p *PageIterator[Cursor, T]) Next(ctx context.Context) bool {
 	if p.page == nil || len(p.page.Results) == 0 {
 		return false
 	}
@@ -57,12 +73,12 @@ func (p *PageIterator[T]) Next(ctx context.Context) bool {
 }
 
 // Current returns the current element.
-func (p *PageIterator[T]) Current() T {
+func (p *PageIterator[Cursor, T]) Current() T {
 	return p.current
 }
 
 // Err returns a non-nil error if the iterator encountered an error.
-func (p *PageIterator[T]) Err() error {
+func (p *PageIterator[Cursor, T]) Err() error {
 	if errors.Is(p.err, ErrNoPages) {
 		return nil
 	}

--- a/generators/go-v2/base/src/asIs/internal/pager.go_
+++ b/generators/go-v2/base/src/asIs/internal/pager.go_
@@ -27,30 +27,15 @@ type Pager[
 	readPageResponse PageResponseFunc[Cursor, Response, Results]
 }
 
-// PageRequest represents the information required to identify a single page.
-type PageRequest[Cursor comparable] struct {
-	Cursor Cursor
-
-	// Holds the value of the response type (populated by the *Caller).
-	Response any
-}
-
-// PageResponse represents the information associated with a single page.
-type PageResponse[Cursor comparable, Result any] struct {
-	Results []Result
-	Next    Cursor
-	Done    bool
-}
-
 // PageRequestFunc prepares the *CallParams from the given page request.
-type PageRequestFunc[Cursor comparable] func(request *PageRequest[Cursor]) *CallParams
+type PageRequestFunc[Cursor comparable] func(request *core.PageRequest[Cursor]) *CallParams
 
 // PageResponseFunc extracts the next page information from the response.
 type PageResponseFunc[
 	Cursor comparable,
 	Response any,
 	Results any,
-] func(Response) *PageResponse[Cursor, Results]
+] func(Response) *core.PageResponse[Cursor, Results]
 
 // NewCursorPager constructs a new Pager that fetches pages from a paginated endpoint.
 func NewCursorPager[Cursor comparable, Response any, Results any](
@@ -85,9 +70,9 @@ func (p *Pager[
 	Cursor,
 	Response,
 	Results,
-]) GetPage(ctx context.Context, cursor Cursor) (*core.Page[Results], error) {
+]) GetPage(ctx context.Context, cursor Cursor) (*core.Page[Cursor, Results], error) {
 	var response Response
-	pageRequest := &PageRequest[Cursor]{
+	pageRequest := &core.PageRequest[Cursor]{
 		Cursor:   cursor,
 		Response: &response,
 	}
@@ -100,9 +85,10 @@ func (p *Pager[
 	pageResponse := p.readPageResponse(response)
 
 	if p.mode == PagerModeOffset {
-		return &core.Page[Results]{
+		return &core.Page[Cursor, Results]{
 			Results: pageResponse.Results,
-			NextPageFunc: func(ctx context.Context) (*core.Page[Results], error) {
+			RawResponse: *pageResponse,
+			NextPageFunc: func(ctx context.Context) (*core.Page[Cursor, Results], error) {
 				page, err := p.GetPage(ctx, pageResponse.Next)
 				if err != nil {
 					return nil, err
@@ -115,9 +101,10 @@ func (p *Pager[
 		}, nil
 	}
 
-	return &core.Page[Results]{
+	return &core.Page[Cursor, Results]{
 		Results: pageResponse.Results,
-		NextPageFunc: func(ctx context.Context) (*core.Page[Results], error) {
+		RawResponse: *pageResponse,
+		NextPageFunc: func(ctx context.Context) (*core.Page[Cursor, Results], error) {
 			if pageResponse.Done {
 				return nil, core.ErrNoPages
 			}

--- a/generators/go-v2/base/src/asIs/internal/pager_test.go_
+++ b/generators/go-v2/base/src/asIs/internal/pager_test.go_
@@ -9,6 +9,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	
+	"{{ .RootImportPath }}/core"
 )
 
 type TestPageResponse struct {
@@ -110,7 +112,7 @@ func TestPager(t *testing.T) {
 			)
 			pager := NewCursorPager(
 				caller,
-				func(request *PageRequest[*string]) *CallParams {
+				func(request *core.PageRequest[*string]) *CallParams {
 					url := server.URL
 					if request.Cursor != nil {
 						url += "?cursor=" + *request.Cursor
@@ -121,7 +123,7 @@ func TestPager(t *testing.T) {
 						Response: request.Response,
 					}
 				},
-				func(response *TestPageResponse) *PageResponse[*string, *TestPageItem] {
+				func(response *TestPageResponse) *core.PageResponse[*string, *TestPageItem] {
 					var items []*TestPageItem
 					for _, item := range response.Items {
 						itemCopy := item
@@ -131,7 +133,7 @@ func TestPager(t *testing.T) {
 					if response.Next != "" {
 						next = &response.Next
 					}
-					return &PageResponse[*string, *TestPageItem]{
+					return &core.PageResponse[*string, *TestPageItem]{
 						Results: items,
 						Next:    next,
 						Done:    response.Next == "",

--- a/generators/go-v2/base/src/context/AbstractGoGeneratorContext.ts
+++ b/generators/go-v2/base/src/context/AbstractGoGeneratorContext.ts
@@ -667,6 +667,8 @@ export abstract class AbstractGoGeneratorContext<
     }
 
     public abstract getInternalAsIsFiles(): string[];
+    
+    public abstract getCoreAsIsFiles(): string[];
 
     public abstract getRootAsIsFiles(): string[];
 

--- a/generators/go-v2/base/src/context/AbstractGoGeneratorContext.ts
+++ b/generators/go-v2/base/src/context/AbstractGoGeneratorContext.ts
@@ -667,7 +667,7 @@ export abstract class AbstractGoGeneratorContext<
     }
 
     public abstract getInternalAsIsFiles(): string[];
-    
+
     public abstract getCoreAsIsFiles(): string[];
 
     public abstract getRootAsIsFiles(): string[];

--- a/generators/go-v2/base/src/project/GoProject.ts
+++ b/generators/go-v2/base/src/project/GoProject.ts
@@ -39,6 +39,7 @@ export class GoProject extends AbstractProject<AbstractGoGeneratorContext<BaseGo
     public async persist({ tidy }: { tidy?: boolean } = {}): Promise<void> {
         this.context.logger.debug(`Writing go files to ${this.absolutePathToOutputDirectory}`);
         await this.writeGoMod();
+        await this.writeCoreFiles();
         await this.writeInternalFiles();
         await this.writeRootAsIsFiles();
         await this.writeGoFiles({
@@ -140,6 +141,14 @@ export class GoProject extends AbstractProject<AbstractGoGeneratorContext<BaseGo
         await this.writeAsIsFiles({
             filenames: this.context.getInternalAsIsFiles(),
             getPackageName: () => "internal",
+            getImportPath: (dirname) => this.getImportPath(dirname)
+        });
+    }
+    
+    private async writeCoreFiles(): Promise<void> {
+        await this.writeAsIsFiles({
+            filenames: this.context.getCoreAsIsFiles(),
+            getPackageName: () => "core",
             getImportPath: (dirname) => this.getImportPath(dirname)
         });
     }

--- a/generators/go-v2/base/src/project/GoProject.ts
+++ b/generators/go-v2/base/src/project/GoProject.ts
@@ -144,7 +144,7 @@ export class GoProject extends AbstractProject<AbstractGoGeneratorContext<BaseGo
             getImportPath: (dirname) => this.getImportPath(dirname)
         });
     }
-    
+
     private async writeCoreFiles(): Promise<void> {
         await this.writeAsIsFiles({
             filenames: this.context.getCoreAsIsFiles(),

--- a/generators/go-v2/sdk/features.yml
+++ b/generators/go-v2/sdk/features.yml
@@ -10,7 +10,7 @@ features:
 
   - id: PAGINATION
     description: |
-      List endpoints are paginated. The SDK provides an iterator so that you can simply loop over the items. You can also iterate page-by-page.
+      List endpoints are paginated. The SDK provides an iterator so that you can simply loop over the items. You can also iterate page-by-page using the `GetNextPage` helper method. If need be you can access the raw response using the `RawResponse` field on the page.
 
   - id: ERRORS
     description: |
@@ -65,11 +65,3 @@ features:
       that come with every object. Calling a setter method for a property will flip a bit in the `explicitFields`
       bitfield for that setter's object; during serialization, any property with a flipped bit will have its
       omittable status stripped, so zero or `nil` values will be sent explicitly rather than omitted altogether:
-
-  - id: WIRE_TESTS
-    advanced: true
-    description: |
-      SDKS's are generated with wire tests by default (opt-out of this feature with `customConfig.enableWireTests: false` in your generator configuration).
-      Wire tests validate serialization, deserialization of request/response types, HTTP method, path, path parameters, query parameters (soon to come) using mock requests
-      made to a mock server run using [WireMock](https://pkg.go.dev/github.com/wiremock/go-wiremock) and [WireMock Test Containers](https://pkg.go.dev/github.com/wiremock/wiremock-testcontainers-go).
-      This dependency means that Docker is required as a runtime dependency.

--- a/generators/go-v2/sdk/src/SdkGeneratorContext.ts
+++ b/generators/go-v2/sdk/src/SdkGeneratorContext.ts
@@ -66,7 +66,7 @@ export class SdkGeneratorContext extends AbstractGoGeneratorContext<SdkCustomCon
         if (this.needsPaginationHelpers()) {
             files.push(AsIsFiles.Page);
         }
-        
+
         return files;
     }
 
@@ -478,11 +478,11 @@ export class SdkGeneratorContext extends AbstractGoGeneratorContext<SdkCustomCon
         return this.callInternalFunc({ name: "QueryValuesWithDefaults", arguments_, multiline: true });
     }
 
-    public getPageTypeReference(valueType: go.Type): go.TypeReference {
+    public getPageTypeReference(cursorType: go.Type, valueType: go.Type): go.TypeReference {
         return go.typeReference({
             name: "Page",
             importPath: this.getCoreImportPath(),
-            generics: [valueType]
+            generics: [cursorType, valueType]
         });
     }
 

--- a/generators/go-v2/sdk/src/SdkGeneratorContext.ts
+++ b/generators/go-v2/sdk/src/SdkGeneratorContext.ts
@@ -60,6 +60,16 @@ export class SdkGeneratorContext extends AbstractGoGeneratorContext<SdkCustomCon
         return [];
     }
 
+    public getCoreAsIsFiles(): string[] {
+        const files = [];
+
+        if (this.needsPaginationHelpers()) {
+            files.push(AsIsFiles.Page);
+        }
+        
+        return files;
+    }
+
     public getRootAsIsFiles(): string[] {
         const files = [
             AsIsFiles.ErrorDecoder,

--- a/generators/go-v2/sdk/src/endpoint/utils/getEndpointPageReturnType.ts
+++ b/generators/go-v2/sdk/src/endpoint/utils/getEndpointPageReturnType.ts
@@ -3,6 +3,7 @@ import { go } from "@fern-api/go-ast";
 import { HttpEndpoint, Pagination } from "@fern-fern/ir-sdk/api";
 
 import { SdkGeneratorContext } from "../../SdkGeneratorContext";
+import { getPageType } from "./getPaginationInfo";
 import { getResponseBodyType } from "./getResponseBodyType";
 
 export function getEndpointPageReturnType({
@@ -31,7 +32,12 @@ function getCorePageReturnType({
     pagination: Pagination;
 }): go.Type {
     return go.Type.pointer(
-        go.Type.reference(context.getPageTypeReference(getPaginationValueType({ context, pagination })))
+        go.Type.reference(
+            context.getPageTypeReference(
+                getPageType({ context, pagination }),
+                getPaginationValueType({ context, pagination })
+            )
+        )
     );
 }
 

--- a/generators/go-v2/sdk/src/readme/ReadmeSnippetBuilder.ts
+++ b/generators/go-v2/sdk/src/readme/ReadmeSnippetBuilder.ts
@@ -247,6 +247,17 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
                     return err
                 }
             }
+
+            // Alternatively, access the next cursor directly from the raw response.
+            ctx := context.TODO()
+            page, err := ${this.getMethodCall(endpoint)}(
+                ctx,
+                ...
+            )
+            if err != nil {
+                return err
+            }
+            nextCursor := page.RawResponse.Next
         `);
     }
 

--- a/generators/go/internal/generator/generator.go
+++ b/generators/go/internal/generator/generator.go
@@ -345,7 +345,6 @@ func (g *Generator) generate(ir *fernir.IntermediateRepresentation, mode Mode) (
 	files = append(files, newExtraPropertiesFile(g.coordinator))
 	files = append(files, newExtraPropertiesTestFile(g.coordinator))
 	// Then handle mode-specific generation tasks.
-	var generatedPagination bool
 	switch mode {
 	case ModeFiber:
 		break
@@ -354,7 +353,6 @@ func (g *Generator) generate(ir *fernir.IntermediateRepresentation, mode Mode) (
 			generatedAuth        *GeneratedAuth
 			generatedEnvironment *GeneratedEnvironment
 		)
-		generatedPagination = needsPaginationHelpers(ir)
 		// Generate the core API files.
 		fileInfo := fileInfoForRequestOptionsDefinition()
 		writer := newFileWriter(
@@ -574,9 +572,6 @@ func (g *Generator) generate(ir *fernir.IntermediateRepresentation, mode Mode) (
 		}
 		if ir.SdkConfig.HasStreamingEndpoints {
 			files = append(files, newStreamFile(g.coordinator))
-		}
-		if generatedPagination {
-			files = append(files, newPageFile(g.coordinator))
 		}
 		clientTestFile, err := newClientTestFile(g.config.FullImportPath, rootPackageName, g.coordinator, g.config.ClientName, g.config.ClientConstructorName)
 		if err != nil {
@@ -1255,14 +1250,6 @@ func newOptionalTestFile(coordinator *coordinator.Client) *File {
 		coordinator,
 		"core/optional_test.go",
 		[]byte(optionalTestFile),
-	)
-}
-
-func newPageFile(coordinator *coordinator.Client) *File {
-	return NewFile(
-		coordinator,
-		"core/page.go",
-		[]byte(pageFile),
 	)
 }
 

--- a/generators/go/internal/generator/sdk.go
+++ b/generators/go/internal/generator/sdk.go
@@ -57,9 +57,6 @@ var (
 	//go:embed sdk/core/optional_test.go
 	optionalTestFile string
 
-	//go:embed sdk/core/page.go
-	pageFile string
-
 	//go:embed sdk/utils/pointer.go
 	pointerFile string
 

--- a/seed/go-sdk/pagination/README.md
+++ b/seed/go-sdk/pagination/README.md
@@ -68,7 +68,7 @@ client := client.NewClient(
 
 ## Pagination
 
-List endpoints are paginated. The SDK provides an iterator so that you can simply loop over the items. You can also iterate page-by-page.
+List endpoints are paginated. The SDK provides an iterator so that you can simply loop over the items. You can also iterate page-by-page using the `GetNextPage` helper method. If need be you can access the raw response using the `RawResponse` field on the page.
 
 ```go
 // Loop over the items using the provided iterator.
@@ -102,6 +102,17 @@ for page != nil {
         return err
     }
 }
+
+// Alternatively, access the next cursor directly from the raw response.
+ctx := context.TODO()
+page, err := client.Complex.Search(
+    ctx,
+    ...
+)
+if err != nil {
+    return err
+}
+nextCursor := page.RawResponse.Next
 ```
 
 ## Errors

--- a/seed/go-sdk/pagination/core/page.go
+++ b/seed/go-sdk/pagination/core/page.go
@@ -11,28 +11,44 @@ import (
 // a non-actionable error.
 var ErrNoPages = errors.New("no pages remain")
 
+// PageRequest represents the information required to identify a single page.
+type PageRequest[Cursor comparable] struct {
+	Cursor Cursor
+
+	// Holds the value of the response type (populated by the *Caller).
+	Response any
+}
+
+// PageResponse represents the information associated with a single page.
+type PageResponse[Cursor comparable, Result any] struct {
+	Results []Result
+	Next    Cursor
+	Done    bool
+}
+
 // Page represents a single page of results.
-type Page[T any] struct {
+type Page[Cursor comparable, T any] struct {
 	Results      []T
-	NextPageFunc func(context.Context) (*Page[T], error)
+	RawResponse  PageResponse[Cursor, T]
+	NextPageFunc func(context.Context) (*Page[Cursor, T], error)
 }
 
 // GetNextPage fetches the next page, if any. If no pages remain,
 // the ErrNoPages error is returned.
-func (p *Page[T]) GetNextPage(ctx context.Context) (*Page[T], error) {
+func (p *Page[Cursor, T]) GetNextPage(ctx context.Context) (*Page[Cursor, T], error) {
 	return p.NextPageFunc(ctx)
 }
 
 // Iterator returns an iterator that starts at the current page.
-func (p *Page[T]) Iterator() *PageIterator[T] {
-	return &PageIterator[T]{
+func (p *Page[Cursor, T]) Iterator() *PageIterator[Cursor, T] {
+	return &PageIterator[Cursor, T]{
 		page: p,
 	}
 }
 
 // PageIterator is an auto-iterator for paginated endpoints.
-type PageIterator[T any] struct {
-	page    *Page[T]
+type PageIterator[Cursor comparable, T any] struct {
+	page    *Page[Cursor, T]
 	current T
 	index   int
 	err     error
@@ -40,7 +56,7 @@ type PageIterator[T any] struct {
 
 // Next returns true if the given iterator has more results,
 // fetching the next page as needed.
-func (p *PageIterator[T]) Next(ctx context.Context) bool {
+func (p *PageIterator[Cursor, T]) Next(ctx context.Context) bool {
 	if p.page == nil || len(p.page.Results) == 0 {
 		return false
 	}
@@ -57,12 +73,12 @@ func (p *PageIterator[T]) Next(ctx context.Context) bool {
 }
 
 // Current returns the current element.
-func (p *PageIterator[T]) Current() T {
+func (p *PageIterator[Cursor, T]) Current() T {
 	return p.current
 }
 
 // Err returns a non-nil error if the iterator encountered an error.
-func (p *PageIterator[T]) Err() error {
+func (p *PageIterator[Cursor, T]) Err() error {
 	if errors.Is(p.err, ErrNoPages) {
 		return nil
 	}

--- a/seed/go-sdk/pagination/inlineusers/inlineusers/client.go
+++ b/seed/go-sdk/pagination/inlineusers/inlineusers/client.go
@@ -41,7 +41,7 @@ func (c *Client) ListWithCursorPagination(
 	ctx context.Context,
 	request *inlineusers.ListUsersCursorPaginationRequest,
 	opts ...option.RequestOption,
-) (*core.Page[*inlineusers.User], error) {
+) (*core.Page[*string, *inlineusers.User], error) {
 	options := core.NewRequestOptions(opts...)
 	baseURL := internal.ResolveBaseURL(
 		options.BaseURL,
@@ -57,7 +57,7 @@ func (c *Client) ListWithCursorPagination(
 		c.options.ToHeader(),
 		options.ToHeader(),
 	)
-	prepareCall := func(pageRequest *internal.PageRequest[*string]) *internal.CallParams {
+	prepareCall := func(pageRequest *core.PageRequest[*string]) *internal.CallParams {
 		if pageRequest.Cursor != nil {
 			queryParams.Set("starting_after", *pageRequest.Cursor)
 		}
@@ -76,11 +76,11 @@ func (c *Client) ListWithCursorPagination(
 			Response:        pageRequest.Response,
 		}
 	}
-	readPageResponse := func(response *inlineusers.ListUsersPaginationResponse) *internal.PageResponse[*string, *inlineusers.User] {
+	readPageResponse := func(response *inlineusers.ListUsersPaginationResponse) *core.PageResponse[*string, *inlineusers.User] {
 		var zeroValue string
 		next := response.GetPage().GetNext().GetStartingAfter()
 		results := response.GetData().GetUsers()
-		return &internal.PageResponse[*string, *inlineusers.User]{
+		return &core.PageResponse[*string, *inlineusers.User]{
 			Next:    &next,
 			Results: results,
 			Done:    next == zeroValue,
@@ -98,7 +98,7 @@ func (c *Client) ListWithMixedTypeCursorPagination(
 	ctx context.Context,
 	request *inlineusers.ListUsersMixedTypeCursorPaginationRequest,
 	opts ...option.RequestOption,
-) (*core.Page[*inlineusers.User], error) {
+) (*core.Page[*string, *inlineusers.User], error) {
 	options := core.NewRequestOptions(opts...)
 	baseURL := internal.ResolveBaseURL(
 		options.BaseURL,
@@ -114,7 +114,7 @@ func (c *Client) ListWithMixedTypeCursorPagination(
 		c.options.ToHeader(),
 		options.ToHeader(),
 	)
-	prepareCall := func(pageRequest *internal.PageRequest[*string]) *internal.CallParams {
+	prepareCall := func(pageRequest *core.PageRequest[*string]) *internal.CallParams {
 		if pageRequest.Cursor != nil {
 			queryParams.Set("cursor", *pageRequest.Cursor)
 		}
@@ -133,11 +133,11 @@ func (c *Client) ListWithMixedTypeCursorPagination(
 			Response:        pageRequest.Response,
 		}
 	}
-	readPageResponse := func(response *inlineusers.ListUsersMixedTypePaginationResponse) *internal.PageResponse[*string, *inlineusers.User] {
+	readPageResponse := func(response *inlineusers.ListUsersMixedTypePaginationResponse) *core.PageResponse[*string, *inlineusers.User] {
 		var zeroValue string
 		next := response.GetNext()
 		results := response.GetData().GetUsers()
-		return &internal.PageResponse[*string, *inlineusers.User]{
+		return &core.PageResponse[*string, *inlineusers.User]{
 			Next:    &next,
 			Results: results,
 			Done:    next == zeroValue,
@@ -171,7 +171,7 @@ func (c *Client) ListWithOffsetPagination(
 	ctx context.Context,
 	request *inlineusers.ListUsersOffsetPaginationRequest,
 	opts ...option.RequestOption,
-) (*core.Page[*inlineusers.User], error) {
+) (*core.Page[*int, *inlineusers.User], error) {
 	options := core.NewRequestOptions(opts...)
 	baseURL := internal.ResolveBaseURL(
 		options.BaseURL,
@@ -187,7 +187,7 @@ func (c *Client) ListWithOffsetPagination(
 		c.options.ToHeader(),
 		options.ToHeader(),
 	)
-	prepareCall := func(pageRequest *internal.PageRequest[*int]) *internal.CallParams {
+	prepareCall := func(pageRequest *core.PageRequest[*int]) *internal.CallParams {
 		if pageRequest.Cursor != nil {
 			queryParams.Set("page", fmt.Sprintf("%v", *pageRequest.Cursor))
 		}
@@ -214,10 +214,10 @@ func (c *Client) ListWithOffsetPagination(
 		}
 	}
 
-	readPageResponse := func(response *inlineusers.ListUsersPaginationResponse) *internal.PageResponse[*int, *inlineusers.User] {
+	readPageResponse := func(response *inlineusers.ListUsersPaginationResponse) *core.PageResponse[*int, *inlineusers.User] {
 		next += 1
 		results := response.GetData().GetUsers()
-		return &internal.PageResponse[*int, *inlineusers.User]{
+		return &core.PageResponse[*int, *inlineusers.User]{
 			Next:    &next,
 			Results: results,
 		}
@@ -234,7 +234,7 @@ func (c *Client) ListWithDoubleOffsetPagination(
 	ctx context.Context,
 	request *inlineusers.ListUsersDoubleOffsetPaginationRequest,
 	opts ...option.RequestOption,
-) (*core.Page[*inlineusers.User], error) {
+) (*core.Page[*float64, *inlineusers.User], error) {
 	options := core.NewRequestOptions(opts...)
 	baseURL := internal.ResolveBaseURL(
 		options.BaseURL,
@@ -250,7 +250,7 @@ func (c *Client) ListWithDoubleOffsetPagination(
 		c.options.ToHeader(),
 		options.ToHeader(),
 	)
-	prepareCall := func(pageRequest *internal.PageRequest[*float64]) *internal.CallParams {
+	prepareCall := func(pageRequest *core.PageRequest[*float64]) *internal.CallParams {
 		if pageRequest.Cursor != nil {
 			queryParams.Set("page", fmt.Sprintf("%v", *pageRequest.Cursor))
 		}
@@ -272,15 +272,15 @@ func (c *Client) ListWithDoubleOffsetPagination(
 	var next float64 = 1
 	if queryParams.Has("page") {
 		var err error
-		if next, err = strconv.Atoi(queryParams.Get("page")); err != nil {
+		if next, err = strconv.ParseFloat(queryParams.Get("page"), 64); err != nil {
 			return nil, err
 		}
 	}
 
-	readPageResponse := func(response *inlineusers.ListUsersPaginationResponse) *internal.PageResponse[*float64, *inlineusers.User] {
+	readPageResponse := func(response *inlineusers.ListUsersPaginationResponse) *core.PageResponse[*float64, *inlineusers.User] {
 		next += 1
 		results := response.GetData().GetUsers()
-		return &internal.PageResponse[*float64, *inlineusers.User]{
+		return &core.PageResponse[*float64, *inlineusers.User]{
 			Next:    &next,
 			Results: results,
 		}
@@ -313,7 +313,7 @@ func (c *Client) ListWithOffsetStepPagination(
 	ctx context.Context,
 	request *inlineusers.ListUsersOffsetStepPaginationRequest,
 	opts ...option.RequestOption,
-) (*core.Page[*inlineusers.User], error) {
+) (*core.Page[*int, *inlineusers.User], error) {
 	options := core.NewRequestOptions(opts...)
 	baseURL := internal.ResolveBaseURL(
 		options.BaseURL,
@@ -329,7 +329,7 @@ func (c *Client) ListWithOffsetStepPagination(
 		c.options.ToHeader(),
 		options.ToHeader(),
 	)
-	prepareCall := func(pageRequest *internal.PageRequest[*int]) *internal.CallParams {
+	prepareCall := func(pageRequest *core.PageRequest[*int]) *internal.CallParams {
 		if pageRequest.Cursor != nil {
 			queryParams.Set("page", fmt.Sprintf("%v", *pageRequest.Cursor))
 		}
@@ -356,10 +356,10 @@ func (c *Client) ListWithOffsetStepPagination(
 		}
 	}
 
-	readPageResponse := func(response *inlineusers.ListUsersPaginationResponse) *internal.PageResponse[*int, *inlineusers.User] {
+	readPageResponse := func(response *inlineusers.ListUsersPaginationResponse) *core.PageResponse[*int, *inlineusers.User] {
 		next += 1
 		results := response.GetData().GetUsers()
-		return &internal.PageResponse[*int, *inlineusers.User]{
+		return &core.PageResponse[*int, *inlineusers.User]{
 			Next:    &next,
 			Results: results,
 		}
@@ -376,7 +376,7 @@ func (c *Client) ListWithOffsetPaginationHasNextPage(
 	ctx context.Context,
 	request *inlineusers.ListWithOffsetPaginationHasNextPageRequest,
 	opts ...option.RequestOption,
-) (*core.Page[*inlineusers.User], error) {
+) (*core.Page[*int, *inlineusers.User], error) {
 	options := core.NewRequestOptions(opts...)
 	baseURL := internal.ResolveBaseURL(
 		options.BaseURL,
@@ -392,7 +392,7 @@ func (c *Client) ListWithOffsetPaginationHasNextPage(
 		c.options.ToHeader(),
 		options.ToHeader(),
 	)
-	prepareCall := func(pageRequest *internal.PageRequest[*int]) *internal.CallParams {
+	prepareCall := func(pageRequest *core.PageRequest[*int]) *internal.CallParams {
 		if pageRequest.Cursor != nil {
 			queryParams.Set("page", fmt.Sprintf("%v", *pageRequest.Cursor))
 		}
@@ -419,10 +419,10 @@ func (c *Client) ListWithOffsetPaginationHasNextPage(
 		}
 	}
 
-	readPageResponse := func(response *inlineusers.ListUsersPaginationResponse) *internal.PageResponse[*int, *inlineusers.User] {
+	readPageResponse := func(response *inlineusers.ListUsersPaginationResponse) *core.PageResponse[*int, *inlineusers.User] {
 		next += 1
 		results := response.GetData().GetUsers()
-		return &internal.PageResponse[*int, *inlineusers.User]{
+		return &core.PageResponse[*int, *inlineusers.User]{
 			Next:    &next,
 			Results: results,
 		}
@@ -439,7 +439,7 @@ func (c *Client) ListWithExtendedResults(
 	ctx context.Context,
 	request *inlineusers.ListUsersExtendedRequest,
 	opts ...option.RequestOption,
-) (*core.Page[*inlineusers.User], error) {
+) (*core.Page[*uuid.UUID, *inlineusers.User], error) {
 	options := core.NewRequestOptions(opts...)
 	baseURL := internal.ResolveBaseURL(
 		options.BaseURL,
@@ -455,7 +455,7 @@ func (c *Client) ListWithExtendedResults(
 		c.options.ToHeader(),
 		options.ToHeader(),
 	)
-	prepareCall := func(pageRequest *internal.PageRequest[*uuid.UUID]) *internal.CallParams {
+	prepareCall := func(pageRequest *core.PageRequest[*uuid.UUID]) *internal.CallParams {
 		if pageRequest.Cursor != nil {
 			queryParams.Set("cursor", fmt.Sprintf("%v", *pageRequest.Cursor))
 		}
@@ -474,11 +474,11 @@ func (c *Client) ListWithExtendedResults(
 			Response:        pageRequest.Response,
 		}
 	}
-	readPageResponse := func(response *inlineusers.ListUsersExtendedResponse) *internal.PageResponse[*uuid.UUID, *inlineusers.User] {
+	readPageResponse := func(response *inlineusers.ListUsersExtendedResponse) *core.PageResponse[*uuid.UUID, *inlineusers.User] {
 		var zeroValue *uuid.UUID
 		next := response.GetNext()
 		results := response.GetData().GetUsers()
-		return &internal.PageResponse[*uuid.UUID, *inlineusers.User]{
+		return &core.PageResponse[*uuid.UUID, *inlineusers.User]{
 			Next:    next,
 			Results: results,
 			Done:    next == zeroValue,
@@ -496,7 +496,7 @@ func (c *Client) ListWithExtendedResultsAndOptionalData(
 	ctx context.Context,
 	request *inlineusers.ListUsersExtendedRequestForOptionalData,
 	opts ...option.RequestOption,
-) (*core.Page[*inlineusers.User], error) {
+) (*core.Page[*uuid.UUID, *inlineusers.User], error) {
 	options := core.NewRequestOptions(opts...)
 	baseURL := internal.ResolveBaseURL(
 		options.BaseURL,
@@ -512,7 +512,7 @@ func (c *Client) ListWithExtendedResultsAndOptionalData(
 		c.options.ToHeader(),
 		options.ToHeader(),
 	)
-	prepareCall := func(pageRequest *internal.PageRequest[*uuid.UUID]) *internal.CallParams {
+	prepareCall := func(pageRequest *core.PageRequest[*uuid.UUID]) *internal.CallParams {
 		if pageRequest.Cursor != nil {
 			queryParams.Set("cursor", fmt.Sprintf("%v", *pageRequest.Cursor))
 		}
@@ -531,11 +531,11 @@ func (c *Client) ListWithExtendedResultsAndOptionalData(
 			Response:        pageRequest.Response,
 		}
 	}
-	readPageResponse := func(response *inlineusers.ListUsersExtendedOptionalListResponse) *internal.PageResponse[*uuid.UUID, *inlineusers.User] {
+	readPageResponse := func(response *inlineusers.ListUsersExtendedOptionalListResponse) *core.PageResponse[*uuid.UUID, *inlineusers.User] {
 		var zeroValue *uuid.UUID
 		next := response.GetNext()
 		results := response.GetData().GetUsers()
-		return &internal.PageResponse[*uuid.UUID, *inlineusers.User]{
+		return &core.PageResponse[*uuid.UUID, *inlineusers.User]{
 			Next:    next,
 			Results: results,
 			Done:    next == zeroValue,
@@ -553,7 +553,7 @@ func (c *Client) ListUsernames(
 	ctx context.Context,
 	request *inlineusers.ListUsernamesRequest,
 	opts ...option.RequestOption,
-) (*core.Page[string], error) {
+) (*core.Page[*string, string], error) {
 	options := core.NewRequestOptions(opts...)
 	baseURL := internal.ResolveBaseURL(
 		options.BaseURL,
@@ -569,7 +569,7 @@ func (c *Client) ListUsernames(
 		c.options.ToHeader(),
 		options.ToHeader(),
 	)
-	prepareCall := func(pageRequest *internal.PageRequest[*string]) *internal.CallParams {
+	prepareCall := func(pageRequest *core.PageRequest[*string]) *internal.CallParams {
 		if pageRequest.Cursor != nil {
 			queryParams.Set("starting_after", *pageRequest.Cursor)
 		}
@@ -588,14 +588,14 @@ func (c *Client) ListUsernames(
 			Response:        pageRequest.Response,
 		}
 	}
-	readPageResponse := func(response *fern.UsernameCursor) *internal.PageResponse[*string, string] {
+	readPageResponse := func(response *fern.UsernameCursor) *core.PageResponse[*string, string] {
 		var zeroValue *string
 		var next *string
 		if response.Cursor != nil {
 			next = response.Cursor.After
 		}
 		results := response.GetCursor().GetData()
-		return &internal.PageResponse[*string, string]{
+		return &core.PageResponse[*string, string]{
 			Next:    next,
 			Results: results,
 			Done:    next == zeroValue,
@@ -613,7 +613,7 @@ func (c *Client) ListWithGlobalConfig(
 	ctx context.Context,
 	request *inlineusers.ListWithGlobalConfigRequest,
 	opts ...option.RequestOption,
-) (*core.Page[string], error) {
+) (*core.Page[*int, string], error) {
 	options := core.NewRequestOptions(opts...)
 	baseURL := internal.ResolveBaseURL(
 		options.BaseURL,
@@ -629,7 +629,7 @@ func (c *Client) ListWithGlobalConfig(
 		c.options.ToHeader(),
 		options.ToHeader(),
 	)
-	prepareCall := func(pageRequest *internal.PageRequest[*int]) *internal.CallParams {
+	prepareCall := func(pageRequest *core.PageRequest[*int]) *internal.CallParams {
 		if pageRequest.Cursor != nil {
 			queryParams.Set("offset", fmt.Sprintf("%v", *pageRequest.Cursor))
 		}
@@ -656,10 +656,10 @@ func (c *Client) ListWithGlobalConfig(
 		}
 	}
 
-	readPageResponse := func(response *inlineusers.UsernameContainer) *internal.PageResponse[*int, string] {
+	readPageResponse := func(response *inlineusers.UsernameContainer) *core.PageResponse[*int, string] {
 		next += 1
 		results := response.GetResults()
-		return &internal.PageResponse[*int, string]{
+		return &core.PageResponse[*int, string]{
 			Next:    &next,
 			Results: results,
 		}

--- a/seed/go-sdk/pagination/internal/pager.go
+++ b/seed/go-sdk/pagination/internal/pager.go
@@ -27,30 +27,15 @@ type Pager[
 	readPageResponse PageResponseFunc[Cursor, Response, Results]
 }
 
-// PageRequest represents the information required to identify a single page.
-type PageRequest[Cursor comparable] struct {
-	Cursor Cursor
-
-	// Holds the value of the response type (populated by the *Caller).
-	Response any
-}
-
-// PageResponse represents the information associated with a single page.
-type PageResponse[Cursor comparable, Result any] struct {
-	Results []Result
-	Next    Cursor
-	Done    bool
-}
-
 // PageRequestFunc prepares the *CallParams from the given page request.
-type PageRequestFunc[Cursor comparable] func(request *PageRequest[Cursor]) *CallParams
+type PageRequestFunc[Cursor comparable] func(request *core.PageRequest[Cursor]) *CallParams
 
 // PageResponseFunc extracts the next page information from the response.
 type PageResponseFunc[
 	Cursor comparable,
 	Response any,
 	Results any,
-] func(Response) *PageResponse[Cursor, Results]
+] func(Response) *core.PageResponse[Cursor, Results]
 
 // NewCursorPager constructs a new Pager that fetches pages from a paginated endpoint.
 func NewCursorPager[Cursor comparable, Response any, Results any](
@@ -85,9 +70,9 @@ func (p *Pager[
 	Cursor,
 	Response,
 	Results,
-]) GetPage(ctx context.Context, cursor Cursor) (*core.Page[Results], error) {
+]) GetPage(ctx context.Context, cursor Cursor) (*core.Page[Cursor, Results], error) {
 	var response Response
-	pageRequest := &PageRequest[Cursor]{
+	pageRequest := &core.PageRequest[Cursor]{
 		Cursor:   cursor,
 		Response: &response,
 	}
@@ -100,9 +85,10 @@ func (p *Pager[
 	pageResponse := p.readPageResponse(response)
 
 	if p.mode == PagerModeOffset {
-		return &core.Page[Results]{
-			Results: pageResponse.Results,
-			NextPageFunc: func(ctx context.Context) (*core.Page[Results], error) {
+		return &core.Page[Cursor, Results]{
+			Results:     pageResponse.Results,
+			RawResponse: *pageResponse,
+			NextPageFunc: func(ctx context.Context) (*core.Page[Cursor, Results], error) {
 				page, err := p.GetPage(ctx, pageResponse.Next)
 				if err != nil {
 					return nil, err
@@ -115,9 +101,10 @@ func (p *Pager[
 		}, nil
 	}
 
-	return &core.Page[Results]{
-		Results: pageResponse.Results,
-		NextPageFunc: func(ctx context.Context) (*core.Page[Results], error) {
+	return &core.Page[Cursor, Results]{
+		Results:     pageResponse.Results,
+		RawResponse: *pageResponse,
+		NextPageFunc: func(ctx context.Context) (*core.Page[Cursor, Results], error) {
 			if pageResponse.Done {
 				return nil, core.ErrNoPages
 			}

--- a/seed/go-sdk/pagination/internal/pager_test.go
+++ b/seed/go-sdk/pagination/internal/pager_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pagination/fern/core"
 )
 
 type TestPageResponse struct {
@@ -110,7 +112,7 @@ func TestPager(t *testing.T) {
 			)
 			pager := NewCursorPager(
 				caller,
-				func(request *PageRequest[*string]) *CallParams {
+				func(request *core.PageRequest[*string]) *CallParams {
 					url := server.URL
 					if request.Cursor != nil {
 						url += "?cursor=" + *request.Cursor
@@ -121,7 +123,7 @@ func TestPager(t *testing.T) {
 						Response: request.Response,
 					}
 				},
-				func(response *TestPageResponse) *PageResponse[*string, *TestPageItem] {
+				func(response *TestPageResponse) *core.PageResponse[*string, *TestPageItem] {
 					var items []*TestPageItem
 					for _, item := range response.Items {
 						itemCopy := item
@@ -131,7 +133,7 @@ func TestPager(t *testing.T) {
 					if response.Next != "" {
 						next = &response.Next
 					}
-					return &PageResponse[*string, *TestPageItem]{
+					return &core.PageResponse[*string, *TestPageItem]{
 						Results: items,
 						Next:    next,
 						Done:    response.Next == "",

--- a/seed/go-sdk/pagination/users/client.go
+++ b/seed/go-sdk/pagination/users/client.go
@@ -40,7 +40,7 @@ func (c *Client) ListWithCursorPagination(
 	ctx context.Context,
 	request *fern.ListUsersCursorPaginationRequest,
 	opts ...option.RequestOption,
-) (*core.Page[*fern.User], error) {
+) (*core.Page[*string, *fern.User], error) {
 	options := core.NewRequestOptions(opts...)
 	baseURL := internal.ResolveBaseURL(
 		options.BaseURL,
@@ -56,7 +56,7 @@ func (c *Client) ListWithCursorPagination(
 		c.options.ToHeader(),
 		options.ToHeader(),
 	)
-	prepareCall := func(pageRequest *internal.PageRequest[*string]) *internal.CallParams {
+	prepareCall := func(pageRequest *core.PageRequest[*string]) *internal.CallParams {
 		if pageRequest.Cursor != nil {
 			queryParams.Set("starting_after", *pageRequest.Cursor)
 		}
@@ -75,11 +75,11 @@ func (c *Client) ListWithCursorPagination(
 			Response:        pageRequest.Response,
 		}
 	}
-	readPageResponse := func(response *fern.ListUsersPaginationResponse) *internal.PageResponse[*string, *fern.User] {
+	readPageResponse := func(response *fern.ListUsersPaginationResponse) *core.PageResponse[*string, *fern.User] {
 		var zeroValue string
 		next := response.GetPage().GetNext().GetStartingAfter()
 		results := response.GetData()
-		return &internal.PageResponse[*string, *fern.User]{
+		return &core.PageResponse[*string, *fern.User]{
 			Next:    &next,
 			Results: results,
 			Done:    next == zeroValue,
@@ -97,7 +97,7 @@ func (c *Client) ListWithMixedTypeCursorPagination(
 	ctx context.Context,
 	request *fern.ListUsersMixedTypeCursorPaginationRequest,
 	opts ...option.RequestOption,
-) (*core.Page[*fern.User], error) {
+) (*core.Page[*string, *fern.User], error) {
 	options := core.NewRequestOptions(opts...)
 	baseURL := internal.ResolveBaseURL(
 		options.BaseURL,
@@ -113,7 +113,7 @@ func (c *Client) ListWithMixedTypeCursorPagination(
 		c.options.ToHeader(),
 		options.ToHeader(),
 	)
-	prepareCall := func(pageRequest *internal.PageRequest[*string]) *internal.CallParams {
+	prepareCall := func(pageRequest *core.PageRequest[*string]) *internal.CallParams {
 		if pageRequest.Cursor != nil {
 			queryParams.Set("cursor", *pageRequest.Cursor)
 		}
@@ -132,11 +132,11 @@ func (c *Client) ListWithMixedTypeCursorPagination(
 			Response:        pageRequest.Response,
 		}
 	}
-	readPageResponse := func(response *fern.ListUsersMixedTypePaginationResponse) *internal.PageResponse[*string, *fern.User] {
+	readPageResponse := func(response *fern.ListUsersMixedTypePaginationResponse) *core.PageResponse[*string, *fern.User] {
 		var zeroValue string
 		next := response.GetNext()
 		results := response.GetData()
-		return &internal.PageResponse[*string, *fern.User]{
+		return &core.PageResponse[*string, *fern.User]{
 			Next:    &next,
 			Results: results,
 			Done:    next == zeroValue,
@@ -170,7 +170,7 @@ func (c *Client) ListWithOffsetPagination(
 	ctx context.Context,
 	request *fern.ListUsersOffsetPaginationRequest,
 	opts ...option.RequestOption,
-) (*core.Page[*fern.User], error) {
+) (*core.Page[*int, *fern.User], error) {
 	options := core.NewRequestOptions(opts...)
 	baseURL := internal.ResolveBaseURL(
 		options.BaseURL,
@@ -186,7 +186,7 @@ func (c *Client) ListWithOffsetPagination(
 		c.options.ToHeader(),
 		options.ToHeader(),
 	)
-	prepareCall := func(pageRequest *internal.PageRequest[*int]) *internal.CallParams {
+	prepareCall := func(pageRequest *core.PageRequest[*int]) *internal.CallParams {
 		if pageRequest.Cursor != nil {
 			queryParams.Set("page", fmt.Sprintf("%v", *pageRequest.Cursor))
 		}
@@ -213,10 +213,10 @@ func (c *Client) ListWithOffsetPagination(
 		}
 	}
 
-	readPageResponse := func(response *fern.ListUsersPaginationResponse) *internal.PageResponse[*int, *fern.User] {
+	readPageResponse := func(response *fern.ListUsersPaginationResponse) *core.PageResponse[*int, *fern.User] {
 		next += 1
 		results := response.GetData()
-		return &internal.PageResponse[*int, *fern.User]{
+		return &core.PageResponse[*int, *fern.User]{
 			Next:    &next,
 			Results: results,
 		}
@@ -233,7 +233,7 @@ func (c *Client) ListWithDoubleOffsetPagination(
 	ctx context.Context,
 	request *fern.ListUsersDoubleOffsetPaginationRequest,
 	opts ...option.RequestOption,
-) (*core.Page[*fern.User], error) {
+) (*core.Page[*float64, *fern.User], error) {
 	options := core.NewRequestOptions(opts...)
 	baseURL := internal.ResolveBaseURL(
 		options.BaseURL,
@@ -249,7 +249,7 @@ func (c *Client) ListWithDoubleOffsetPagination(
 		c.options.ToHeader(),
 		options.ToHeader(),
 	)
-	prepareCall := func(pageRequest *internal.PageRequest[*float64]) *internal.CallParams {
+	prepareCall := func(pageRequest *core.PageRequest[*float64]) *internal.CallParams {
 		if pageRequest.Cursor != nil {
 			queryParams.Set("page", fmt.Sprintf("%v", *pageRequest.Cursor))
 		}
@@ -271,15 +271,15 @@ func (c *Client) ListWithDoubleOffsetPagination(
 	var next float64 = 1
 	if queryParams.Has("page") {
 		var err error
-		if next, err = strconv.Atoi(queryParams.Get("page")); err != nil {
+		if next, err = strconv.ParseFloat(queryParams.Get("page"), 64); err != nil {
 			return nil, err
 		}
 	}
 
-	readPageResponse := func(response *fern.ListUsersPaginationResponse) *internal.PageResponse[*float64, *fern.User] {
+	readPageResponse := func(response *fern.ListUsersPaginationResponse) *core.PageResponse[*float64, *fern.User] {
 		next += 1
 		results := response.GetData()
-		return &internal.PageResponse[*float64, *fern.User]{
+		return &core.PageResponse[*float64, *fern.User]{
 			Next:    &next,
 			Results: results,
 		}
@@ -312,7 +312,7 @@ func (c *Client) ListWithOffsetStepPagination(
 	ctx context.Context,
 	request *fern.ListUsersOffsetStepPaginationRequest,
 	opts ...option.RequestOption,
-) (*core.Page[*fern.User], error) {
+) (*core.Page[*int, *fern.User], error) {
 	options := core.NewRequestOptions(opts...)
 	baseURL := internal.ResolveBaseURL(
 		options.BaseURL,
@@ -328,7 +328,7 @@ func (c *Client) ListWithOffsetStepPagination(
 		c.options.ToHeader(),
 		options.ToHeader(),
 	)
-	prepareCall := func(pageRequest *internal.PageRequest[*int]) *internal.CallParams {
+	prepareCall := func(pageRequest *core.PageRequest[*int]) *internal.CallParams {
 		if pageRequest.Cursor != nil {
 			queryParams.Set("page", fmt.Sprintf("%v", *pageRequest.Cursor))
 		}
@@ -355,10 +355,10 @@ func (c *Client) ListWithOffsetStepPagination(
 		}
 	}
 
-	readPageResponse := func(response *fern.ListUsersPaginationResponse) *internal.PageResponse[*int, *fern.User] {
+	readPageResponse := func(response *fern.ListUsersPaginationResponse) *core.PageResponse[*int, *fern.User] {
 		next += 1
 		results := response.GetData()
-		return &internal.PageResponse[*int, *fern.User]{
+		return &core.PageResponse[*int, *fern.User]{
 			Next:    &next,
 			Results: results,
 		}
@@ -375,7 +375,7 @@ func (c *Client) ListWithOffsetPaginationHasNextPage(
 	ctx context.Context,
 	request *fern.ListWithOffsetPaginationHasNextPageRequest,
 	opts ...option.RequestOption,
-) (*core.Page[*fern.User], error) {
+) (*core.Page[*int, *fern.User], error) {
 	options := core.NewRequestOptions(opts...)
 	baseURL := internal.ResolveBaseURL(
 		options.BaseURL,
@@ -391,7 +391,7 @@ func (c *Client) ListWithOffsetPaginationHasNextPage(
 		c.options.ToHeader(),
 		options.ToHeader(),
 	)
-	prepareCall := func(pageRequest *internal.PageRequest[*int]) *internal.CallParams {
+	prepareCall := func(pageRequest *core.PageRequest[*int]) *internal.CallParams {
 		if pageRequest.Cursor != nil {
 			queryParams.Set("page", fmt.Sprintf("%v", *pageRequest.Cursor))
 		}
@@ -418,10 +418,10 @@ func (c *Client) ListWithOffsetPaginationHasNextPage(
 		}
 	}
 
-	readPageResponse := func(response *fern.ListUsersPaginationResponse) *internal.PageResponse[*int, *fern.User] {
+	readPageResponse := func(response *fern.ListUsersPaginationResponse) *core.PageResponse[*int, *fern.User] {
 		next += 1
 		results := response.GetData()
-		return &internal.PageResponse[*int, *fern.User]{
+		return &core.PageResponse[*int, *fern.User]{
 			Next:    &next,
 			Results: results,
 		}
@@ -438,7 +438,7 @@ func (c *Client) ListWithExtendedResults(
 	ctx context.Context,
 	request *fern.ListUsersExtendedRequest,
 	opts ...option.RequestOption,
-) (*core.Page[*fern.User], error) {
+) (*core.Page[*uuid.UUID, *fern.User], error) {
 	options := core.NewRequestOptions(opts...)
 	baseURL := internal.ResolveBaseURL(
 		options.BaseURL,
@@ -454,7 +454,7 @@ func (c *Client) ListWithExtendedResults(
 		c.options.ToHeader(),
 		options.ToHeader(),
 	)
-	prepareCall := func(pageRequest *internal.PageRequest[*uuid.UUID]) *internal.CallParams {
+	prepareCall := func(pageRequest *core.PageRequest[*uuid.UUID]) *internal.CallParams {
 		if pageRequest.Cursor != nil {
 			queryParams.Set("cursor", fmt.Sprintf("%v", *pageRequest.Cursor))
 		}
@@ -473,11 +473,11 @@ func (c *Client) ListWithExtendedResults(
 			Response:        pageRequest.Response,
 		}
 	}
-	readPageResponse := func(response *fern.ListUsersExtendedResponse) *internal.PageResponse[*uuid.UUID, *fern.User] {
+	readPageResponse := func(response *fern.ListUsersExtendedResponse) *core.PageResponse[*uuid.UUID, *fern.User] {
 		var zeroValue *uuid.UUID
 		next := response.GetNext()
 		results := response.GetData().GetUsers()
-		return &internal.PageResponse[*uuid.UUID, *fern.User]{
+		return &core.PageResponse[*uuid.UUID, *fern.User]{
 			Next:    next,
 			Results: results,
 			Done:    next == zeroValue,
@@ -495,7 +495,7 @@ func (c *Client) ListWithExtendedResultsAndOptionalData(
 	ctx context.Context,
 	request *fern.ListUsersExtendedRequestForOptionalData,
 	opts ...option.RequestOption,
-) (*core.Page[*fern.User], error) {
+) (*core.Page[*uuid.UUID, *fern.User], error) {
 	options := core.NewRequestOptions(opts...)
 	baseURL := internal.ResolveBaseURL(
 		options.BaseURL,
@@ -511,7 +511,7 @@ func (c *Client) ListWithExtendedResultsAndOptionalData(
 		c.options.ToHeader(),
 		options.ToHeader(),
 	)
-	prepareCall := func(pageRequest *internal.PageRequest[*uuid.UUID]) *internal.CallParams {
+	prepareCall := func(pageRequest *core.PageRequest[*uuid.UUID]) *internal.CallParams {
 		if pageRequest.Cursor != nil {
 			queryParams.Set("cursor", fmt.Sprintf("%v", *pageRequest.Cursor))
 		}
@@ -530,11 +530,11 @@ func (c *Client) ListWithExtendedResultsAndOptionalData(
 			Response:        pageRequest.Response,
 		}
 	}
-	readPageResponse := func(response *fern.ListUsersExtendedOptionalListResponse) *internal.PageResponse[*uuid.UUID, *fern.User] {
+	readPageResponse := func(response *fern.ListUsersExtendedOptionalListResponse) *core.PageResponse[*uuid.UUID, *fern.User] {
 		var zeroValue *uuid.UUID
 		next := response.GetNext()
 		results := response.GetData().GetUsers()
-		return &internal.PageResponse[*uuid.UUID, *fern.User]{
+		return &core.PageResponse[*uuid.UUID, *fern.User]{
 			Next:    next,
 			Results: results,
 			Done:    next == zeroValue,
@@ -552,7 +552,7 @@ func (c *Client) ListUsernames(
 	ctx context.Context,
 	request *fern.ListUsernamesRequest,
 	opts ...option.RequestOption,
-) (*core.Page[string], error) {
+) (*core.Page[*string, string], error) {
 	options := core.NewRequestOptions(opts...)
 	baseURL := internal.ResolveBaseURL(
 		options.BaseURL,
@@ -568,7 +568,7 @@ func (c *Client) ListUsernames(
 		c.options.ToHeader(),
 		options.ToHeader(),
 	)
-	prepareCall := func(pageRequest *internal.PageRequest[*string]) *internal.CallParams {
+	prepareCall := func(pageRequest *core.PageRequest[*string]) *internal.CallParams {
 		if pageRequest.Cursor != nil {
 			queryParams.Set("starting_after", *pageRequest.Cursor)
 		}
@@ -587,14 +587,14 @@ func (c *Client) ListUsernames(
 			Response:        pageRequest.Response,
 		}
 	}
-	readPageResponse := func(response *fern.UsernameCursor) *internal.PageResponse[*string, string] {
+	readPageResponse := func(response *fern.UsernameCursor) *core.PageResponse[*string, string] {
 		var zeroValue *string
 		var next *string
 		if response.Cursor != nil {
 			next = response.Cursor.After
 		}
 		results := response.GetCursor().GetData()
-		return &internal.PageResponse[*string, string]{
+		return &core.PageResponse[*string, string]{
 			Next:    next,
 			Results: results,
 			Done:    next == zeroValue,
@@ -612,7 +612,7 @@ func (c *Client) ListWithGlobalConfig(
 	ctx context.Context,
 	request *fern.ListWithGlobalConfigRequest,
 	opts ...option.RequestOption,
-) (*core.Page[string], error) {
+) (*core.Page[*int, string], error) {
 	options := core.NewRequestOptions(opts...)
 	baseURL := internal.ResolveBaseURL(
 		options.BaseURL,
@@ -628,7 +628,7 @@ func (c *Client) ListWithGlobalConfig(
 		c.options.ToHeader(),
 		options.ToHeader(),
 	)
-	prepareCall := func(pageRequest *internal.PageRequest[*int]) *internal.CallParams {
+	prepareCall := func(pageRequest *core.PageRequest[*int]) *internal.CallParams {
 		if pageRequest.Cursor != nil {
 			queryParams.Set("offset", fmt.Sprintf("%v", *pageRequest.Cursor))
 		}
@@ -655,10 +655,10 @@ func (c *Client) ListWithGlobalConfig(
 		}
 	}
 
-	readPageResponse := func(response *fern.UsernameContainer) *internal.PageResponse[*int, string] {
+	readPageResponse := func(response *fern.UsernameContainer) *core.PageResponse[*int, string] {
 		next += 1
 		results := response.GetResults()
-		return &internal.PageResponse[*int, string]{
+		return &core.PageResponse[*int, string]{
 			Next:    &next,
 			Results: results,
 		}


### PR DESCRIPTION
## Summary
Customers want to be able to access the raw cursor property from paginated response, not just use the `GetNextPage` helper function.

## Testing
I ran the `pagination` seed case, are there any other seed cases that might be useful to prove this functionality out?