### PR TITLE
feat(ci): Get reporting summaries for passing tests still in allowedFailures

### DIFF
--- a/.github/actions/run-seed-process/action.yaml
+++ b/.github/actions/run-seed-process/action.yaml
@@ -82,15 +82,23 @@ runs:
       if: always() && !cancelled()
       shell: bash
       run: |
-        # Verify file exists from previous step
+        # Verify file exists from previous step. For parsing, focus on end of file (grabbing a few hundred lines should be more than enough) and reverse search (bottom-up) for better perf
         if [ -f "output.log" ]; then 
-          # Focusing on last 100 lines of file (should be more than enough), reverse search (bottom-up) for string including unexpected failures
-          UNEXPECTED_FAILURES=$(tail -n 100 output.log | tac | grep -m 1 "unexpected failures, including:" | sed -n 's/.*unexpected failures, including: \(.*\)\./\1/p' || echo "")
+          # Find string including new, unexpected failures
+          UNEXPECTED_FAILURES=$(tail -n 200 output.log | tac | grep -m 1 "unexpected failures, including:" | sed -n 's/.*unexpected failures, including: \(.*\)\./\1/p' || echo "")
           if [ -n "$UNEXPECTED_FAILURES" ]; then
-            echo "**${{ inputs.sdk-name }} Unexpected Test Failures:** ${UNEXPECTED_FAILURES}" >> $GITHUB_STEP_SUMMARY
+            echo "**❌ ${{ inputs.sdk-name }} Unexpected Test Failures:** ${UNEXPECTED_FAILURES}" >> $GITHUB_STEP_SUMMARY
           else
             echo "No unexpected errors parsed from output"
           fi
+
+          # Find string including passing fixtures that are still in allowedFailures list
+          UNEXPECTEDLY_PASSING=$(tail -n 200 output.log | tac | grep -m 1 "Consider removing the following fixtures from allowedFailures:" | sed -n 's/.*Consider removing the following fixtures from allowedFailures: \(.*\)\./\1/p' || echo "")
+          if [ -n "$UNEXPECTEDLY_PASSING" ]; then
+            echo "**⚠️ ${{ inputs.sdk-name }} Passing Tests in Allowed Failures List:** ${UNEXPECTEDLY_PASSING}" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "No passing tests found in allowedFailures list from output"
+          fi 
         else 
           echo "No output available to parse for test group"
         fi

--- a/generators/csharp/sdk/package.json
+++ b/generators/csharp/sdk/package.json
@@ -20,9 +20,7 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
     "compile": "tsc --build",

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/ada.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/ada.json
@@ -1475,6 +1475,196 @@ types:
     inline: true
 ",
     },
