### PR TITLE
chore(ci): Always pair always with not cancelled in actions to avoid unstoppable CI

### DIFF
--- a/.github/workflows/nightly-seed-grouping.yml
+++ b/.github/workflows/nightly-seed-grouping.yml
@@ -94,7 +94,7 @@ jobs:
   build-seed-groups:
     runs-on: ubuntu-latest
     timeout-minutes: 3
-    if: always() && (needs.run-seed-test.result == 'success' || needs.run-seed-test.result == 'failure')
+    if: always() && !cancelled() && (needs.run-seed-test.result == 'success' || needs.run-seed-test.result == 'failure')
     needs: [run-seed-test]
     strategy:
       fail-fast: false
@@ -171,7 +171,7 @@ jobs:
   pr-seed-group-files:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: always() && (needs.build-seed-groups.result == 'success' || needs.build-seed-groups.result == 'failure')
+    if: always() && !cancelled() && (needs.build-seed-groups.result == 'success' || needs.build-seed-groups.result == 'failure')
     needs: [build-seed-groups]
     steps:
       - name: Checkout Repo

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -1076,7 +1076,7 @@ jobs:
   commit-seed-changes-by-push:
     if: >-
       ${{
-        always() && needs.setup.outputs.update-by-push == 'true' &&
+        always() && !cancelled() && needs.setup.outputs.update-by-push == 'true' &&
         !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
       }}
     needs:
@@ -1151,7 +1151,7 @@ jobs:
   commit-seed-changes-by-pr:
     if: >-
       ${{
-        always() &&
+        always() && !cancelled() &&
         github.ref == 'refs/heads/main' &&
         needs.setup.outputs.update-by-pr == 'true' &&
         !contains(needs.*.result, 'failure') && 


### PR DESCRIPTION
## Description
Linear ticket: Closes FER-7247
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
<!-- Provide a clear and concise description of the changes made in this PR -->
Give the ability to cancel any CI job (ones using `always()` need to be accompanied by `&& !cancelled()`)

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Attach a `&& !cancelled()` to every `always()` in GitHub actions to prevent jobs from running when cancelled

## Testing
<!-- Describe how you tested these changes -->
- Making jobs cancellable: Verified in CI here: https://github.com/fern-api/fern/actions/runs/18632889160
