### PR TITLE
fix(typescript): `hasNextPage()` considers `offset.step` to return `false` on non-full pages

### DIFF
--- a/generators/typescript/sdk/client-class-generator/src/endpoints/default/endpoint-response/GeneratedThrowingEndpointResponse.ts
+++ b/generators/typescript/sdk/client-class-generator/src/endpoints/default/endpoint-response/GeneratedThrowingEndpointResponse.ts
@@ -336,7 +336,7 @@ export class GeneratedThrowingEndpointResponse implements GeneratedEndpointRespo
                               ts.factory.createBinaryExpression(
                                   stepPropertyAccess,
                                   ts.factory.createToken(ts.SyntaxKind.QuestionQuestionToken),
-                                  ts.factory.createNumericLiteral("0")
+                                  ts.factory.createNumericLiteral("1")
                               )
                           )
                       );

--- a/generators/typescript/sdk/client-class-generator/src/endpoints/default/endpoint-response/GeneratedThrowingEndpointResponse.ts
+++ b/generators/typescript/sdk/client-class-generator/src/endpoints/default/endpoint-response/GeneratedThrowingEndpointResponse.ts
@@ -298,7 +298,7 @@ export class GeneratedThrowingEndpointResponse implements GeneratedEndpointRespo
             )
         );
 
-        // hasNextPage checks if the items are not empty
+        // hasNextPage
         const itemsPropertyAccess = context.type.generateGetterForResponseProperty({
             property: offset.results,
             variable: "response",
@@ -309,32 +309,70 @@ export class GeneratedThrowingEndpointResponse implements GeneratedEndpointRespo
             variable: "response",
             noOptionalChaining: true
         });
