### PR TITLE
feat: Display all CLI errors at bottom with proper exit codes

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/parse.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/parse.ts
@@ -124,12 +124,13 @@ export function parse({
                     assertNever(document);
             }
         } catch (error) {
-            context.logger.debug(
-                `Skipping parsing document ${document.type === "openapi" ? document.value.info?.title : document.source?.file}`
+            context.logger.error(
+                `Failed to parse document ${document.type === "openapi" ? document.value.info?.title : document.source?.file}`
             );
             if (error instanceof Error) {
-                context.logger.debug(error.message, error.stack ? "\n" + error.stack : "");
+                context.logger.error(error.message, error.stack ? "\n" + error.stack : "");
             }
+            context.failWithoutThrowing(`Failed to parse document`);
         }
     }
     return ir;


### PR DESCRIPTION
### Description

Closes #10107 

- Previously, Fern CLI errors were logged immediately but buried in verbose output, making it hard to see failures. Parsing errors were logged at debug level and didn't cause non-zero exits.

## Changes Made
- Added error collection mechanism in CliContext to gather all ERROR level messages
- Modified CLI exit flow to display collected errors summary before terminating  
- Updated document parsing to log failures as errors and properly fail the CLI
- Simplified error logging utilities for cleaner implementation