### PR TITLE
fix(cli): Fix discriminated union validation in `fern check` to include base properties and extends

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -2,6 +2,22 @@
 
 - changelogEntry:
     - summary: |
+        Fix discriminated union validation in `fern check` to include base properties and extends.
+      type: fix
+  irVersion: 61
+  createdAt: "2025-10-31"
+  version: 0.102.1
+
+- changelogEntry:
+    - summary: |
+        Add discriminated union base property and extend property examples to IR.
+      type: feat
+  irVersion: 61
+  createdAt: "2025-10-31"
+  version: 0.102.0
+
+- changelogEntry:
+    - summary: |
         Fix `coerce-enums-to-literals` setting to coerce single value enums to literals.
       type: fix
   irVersion: 61
@@ -15,14 +31,6 @@
   irVersion: 61
   createdAt: "2025-10-31"
   version: 0.101.3
-
-- changelogEntry:
-    - summary: |
-        Add discriminated union base property and extend property examples to IR.
-      type: feat
-  irVersion: 61
-  createdAt: "2025-10-31"
-  version: 0.102.0
 
 - changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description
## Changes Made
Fix discriminated union validation in `fern check` to include base properties and extends

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated
- [x] Manual testing completed
