### PR TITLE
fix(java): add boolean and long to abstract writer primtive types

### DIFF
--- a/generators/java/sdk/Dockerfile
+++ b/generators/java/sdk/Dockerfile
@@ -11,7 +11,7 @@ RUN cd / \
     && tar -xvf sdk.tar \
     && rm -rf sdk.tar
 
-ENV JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
+ENV JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8 -Xmx4096m"
 
 # Copy over node contents to be able to run the compiled CLI
 COPY --from=node /usr/local/bin/node /usr/local/bin/

--- a/generators/java/sdk/Dockerfile
+++ b/generators/java/sdk/Dockerfile
@@ -11,7 +11,7 @@ RUN cd / \
     && tar -xvf sdk.tar \
     && rm -rf sdk.tar
 
-ENV JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8 -Xmx4096m"
+ENV JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
 
 # Copy over node contents to be able to run the compiled CLI
 COPY --from=node /usr/local/bin/node /usr/local/bin/

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/AbstractEndpointWriter.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/AbstractEndpointWriter.java
@@ -128,6 +128,10 @@ public abstract class AbstractEndpointWriter {
             return CodeBlock.of("$T.toString($L)", Double.class, reference);
         } else if (typeName.equals(TypeName.INT)) {
             return CodeBlock.of("$T.toString($L)", Integer.class, reference);
+        } else if (typeName.equals(TypeName.LONG)) {
+            return CodeBlock.of("$T.toString($L)", Long.class, reference);
+        } else if (typeName.equals(TypeName.BOOLEAN)) {
+            return CodeBlock.of("$T.toString($L)", Boolean.class, reference);
         } else {
             return CodeBlock.of("$L.toString()", reference);
         }

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,3 +1,13 @@
+- version: 3.10.4
+  changelogEntry:
+    - summary: |
+        Fix AbstractEndpointWriter.stringify() missing BOOLEAN and LONG primitive handling.
+        Prevents "boolean cannot be dereferenced" compilation errors when boolean query
+        parameters are used in certain code generation paths.
+      type: fix
+  createdAt: "2025-10-29"
+  irVersion: 61
+
 - version: 3.10.3
   changelogEntry:
     - summary: |

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,9 +1,7 @@
 - version: 3.10.4
   changelogEntry:
     - summary: |
-        Fix AbstractEndpointWriter.stringify() missing BOOLEAN and LONG primitive handling.
-        Prevents "boolean cannot be dereferenced" compilation errors when boolean query
-        parameters are used in certain code generation paths.
+        Fix compilation errors when using boolean or long query parameters.
       type: fix
   createdAt: "2025-10-29"
   irVersion: 61


### PR DESCRIPTION
## Description
Linear ticket: Closes [FER-7490: Schematic fix for Java](https://linear.app/buildwithfern/issue/FER-7490/schematic-fix-for-java)
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
<!-- Provide a clear and concise description of the changes made in this PR -->

AbstractEndpointWriter.stringify() was missing BOOLEAN and LONG primitive handling, causing potential compilation errors when these types are used  in query parameters or path parameters.

## Testing
<!-- Describe how you tested these changes -->
- [ ] Unit tests added/updated
- [ ] Manual testing completed