+    "webhooks.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {
+        "imports": {
+          "root": "__package__.yml",
+        },
+        "webhooks": {
+          "v1EndUserCreatedPost29a75ca0": {
+            "audiences": [],
+            "display-name": "End user created webhook",
+            "docs": "A webhook sent when a new end user is created",
+            "examples": [
+              {
+                "docs": undefined,
+                "name": undefined,
+                "payload": {
+                  "data": {
+                    "created_at": "2023-12-08T19:06:04.890000",
+                    "end_user_id": "5f7e0e2c1e7c7e000f0f9c3a",
+                    "profile": {
+                      "email": "ada.lovelace@ada.cx",
+                      "first_name": "Ada",
+                      "language": "en-US",
+                      "last_name": "Lovelace",
+                      "metadata": {
+                        "example_key1": "example_string_value",
+                        "example_key2": true,
+                        "example_key3": 123,
+                      },
+                      "system_properties": {
+                        "browser": "Chrome",
+                        "browser_version": "119.0.0.0",
+                        "device": "macos",
+                        "introshown": false,
+                        "last_answer_id": "650071321ef45533437f6f29",
+                        "last_question_asked": "What is my account balance?",
+                        "sunshine_conversation_id": "12345abc",
+                        "sunshine_end_user_channel": "whatsapp",
+                        "sunshine_first_message_id": "65736922f17d0bf841d8eeb4",
+                        "sunshine_signed_up_at": "2023-12-08T19:06:04.890000",
+                        "sunshine_user_id": "5f7e0e2c1e7c7e000f0f9c3a",
+                        "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36",
+                      },
+                    },
+                    "updated_at": "2023-12-08T19:06:04.890000",
+                  },
+                  "timestamp": "2024-01-17T22:23:35.835",
+                  "type": "v1.end_user.created",
+                },
+              },
+            ],
+            "headers": {},
+            "method": "POST",
+            "payload": "root.EndUserCreatedWebhookPayload",
+          },
+          "v1EndUserUpdatedPost83bfd265": {
+            "audiences": [],
+            "display-name": "End user updated webhook",
+            "docs": "A webhook sent when an end user is updated",
+            "examples": [
+              {
+                "docs": undefined,
+                "name": undefined,
+                "payload": {
+                  "data": {
+                    "created_at": "2023-12-08T19:06:04.890000",
+                    "end_user_id": "5f7e0e2c1e7c7e000f0f9c3a",
+                    "profile": {
+                      "email": "ada.lovelace@ada.cx",
+                      "first_name": "Ada",
+                      "language": "en-US",
+                      "last_name": "Lovelace",
+                      "metadata": {
+                        "example_key1": "example_string_value",
+                        "example_key2": true,
+                        "example_key3": 123,
+                      },
+                      "system_properties": {
+                        "browser": "Chrome",
+                        "browser_version": "119.0.0.0",
+                        "device": "macos",
+                        "introshown": false,
+                        "last_answer_id": "650071321ef45533437f6f29",
+                        "last_question_asked": "What is my account balance?",
+                        "sunshine_conversation_id": "12345abc",
+                        "sunshine_end_user_channel": "whatsapp",
+                        "sunshine_first_message_id": "65736922f17d0bf841d8eeb4",
+                        "sunshine_signed_up_at": "2023-12-08T19:06:04.890000",
+                        "sunshine_user_id": "5f7e0e2c1e7c7e000f0f9c3a",
+                        "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36",
+                      },
+                    },
+                    "updated_at": "2023-12-08T19:06:04.890000",
+                  },
+                  "timestamp": "2024-01-17T22:23:35.835",
+                  "type": "v1.end_user.updated",
+                },
+              },
+            ],
+            "headers": {},
+            "method": "POST",
+            "payload": "root.EndUserUpdatedWebhookPayload",
+          },
+        },
+      },
+      "rawContents": "imports:
+  root: __package__.yml
+webhooks:
+  v1EndUserCreatedPost29a75ca0:
+    audiences: []
+    method: POST
+    display-name: End user created webhook
+    headers: {}
+    payload: root.EndUserCreatedWebhookPayload
+    examples:
+      - payload:
+          type: v1.end_user.created
+          timestamp: '2024-01-17T22:23:35.835'
+          data:
+            end_user_id: 5f7e0e2c1e7c7e000f0f9c3a
+            profile:
+              first_name: Ada
+              last_name: Lovelace
+              email: ada.lovelace@ada.cx
+              language: en-US
+              metadata:
+                example_key1: example_string_value
+                example_key2: true
+                example_key3: 123
+              system_properties:
+                user_agent: >-
+                  Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)
+                  AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0
+                  Safari/537.36
+                device: macos
+                browser: Chrome
+                browser_version: 119.0.0.0
+                introshown: false
+                last_answer_id: 650071321ef45533437f6f29
+                last_question_asked: What is my account balance?
+                sunshine_first_message_id: 65736922f17d0bf841d8eeb4
+                sunshine_conversation_id: 12345abc
+                sunshine_end_user_channel: whatsapp
+                sunshine_signed_up_at: '2023-12-08T19:06:04.890000'
+                sunshine_user_id: 5f7e0e2c1e7c7e000f0f9c3a
+            created_at: '2023-12-08T19:06:04.890000'
+            updated_at: '2023-12-08T19:06:04.890000'
+    docs: A webhook sent when a new end user is created
+  v1EndUserUpdatedPost83bfd265:
+    audiences: []
+    method: POST
+    display-name: End user updated webhook
+    headers: {}
+    payload: root.EndUserUpdatedWebhookPayload
+    examples:
+      - payload:
+          type: v1.end_user.updated
+          timestamp: '2024-01-17T22:23:35.835'
+          data:
+            end_user_id: 5f7e0e2c1e7c7e000f0f9c3a
+            profile:
+              first_name: Ada
+              last_name: Lovelace
+              email: ada.lovelace@ada.cx
+              language: en-US
+              metadata:
+                example_key1: example_string_value
+                example_key2: true
+                example_key3: 123
+              system_properties:
+                user_agent: >-
+                  Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)
+                  AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0
+                  Safari/537.36
+                device: macos
+                browser: Chrome
+                browser_version: 119.0.0.0
+                introshown: false
+                last_answer_id: 650071321ef45533437f6f29
+                last_question_asked: What is my account balance?
+                sunshine_first_message_id: 65736922f17d0bf841d8eeb4
+                sunshine_conversation_id: 12345abc
+                sunshine_end_user_channel: whatsapp
+                sunshine_signed_up_at: '2023-12-08T19:06:04.890000'
+                sunshine_user_id: 5f7e0e2c1e7c7e000f0f9c3a
+            created_at: '2023-12-08T19:06:04.890000'
+            updated_at: '2023-12-08T19:06:04.890000'
+    docs: A webhook sent when an end user is updated
+",
+    },
   },
   "packageMarkers": {},
   "rootApiFile": {

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/ada.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/ada.json
@@ -2024,7 +2024,506 @@
       }
     }
   ],