-        let hasNextPage: ts.Expression = ts.factory.createBinaryExpression(
-            ts.factory.createPropertyAccessExpression(
-                ts.factory.createParenthesizedExpression(
-                    ts.factory.createBinaryExpression(
-                        itemsPropertyAccess,
-                        ts.factory.createToken(ts.SyntaxKind.QuestionQuestionToken),
-                        ts.factory.createArrayLiteralExpression([], false)
-                    )
-                ),
-                ts.factory.createIdentifier("length")
-            ),
-            ts.factory.createToken(ts.SyntaxKind.GreaterThanToken),
-            ts.factory.createNumericLiteral("0")
-        );
-        if (offset.hasNextPage != null) {
-            const hasNextPagePropertyAccess = context.type.generateGetterForResponseProperty({
-                property: offset.hasNextPage,
-                variable: "response",
-                isVariableOptional: true
-            });
-            hasNextPage = ts.factory.createBinaryExpression(
-                hasNextPagePropertyAccess,
-                ts.factory.createToken(ts.SyntaxKind.QuestionQuestionToken),
-                hasNextPage
-            );
-        }
+
+        // Use offset.step if available to ensure that page is full before returning true
+        const baseHasNextPage: ts.Expression =
+            offset.step != null
+                ? // If step is defined, check if items.length >= step (got full page)
+                  (() => {
+                      const stepPropertyAccess = context.type.generateGetterForRequestProperty({
+                          property: offset.step,
+                          variable: "request",
+                          isVariableOptional: true
+                      });
+                      return ts.factory.createBinaryExpression(
+                          ts.factory.createPropertyAccessExpression(
+                              ts.factory.createParenthesizedExpression(
+                                  ts.factory.createBinaryExpression(
+                                      itemsPropertyAccess,
+                                      ts.factory.createToken(ts.SyntaxKind.QuestionQuestionToken),
+                                      ts.factory.createArrayLiteralExpression([], false)
+                                  )
+                              ),
+                              ts.factory.createIdentifier("length")
+                          ),
+                          ts.factory.createToken(ts.SyntaxKind.GreaterThanEqualsToken),
+                          ts.factory.createParenthesizedExpression(
+                              ts.factory.createBinaryExpression(
+                                  stepPropertyAccess,
+                                  ts.factory.createToken(ts.SyntaxKind.QuestionQuestionToken),
+                                  ts.factory.createNumericLiteral("0")
+                              )
+                          )
+                      );
+                  })()
+                : // Fallback: check if items.length > 0 (got something)
+                  ts.factory.createBinaryExpression(
+                      ts.factory.createPropertyAccessExpression(
+                          ts.factory.createParenthesizedExpression(
+                              ts.factory.createBinaryExpression(
+                                  itemsPropertyAccess,
+                                  ts.factory.createToken(ts.SyntaxKind.QuestionQuestionToken),
+                                  ts.factory.createArrayLiteralExpression([], false)
+                              )
+                          ),
+                          ts.factory.createIdentifier("length")
+                      ),
+                      ts.factory.createToken(ts.SyntaxKind.GreaterThanToken),
+                      ts.factory.createNumericLiteral("0")
+                  );
+
+        // If explicit hasNextPage property exists, it takes priority (?? to fallback to base check)
+        const hasNextPage: ts.Expression =
+            offset.hasNextPage != null
+                ? (() => {
+                      const hasNextPagePropertyAccess = context.type.generateGetterForResponseProperty({
+                          property: offset.hasNextPage,
+                          variable: "response",
+                          isVariableOptional: true
+                      });
+                      return ts.factory.createBinaryExpression(
+                          hasNextPagePropertyAccess,
+                          ts.factory.createToken(ts.SyntaxKind.QuestionQuestionToken),
+                          baseHasNextPage
+                      );
+                  })()
+                : baseHasNextPage;
 
         // getItems gets the items
         const getItems = ts.factory.createBinaryExpression(

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.17.1
+  changelogEntry:
+    - summary: |
+        `hasNextPage()` now factors in `offset.step` if provided for offset-based pagination
+        such that `hasNextPage` now returns `false` if the returned page was not as large as requested.
+      type: fix
+  createdAt: "2025-10-31"
+  irVersion: 60
+
 - version: 3.17.0
   changelogEntry:
     - summary: |

--- a/seed/ts-sdk/pagination/src/api/resources/inlineUsers/resources/inlineUsers/client/Client.ts
+++ b/seed/ts-sdk/pagination/src/api/resources/inlineUsers/resources/inlineUsers/client/Client.ts
@@ -709,7 +709,7 @@ export class InlineUsers {
         >({
             response: dataWithRawResponse.data,
             rawResponse: dataWithRawResponse.rawResponse,
-            hasNextPage: (response) => (response?.data.users ?? []).length >= (request?.limit ?? 0),
+            hasNextPage: (response) => (response?.data.users ?? []).length >= (request?.limit ?? 1),
             getItems: (response) => response?.data.users ?? [],
             loadPage: (response) => {
                 _offset += response?.data.users != null ? response.data.users.length : 1;
@@ -810,7 +810,7 @@ export class InlineUsers {
             response: dataWithRawResponse.data,
             rawResponse: dataWithRawResponse.rawResponse,
             hasNextPage: (response) =>
-                response?.hasNextPage ?? (response?.data.users ?? []).length >= (request?.limit ?? 0),
+                response?.hasNextPage ?? (response?.data.users ?? []).length >= (request?.limit ?? 1),
             getItems: (response) => response?.data.users ?? [],
             loadPage: (response) => {
                 _offset += response?.data.users != null ? response.data.users.length : 1;

--- a/seed/ts-sdk/pagination/src/api/resources/inlineUsers/resources/inlineUsers/client/Client.ts
+++ b/seed/ts-sdk/pagination/src/api/resources/inlineUsers/resources/inlineUsers/client/Client.ts
@@ -709,7 +709,7 @@ export class InlineUsers {
         >({
             response: dataWithRawResponse.data,
             rawResponse: dataWithRawResponse.rawResponse,
-            hasNextPage: (response) => (response?.data.users ?? []).length > 0,
+            hasNextPage: (response) => (response?.data.users ?? []).length >= (request?.limit ?? 0),
             getItems: (response) => response?.data.users ?? [],
             loadPage: (response) => {
                 _offset += response?.data.users != null ? response.data.users.length : 1;
@@ -809,7 +809,8 @@ export class InlineUsers {
         >({
             response: dataWithRawResponse.data,
             rawResponse: dataWithRawResponse.rawResponse,
-            hasNextPage: (response) => response?.hasNextPage ?? (response?.data.users ?? []).length > 0,
+            hasNextPage: (response) =>
+                response?.hasNextPage ?? (response?.data.users ?? []).length >= (request?.limit ?? 0),
             getItems: (response) => response?.data.users ?? [],
             loadPage: (response) => {
                 _offset += response?.data.users != null ? response.data.users.length : 1;

--- a/seed/ts-sdk/pagination/src/api/resources/users/client/Client.ts
+++ b/seed/ts-sdk/pagination/src/api/resources/users/client/Client.ts
@@ -647,7 +647,7 @@ export class Users {
         return new core.Page<SeedPagination.User, SeedPagination.ListUsersPaginationResponse>({
             response: dataWithRawResponse.data,
             rawResponse: dataWithRawResponse.rawResponse,
-            hasNextPage: (response) => (response?.data ?? []).length > 0,
+            hasNextPage: (response) => (response?.data ?? []).length >= (request?.limit ?? 0),
             getItems: (response) => response?.data ?? [],
             loadPage: (response) => {
                 _offset += response?.data != null ? response.data.length : 1;
@@ -739,7 +739,7 @@ export class Users {
         return new core.Page<SeedPagination.User, SeedPagination.ListUsersPaginationResponse>({
             response: dataWithRawResponse.data,
             rawResponse: dataWithRawResponse.rawResponse,
-            hasNextPage: (response) => response?.hasNextPage ?? (response?.data ?? []).length > 0,
+            hasNextPage: (response) => response?.hasNextPage ?? (response?.data ?? []).length >= (request?.limit ?? 0),
             getItems: (response) => response?.data ?? [],
             loadPage: (response) => {
                 _offset += response?.data != null ? response.data.length : 1;

--- a/seed/ts-sdk/pagination/src/api/resources/users/client/Client.ts
+++ b/seed/ts-sdk/pagination/src/api/resources/users/client/Client.ts
@@ -647,7 +647,7 @@ export class Users {
         return new core.Page<SeedPagination.User, SeedPagination.ListUsersPaginationResponse>({
             response: dataWithRawResponse.data,
             rawResponse: dataWithRawResponse.rawResponse,
-            hasNextPage: (response) => (response?.data ?? []).length >= (request?.limit ?? 0),
+            hasNextPage: (response) => (response?.data ?? []).length >= (request?.limit ?? 1),
             getItems: (response) => response?.data ?? [],
             loadPage: (response) => {
                 _offset += response?.data != null ? response.data.length : 1;
@@ -739,7 +739,7 @@ export class Users {
         return new core.Page<SeedPagination.User, SeedPagination.ListUsersPaginationResponse>({
             response: dataWithRawResponse.data,
             rawResponse: dataWithRawResponse.rawResponse,
-            hasNextPage: (response) => response?.hasNextPage ?? (response?.data ?? []).length >= (request?.limit ?? 0),
+            hasNextPage: (response) => response?.hasNextPage ?? (response?.data ?? []).length >= (request?.limit ?? 1),
             getItems: (response) => response?.data ?? [],
             loadPage: (response) => {
                 _offset += response?.data != null ? response.data.length : 1;


### PR DESCRIPTION
## Description
Linear ticket: Closes FER-7004.
In offset-based pagination, our current method for calculating whether there is a next page available:
```ts
hasNextPage: (response) => (response?.data ?? []).length > 0
``` 
would occasionally lie when the returned `data` was nonempty, but less than what was asked for; in that situation, we're at the last page, so we should return false. Users can now use the `step` property to specify what attribute in their request signifies requested page sizes, which will change the calculation to
```ts
hasNextPage: (response) => (response?.data ?? []).length >= (request?.step ?? 1)
```
(Or users can still use the boolean `hasNextPage` property, which works as a first-priority override:)
```ts
hasNextPage: (response) => response?.hasNextPage ?? (response?.data ?? []).length >= (request?.step ?? 1)
```

## Changes Made
Changes to `GeneratedThrowingEndpointResponse.ts` for offset pagination.

## Testing
Running seed now!
- [X] Unit tests added/updated
- [X] Manual testing completed