-  "webhooks": [],
+  "webhooks": [
+    {
+      "summary": "End user created webhook",
+      "audiences": [],
+      "method": "POST",
+      "operationId": "v1EndUserCreatedPost29a75ca0",
+      "tags": [
+        "Webhooks"
+      ],
+      "headers": [],
+      "generatedPayloadName": "PostV1EndUserCreatedPayload",
+      "payload": {
+        "generatedName": "PostV1EndUserCreatedPayload",
+        "schema": "EndUserCreatedWebhookPayload",
+        "source": {
+          "file": "../openapi.json",
+          "type": "openapi"
+        },
+        "type": "reference"
+      },
+      "description": "A webhook sent when a new end user is created",
+      "examples": [
+        {
+          "payload": {
+            "properties": {
+              "type": {
+                "value": {
+                  "value": "v1.end_user.created",
+                  "type": "string"
+                },
+                "type": "primitive"
+              },
+              "timestamp": {
+                "value": {
+                  "value": "2024-01-17T22:23:35.835",
+                  "type": "string"
+                },
+                "type": "primitive"
+              },
+              "data": {
+                "properties": {
+                  "end_user_id": {
+                    "value": {
+                      "value": "5f7e0e2c1e7c7e000f0f9c3a",
+                      "type": "string"
+                    },
+                    "type": "primitive"
+                  },
+                  "profile": {
+                    "properties": {
+                      "first_name": {
+                        "value": {
+                          "value": "Ada",
+                          "type": "string"
+                        },
+                        "type": "primitive"
+                      },
+                      "last_name": {
+                        "value": {
+                          "value": "Lovelace",
+                          "type": "string"
+                        },
+                        "type": "primitive"
+                      },
+                      "email": {
+                        "value": {
+                          "value": "ada.lovelace@ada.cx",
+                          "type": "string"
+                        },
+                        "type": "primitive"
+                      },
+                      "language": {
+                        "value": {
+                          "value": "en-US",
+                          "type": "string"
+                        },
+                        "type": "primitive"
+                      },
+                      "metadata": {
+                        "value": [
+                          {
+                            "key": {
+                              "value": "example_key1",
+                              "type": "string"
+                            },
+                            "value": {
+                              "value": {
+                                "value": {
+                                  "value": "example_string_value",
+                                  "type": "string"
+                                },
+                                "type": "primitive"
+                              },
+                              "type": "unknown"
+                            }
+                          },
+                          {
+                            "key": {
+                              "value": "example_key2",
+                              "type": "string"
+                            },
+                            "value": {
+                              "value": {
+                                "value": {
+                                  "value": true,
+                                  "type": "boolean"
+                                },
+                                "type": "primitive"
+                              },
+                              "type": "unknown"
+                            }
+                          },
+                          {
+                            "key": {
+                              "value": "example_key3",
+                              "type": "string"
+                            },
+                            "value": {
+                              "value": {
+                                "value": {
+                                  "value": 123,
+                                  "type": "int"
+                                },
+                                "type": "primitive"
+                              },
+                              "type": "unknown"
+                            }
+                          }
+                        ],
+                        "type": "map"
+                      },
+                      "system_properties": {
+                        "properties": {
+                          "user_agent": {
+                            "value": {
+                              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36",
+                              "type": "string"
+                            },
+                            "type": "primitive"
+                          },
+                          "device": {
+                            "value": {
+                              "value": "macos",
+                              "type": "string"
+                            },
+                            "type": "primitive"
+                          },
+                          "browser": {
+                            "value": {
+                              "value": "Chrome",
+                              "type": "string"
+                            },
+                            "type": "primitive"
+                          },
+                          "browser_version": {
+                            "value": {
+                              "value": "119.0.0.0",
+                              "type": "string"
+                            },
+                            "type": "primitive"
+                          },
+                          "introshown": {
+                            "value": {
+                              "value": false,
+                              "type": "boolean"
+                            },
+                            "type": "primitive"
+                          },
+                          "last_answer_id": {
+                            "value": {
+                              "value": "650071321ef45533437f6f29",
+                              "type": "string"
+                            },
+                            "type": "primitive"
+                          },
+                          "last_question_asked": {
+                            "value": {
+                              "value": "What is my account balance?",
+                              "type": "string"
+                            },
+                            "type": "primitive"
+                          },
+                          "sunshine_first_message_id": {
+                            "value": {
+                              "value": "65736922f17d0bf841d8eeb4",
+                              "type": "string"
+                            },
+                            "type": "primitive"
+                          },
+                          "sunshine_conversation_id": {
+                            "value": {
+                              "value": "12345abc",
+                              "type": "string"
+                            },
+                            "type": "primitive"
+                          },
+                          "sunshine_end_user_channel": {
+                            "value": {
+                              "value": "whatsapp",
+                              "type": "string"
+                            },
+                            "type": "primitive"
+                          },
+                          "sunshine_signed_up_at": {
+                            "value": {
+                              "value": "2023-12-08T19:06:04.890000",
+                              "type": "string"
+                            },
+                            "type": "primitive"
+                          },
+                          "sunshine_user_id": {
+                            "value": {
+                              "value": "5f7e0e2c1e7c7e000f0f9c3a",
+                              "type": "string"
+                            },
+                            "type": "primitive"
+                          }
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "created_at": {
+                    "value": {
+                      "value": "2023-12-08T19:06:04.890000",
+                      "type": "string"
+                    },
+                    "type": "primitive"
+                  },
+                  "updated_at": {
+                    "value": {
+                      "value": "2023-12-08T19:06:04.890000",
+                      "type": "string"
+                    },
+                    "type": "primitive"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          }
+        }
+      ],
+      "source": {
+        "file": "../openapi.json",
+        "type": "openapi"
+      }
+    },
+    {
+      "summary": "End user updated webhook",
+      "audiences": [],
+      "method": "POST",
+      "operationId": "v1EndUserUpdatedPost83bfd265",
+      "tags": [
+        "Webhooks"
+      ],
+      "headers": [],
+      "generatedPayloadName": "PostV1EndUserUpdatedPayload",
+      "payload": {
+        "generatedName": "PostV1EndUserUpdatedPayload",
+        "schema": "EndUserUpdatedWebhookPayload",
+        "source": {
+          "file": "../openapi.json",
+          "type": "openapi"
+        },
+        "type": "reference"
+      },
+      "description": "A webhook sent when an end user is updated",
+      "examples": [
+        {
+          "payload": {
+            "properties": {
+              "type": {
+                "value": {
+                  "value": "v1.end_user.updated",
+                  "type": "string"
+                },
+                "type": "primitive"
+              },
+              "timestamp": {
+                "value": {
+                  "value": "2024-01-17T22:23:35.835",
+                  "type": "string"
+                },
+                "type": "primitive"
+              },
+              "data": {
+                "properties": {
+                  "end_user_id": {
+                    "value": {
+                      "value": "5f7e0e2c1e7c7e000f0f9c3a",
+                      "type": "string"
+                    },
+                    "type": "primitive"
+                  },
+                  "profile": {
+                    "properties": {
+                      "first_name": {
+                        "value": {
+                          "value": "Ada",
+                          "type": "string"
+                        },
+                        "type": "primitive"
+                      },
+                      "last_name": {
+                        "value": {
+                          "value": "Lovelace",
+                          "type": "string"
+                        },
+                        "type": "primitive"
+                      },
+                      "email": {
+                        "value": {
+                          "value": "ada.lovelace@ada.cx",
+                          "type": "string"
+                        },
+                        "type": "primitive"
+                      },
+                      "language": {
+                        "value": {
+                          "value": "en-US",
+                          "type": "string"
+                        },
+                        "type": "primitive"
+                      },
+                      "metadata": {
+                        "value": [
+                          {
+                            "key": {
+                              "value": "example_key1",
+                              "type": "string"
+                            },
+                            "value": {
+                              "value": {
+                                "value": {
+                                  "value": "example_string_value",
+                                  "type": "string"
+                                },
+                                "type": "primitive"
+                              },
+                              "type": "unknown"
+                            }
+                          },
+                          {
+                            "key": {
+                              "value": "example_key2",
+                              "type": "string"
+                            },
+                            "value": {
+                              "value": {
+                                "value": {
+                                  "value": true,
+                                  "type": "boolean"
+                                },
+                                "type": "primitive"
+                              },
+                              "type": "unknown"
+                            }
+                          },
+                          {
+                            "key": {
+                              "value": "example_key3",
+                              "type": "string"
+                            },
+                            "value": {
+                              "value": {
+                                "value": {
+                                  "value": 123,
+                                  "type": "int"
+                                },
+                                "type": "primitive"
+                              },
+                              "type": "unknown"
+                            }
+                          }
+                        ],
+                        "type": "map"
+                      },
+                      "system_properties": {
+                        "properties": {
+                          "user_agent": {
+                            "value": {
+                              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36",
+                              "type": "string"
+                            },
+                            "type": "primitive"
+                          },
+                          "device": {
+                            "value": {
+                              "value": "macos",
+                              "type": "string"
+                            },
+                            "type": "primitive"
+                          },
+                          "browser": {
+                            "value": {
+                              "value": "Chrome",
+                              "type": "string"
+                            },
+                            "type": "primitive"
+                          },
+                          "browser_version": {
+                            "value": {
+                              "value": "119.0.0.0",
+                              "type": "string"
+                            },
+                            "type": "primitive"
+                          },
+                          "introshown": {
+                            "value": {
+                              "value": false,
+                              "type": "boolean"
+                            },
+                            "type": "primitive"
+                          },
+                          "last_answer_id": {
+                            "value": {
+                              "value": "650071321ef45533437f6f29",
+                              "type": "string"
+                            },
+                            "type": "primitive"
+                          },
+                          "last_question_asked": {
+                            "value": {
+                              "value": "What is my account balance?",
+                              "type": "string"
+                            },
+                            "type": "primitive"
+                          },
+                          "sunshine_first_message_id": {
+                            "value": {
+                              "value": "65736922f17d0bf841d8eeb4",
+                              "type": "string"
+                            },
+                            "type": "primitive"
+                          },
+                          "sunshine_conversation_id": {
+                            "value": {
+                              "value": "12345abc",
+                              "type": "string"
+                            },
+                            "type": "primitive"
+                          },
+                          "sunshine_end_user_channel": {
+                            "value": {
+                              "value": "whatsapp",
+                              "type": "string"
+                            },
+                            "type": "primitive"
+                          },
+                          "sunshine_signed_up_at": {
+                            "value": {
+                              "value": "2023-12-08T19:06:04.890000",
+                              "type": "string"
+                            },
+                            "type": "primitive"
+                          },
+                          "sunshine_user_id": {
+                            "value": {
+                              "value": "5f7e0e2c1e7c7e000f0f9c3a",
+                              "type": "string"
+                            },
+                            "type": "primitive"
+                          }
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "created_at": {
+                    "value": {
+                      "value": "2023-12-08T19:06:04.890000",
+                      "type": "string"
+                    },
+                    "type": "primitive"
+                  },
+                  "updated_at": {
+                    "value": {
+                      "value": "2023-12-08T19:06:04.890000",
+                      "type": "string"
+                    },
+                    "type": "primitive"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          }
+        }
+      ],
+      "source": {
+        "file": "../openapi.json",
+        "type": "openapi"
+      }
+    }
+  ],
   "channels": {},
   "groupedSchemas": {
     "rootSchemas": {

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/ada.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/ada.json
@@ -1237,6 +1237,196 @@ types:
     inline: true
 ",
     },
+    "webhooks.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {
+        "imports": {
+          "root": "__package__.yml",
+        },
+        "webhooks": {
+          "v1EndUserCreatedPost29a75ca0": {
+            "audiences": [],
+            "display-name": "End user created webhook",
+            "docs": "A webhook sent when a new end user is created",
+            "examples": [
+              {
+                "docs": undefined,
+                "name": undefined,
+                "payload": {
+                  "data": {
+                    "created_at": "2023-12-08T19:06:04.890000",
+                    "end_user_id": "5f7e0e2c1e7c7e000f0f9c3a",
+                    "profile": {
+                      "email": "ada.lovelace@ada.cx",
+                      "first_name": "Ada",
+                      "language": "en-US",
+                      "last_name": "Lovelace",
+                      "metadata": {
+                        "example_key1": "example_string_value",
+                        "example_key2": true,
+                        "example_key3": 123,
+                      },
+                      "system_properties": {
+                        "browser": "Chrome",
+                        "browser_version": "119.0.0.0",
+                        "device": "macos",
+                        "introshown": false,
+                        "last_answer_id": "650071321ef45533437f6f29",
+                        "last_question_asked": "What is my account balance?",
+                        "sunshine_conversation_id": "12345abc",
+                        "sunshine_end_user_channel": "whatsapp",
+                        "sunshine_first_message_id": "65736922f17d0bf841d8eeb4",
+                        "sunshine_signed_up_at": "2023-12-08T19:06:04.890000",
+                        "sunshine_user_id": "5f7e0e2c1e7c7e000f0f9c3a",
+                        "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36",
+                      },
+                    },
+                    "updated_at": "2023-12-08T19:06:04.890000",
+                  },
+                  "timestamp": "2024-01-17T22:23:35.835",
+                  "type": "v1.end_user.created",
+                },
+              },
+            ],
+            "headers": {},
+            "method": "POST",
+            "payload": "root.EndUserCreatedWebhookPayload",
+          },
+          "v1EndUserUpdatedPost83bfd265": {
+            "audiences": [],
+            "display-name": "End user updated webhook",
+            "docs": "A webhook sent when an end user is updated",
+            "examples": [
+              {
+                "docs": undefined,
+                "name": undefined,
+                "payload": {
+                  "data": {
+                    "created_at": "2023-12-08T19:06:04.890000",
+                    "end_user_id": "5f7e0e2c1e7c7e000f0f9c3a",
+                    "profile": {
+                      "email": "ada.lovelace@ada.cx",
+                      "first_name": "Ada",
+                      "language": "en-US",
+                      "last_name": "Lovelace",
+                      "metadata": {
+                        "example_key1": "example_string_value",
+                        "example_key2": true,
+                        "example_key3": 123,
+                      },
+                      "system_properties": {
+                        "browser": "Chrome",
+                        "browser_version": "119.0.0.0",
+                        "device": "macos",
+                        "introshown": false,
+                        "last_answer_id": "650071321ef45533437f6f29",
+                        "last_question_asked": "What is my account balance?",
+                        "sunshine_conversation_id": "12345abc",
+                        "sunshine_end_user_channel": "whatsapp",
+                        "sunshine_first_message_id": "65736922f17d0bf841d8eeb4",
+                        "sunshine_signed_up_at": "2023-12-08T19:06:04.890000",
+                        "sunshine_user_id": "5f7e0e2c1e7c7e000f0f9c3a",
+                        "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36",
+                      },
+                    },
+                    "updated_at": "2023-12-08T19:06:04.890000",
+                  },
+                  "timestamp": "2024-01-17T22:23:35.835",
+                  "type": "v1.end_user.updated",
+                },
+              },
+            ],
+            "headers": {},
+            "method": "POST",
+            "payload": "root.EndUserUpdatedWebhookPayload",
+          },
+        },
+      },
+      "rawContents": "imports:
+  root: __package__.yml
+webhooks:
+  v1EndUserCreatedPost29a75ca0:
+    audiences: []
+    method: POST
+    display-name: End user created webhook
+    headers: {}
+    payload: root.EndUserCreatedWebhookPayload
+    examples:
+      - payload:
+          type: v1.end_user.created
+          timestamp: '2024-01-17T22:23:35.835'
+          data:
+            end_user_id: 5f7e0e2c1e7c7e000f0f9c3a
+            profile:
+              first_name: Ada
+              last_name: Lovelace
+              email: ada.lovelace@ada.cx
+              language: en-US
+              metadata:
+                example_key1: example_string_value
+                example_key2: true
+                example_key3: 123
+              system_properties:
+                user_agent: >-
+                  Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)
+                  AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0
+                  Safari/537.36
+                device: macos
+                browser: Chrome
+                browser_version: 119.0.0.0
+                introshown: false
+                last_answer_id: 650071321ef45533437f6f29
+                last_question_asked: What is my account balance?
+                sunshine_first_message_id: 65736922f17d0bf841d8eeb4
+                sunshine_conversation_id: 12345abc
+                sunshine_end_user_channel: whatsapp
+                sunshine_signed_up_at: '2023-12-08T19:06:04.890000'
+                sunshine_user_id: 5f7e0e2c1e7c7e000f0f9c3a
+            created_at: '2023-12-08T19:06:04.890000'
+            updated_at: '2023-12-08T19:06:04.890000'
+    docs: A webhook sent when a new end user is created
+  v1EndUserUpdatedPost83bfd265:
+    audiences: []
+    method: POST
+    display-name: End user updated webhook
+    headers: {}
+    payload: root.EndUserUpdatedWebhookPayload
+    examples:
+      - payload:
+          type: v1.end_user.updated
+          timestamp: '2024-01-17T22:23:35.835'
+          data:
+            end_user_id: 5f7e0e2c1e7c7e000f0f9c3a
+            profile:
+              first_name: Ada
+              last_name: Lovelace
+              email: ada.lovelace@ada.cx
+              language: en-US
+              metadata:
+                example_key1: example_string_value
+                example_key2: true
+                example_key3: 123
+              system_properties:
+                user_agent: >-
+                  Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)
+                  AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0
+                  Safari/537.36
+                device: macos
+                browser: Chrome
+                browser_version: 119.0.0.0
+                introshown: false
+                last_answer_id: 650071321ef45533437f6f29
+                last_question_asked: What is my account balance?
+                sunshine_first_message_id: 65736922f17d0bf841d8eeb4
+                sunshine_conversation_id: 12345abc
+                sunshine_end_user_channel: whatsapp
+                sunshine_signed_up_at: '2023-12-08T19:06:04.890000'
+                sunshine_user_id: 5f7e0e2c1e7c7e000f0f9c3a
+            created_at: '2023-12-08T19:06:04.890000'
+            updated_at: '2023-12-08T19:06:04.890000'
+    docs: A webhook sent when an end user is updated
+",
+    },
   },
   "packageMarkers": {},
   "rootApiFile": {

--- a/packages/cli/register/src/ir-to-fdr-converter/__test__/__snapshots__/oas-ir-fdr/callbacks-no-operation-id.json
+++ b/packages/cli/register/src/ir-to-fdr-converter/__test__/__snapshots__/oas-ir-fdr/callbacks-no-operation-id.json
@@ -1,0 +1,168 @@
+{
+  "types": {
+    "subscribe_Response_200": {
+      "name": "subscribe_Response_200",
+      "shape": {
+        "type": "object",
+        "extends": [],
+        "properties": [
+          {
+            "key": "subscriptionId",
+            "valueType": {
+              "type": "optional",
+              "itemType": {
+                "type": "primitive",
+                "value": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "subpackages": {},
+  "rootPackage": {
+    "endpoints": [
+      {
+        "auth": false,
+        "description": "Subscribe to receive webhook notifications",
+        "method": "POST",
+        "id": "subscribe",
+        "originalEndpointId": "endpoint_.subscribe",
+        "name": "Subscribe to notifications",
+        "path": {
+          "pathParameters": [],
+          "parts": [
+            {
+              "type": "literal",
+              "value": ""
+            },
+            {
+              "type": "literal",
+              "value": "/subscribe"
+            }
+          ]
+        },
+        "queryParameters": [],
+        "headers": [],
+        "request": {
+          "type": {
+            "type": "json",
+            "contentType": "application/json",
+            "shape": {
+              "type": "object",
+              "extends": [],
+              "properties": [
+                {
+                  "description": "URL to receive webhook notifications",
+                  "key": "callbackUrl",
+                  "valueType": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string",
+                      "format": "uri"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        "requestsV2": {
+          "requests": [
+            {
+              "type": {
+                "type": "json",
+                "contentType": "application/json",
+                "shape": {
+                  "type": "object",
+                  "extends": [],
+                  "properties": [
+                    {
+                      "description": "URL to receive webhook notifications",
+                      "key": "callbackUrl",
+                      "valueType": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string",
+                          "format": "uri"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "response": {
+          "type": {
+            "type": "reference",
+            "value": {
+              "type": "id",
+              "value": "subscribe_Response_200"
+            }
+          },
+          "statusCode": 200,
+          "description": "Successfully subscribed"
+        },
+        "responsesV2": {
+          "responses": [
+            {
+              "type": {
+                "type": "reference",
+                "value": {
+                  "type": "id",
+                  "value": "subscribe_Response_200"
+                }
+              },
+              "statusCode": 200,
+              "description": "Successfully subscribed"
+            }
+          ]
+        },
+        "errorsV2": [],
+        "examples": [
+          {
+            "description": "",
+            "path": "/subscribe",
+            "pathParameters": {},
+            "queryParameters": {},
+            "headers": {},
+            "requestBody": {
+              "callbackUrl": "string"
+            },
+            "requestBodyV3": {
+              "type": "json",
+              "value": {
+                "callbackUrl": "string"
+              }
+            },
+            "responseStatusCode": 200,
+            "responseBody": {
+              "subscriptionId": "string"
+            },
+            "responseBodyV3": {
+              "type": "json",
+              "value": {
+                "subscriptionId": "string"
+              }
+            }
+          }
+        ],
+        "protocol": {
+          "type": "rest"
+        }
+      }
+    ],
+    "webhooks": [],
+    "websockets": [],
+    "types": [],
+    "subpackages": []
+  },
+  "authSchemes": {},
+  "snippetsConfiguration": {},
+  "globalHeaders": []
+}

--- a/packages/seed/src/commands/test/testWorkspaceFixtures.ts
+++ b/packages/seed/src/commands/test/testWorkspaceFixtures.ts
@@ -106,7 +106,7 @@ export async function testGenerator({
     }
 
     if (unexpectedlySucceededFixtures.length > 0) {
-        CONSOLE_LOGGER.warn(
+        CONSOLE_LOGGER.info(
             `⚠️ ${unexpectedlySucceededFixtures.length}/${
                 results.length
             } test cases succeeded unexpectedly. Consider removing the following fixtures from allowedFailures: ${unexpectedlySucceededFixtures.join(", ")}.`

--- a/packages/seed/src/commands/test/testWorkspaceFixtures.ts
+++ b/packages/seed/src/commands/test/testWorkspaceFixtures.ts
@@ -87,14 +87,6 @@ export async function testGenerator({
         .map((res) => (res.id === res.outputFolder || !res.outputFolder ? res.id : `${res.id}:${res.outputFolder}`));
     const unexpectedlySucceededFixtures = succeededFixtures.filter((fixture) => allowedFailuresAsSet.has(fixture));
 
-    if (unexpectedlySucceededFixtures.length > 0) {
-        CONSOLE_LOGGER.warn(
-            `⚠️ ${unexpectedlySucceededFixtures.length}/${
-                results.length
-            } test cases succeeded unexpectedly. Consider removing the following fixtures from allowedFailures: ${unexpectedlySucceededFixtures.join(", ")}.`
-        );
-    }
-
     if (failedFixtures.length === 0) {
         CONSOLE_LOGGER.info(`${results.length}/${results.length} test cases passed ✅`);
     } else {
@@ -112,6 +104,15 @@ export async function testGenerator({
             CONSOLE_LOGGER.info("✅ All failed fixtures were expected failures.");
         }
     }
+
+    if (unexpectedlySucceededFixtures.length > 0) {
+        CONSOLE_LOGGER.warn(
+            `⚠️ ${unexpectedlySucceededFixtures.length}/${
+                results.length
+            } test cases succeeded unexpectedly. Consider removing the following fixtures from allowedFailures: ${unexpectedlySucceededFixtures.join(", ")}.`
+        );
+    }
+
     return true;
 }
 

--- a/seed/ts-express/seed.yml
+++ b/seed/ts-express/seed.yml
@@ -91,6 +91,8 @@ fixtures:
 allowedFailures:
   - bytes-download
   - bytes-upload
+  - imdb:no-custom-config # CHRISM - test
+  - imdb:output-compiled # CHRISM - test
   - file-download
   - file-upload
   - file-upload-openapi

--- a/seed/ts-express/seed.yml
+++ b/seed/ts-express/seed.yml
@@ -91,8 +91,6 @@ fixtures:
 allowedFailures:
   - bytes-download
   - bytes-upload
-  - imdb:no-custom-config # CHRISM - test
-  - imdb:output-compiled # CHRISM - test
   - file-download
   - file-upload
   - file-upload-openapi


### PR DESCRIPTION
## Description
Linear ticket: Closes FER-7504
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
<!-- Provide a clear and concise description of the changes made in this PR -->
Add a GitHub summary for tests that are passing that are still listed in the allowedFailures list

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Similar change as previous PR, but scraping Anar's update for passing tests that are in the allowedFailures list

## Testing
<!-- Describe how you tested these changes -->
- Verified in CI here: https://github.com/fern-api/fern/actions/runs/18942910874
