### PR TITLE
fix(typescript): `mergeHeaders` functions are case-insensitive

### DIFF
--- a/generators/typescript/asIs/core/headers.ts
+++ b/generators/typescript/asIs/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const lowercaseKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[lowercaseKey] = value;
+        } else if (lowercaseKey in result) {
+            delete result[lowercaseKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const lowercaseKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[lowercaseKey] = value;
         }
     }
 

--- a/generators/typescript/asIs/core/headers.ts
+++ b/generators/typescript/asIs/core/headers.ts
@@ -6,11 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
-        const lowercaseKey = key.toLowerCase();
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[lowercaseKey] = value;
-        } else if (lowercaseKey in result) {
-            delete result[lowercaseKey];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -25,9 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
-        const lowercaseKey = key.toLowerCase();
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[lowercaseKey] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.19.1
+  changelogEntry:
+    - summary: |
+        `mergeHeaders()` and `mergeOnlyDefinedHeaders()` are now case-insensitive.
+      type: fix
+  createdAt: "2025-11-03"
+  irVersion: 60
+
 - version: 3.19.0
   changelogEntry:
     - summary: |

--- a/seed/ts-sdk/accept-header/src/core/headers.ts
+++ b/seed/ts-sdk/accept-header/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/alias-extends/src/core/headers.ts
+++ b/seed/ts-sdk/alias-extends/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/alias/src/core/headers.ts
+++ b/seed/ts-sdk/alias/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/any-auth/generate-endpoint-metadata/src/core/headers.ts
+++ b/seed/ts-sdk/any-auth/generate-endpoint-metadata/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/any-auth/no-custom-config/src/core/headers.ts
+++ b/seed/ts-sdk/any-auth/no-custom-config/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/api-wide-base-path/src/core/headers.ts
+++ b/seed/ts-sdk/api-wide-base-path/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/audiences/no-custom-config/src/core/headers.ts
+++ b/seed/ts-sdk/audiences/no-custom-config/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/audiences/with-partner-audience/src/core/headers.ts
+++ b/seed/ts-sdk/audiences/with-partner-audience/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/auth-environment-variables/src/core/headers.ts
+++ b/seed/ts-sdk/auth-environment-variables/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/basic-auth-environment-variables/src/core/headers.ts
+++ b/seed/ts-sdk/basic-auth-environment-variables/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/basic-auth/src/core/headers.ts
+++ b/seed/ts-sdk/basic-auth/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/bearer-token-environment-variable/src/core/headers.ts
+++ b/seed/ts-sdk/bearer-token-environment-variable/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/bytes-upload/src/core/headers.ts
+++ b/seed/ts-sdk/bytes-upload/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/circular-references-advanced/src/core/headers.ts
+++ b/seed/ts-sdk/circular-references-advanced/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/circular-references/src/core/headers.ts
+++ b/seed/ts-sdk/circular-references/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/client-side-params/src/core/headers.ts
+++ b/seed/ts-sdk/client-side-params/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/content-type/src/core/headers.ts
+++ b/seed/ts-sdk/content-type/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/cross-package-type-names/src/core/headers.ts
+++ b/seed/ts-sdk/cross-package-type-names/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/custom-auth/src/core/headers.ts
+++ b/seed/ts-sdk/custom-auth/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/empty-clients/src/core/headers.ts
+++ b/seed/ts-sdk/empty-clients/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/enum/src/core/headers.ts
+++ b/seed/ts-sdk/enum/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/error-property/no-custom-config/src/core/headers.ts
+++ b/seed/ts-sdk/error-property/no-custom-config/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/error-property/union-utils/src/core/headers.ts
+++ b/seed/ts-sdk/error-property/union-utils/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/errors/src/core/headers.ts
+++ b/seed/ts-sdk/errors/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/examples/examples-with-api-reference/src/core/headers.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/examples/retain-original-casing/src/core/headers.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/core/headers.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/core/headers.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/exhaustive/bigint/src/core/headers.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/core/headers.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/core/headers.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/core/headers.js
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/core/headers.js
@@ -7,11 +7,12 @@ function mergeHeaders(...headersArray) {
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
-        else if (key in result) {
-            delete result[key];
+        else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
     return result;
@@ -21,8 +22,9 @@ function mergeOnlyDefinedHeaders(...headersArray) {
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
     return result;

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/core/headers.mjs
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/core/headers.mjs
@@ -3,11 +3,12 @@ export function mergeHeaders(...headersArray) {
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
-        else if (key in result) {
-            delete result[key];
+        else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
     return result;
@@ -17,8 +18,9 @@ export function mergeOnlyDefinedHeaders(...headersArray) {
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
     return result;

--- a/seed/ts-sdk/exhaustive/local-files/core/headers.ts
+++ b/seed/ts-sdk/exhaustive/local-files/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/exhaustive/never-throw-errors/src/core/headers.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/core/headers.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/exhaustive/node-fetch/src/core/headers.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/core/headers.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/core/headers.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/exhaustive/serde-layer/src/core/headers.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/exhaustive/use-jest/src/core/headers.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/core/headers.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/exhaustive/with-audiences/src/core/headers.ts
+++ b/seed/ts-sdk/exhaustive/with-audiences/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/extends/src/core/headers.ts
+++ b/seed/ts-sdk/extends/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/extra-properties/src/core/headers.ts
+++ b/seed/ts-sdk/extra-properties/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/file-download/file-download-response-headers/src/core/headers.ts
+++ b/seed/ts-sdk/file-download/file-download-response-headers/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/file-download/no-custom-config/src/core/headers.ts
+++ b/seed/ts-sdk/file-download/no-custom-config/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/file-download/stream-wrapper/src/core/headers.ts
+++ b/seed/ts-sdk/file-download/stream-wrapper/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/file-upload-openapi/src/core/headers.ts
+++ b/seed/ts-sdk/file-upload-openapi/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/file-upload/form-data-node16/src/core/headers.ts
+++ b/seed/ts-sdk/file-upload/form-data-node16/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/file-upload/inline/src/core/headers.ts
+++ b/seed/ts-sdk/file-upload/inline/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/file-upload/no-custom-config/src/core/headers.ts
+++ b/seed/ts-sdk/file-upload/no-custom-config/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/file-upload/serde/src/core/headers.ts
+++ b/seed/ts-sdk/file-upload/serde/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/file-upload/use-jest/src/core/headers.ts
+++ b/seed/ts-sdk/file-upload/use-jest/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/file-upload/wrapper/src/core/headers.ts
+++ b/seed/ts-sdk/file-upload/wrapper/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/folders/src/core/headers.ts
+++ b/seed/ts-sdk/folders/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/http-head/src/core/headers.ts
+++ b/seed/ts-sdk/http-head/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/idempotency-headers/src/core/headers.ts
+++ b/seed/ts-sdk/idempotency-headers/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/imdb/branded-string-aliases/src/core/headers.ts
+++ b/seed/ts-sdk/imdb/branded-string-aliases/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/imdb/no-custom-config/src/core/headers.ts
+++ b/seed/ts-sdk/imdb/no-custom-config/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/imdb/omit-undefined/src/core/headers.ts
+++ b/seed/ts-sdk/imdb/omit-undefined/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/inferred-auth-explicit/src/core/headers.ts
+++ b/seed/ts-sdk/inferred-auth-explicit/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/inferred-auth-implicit-no-expiry/src/core/headers.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-no-expiry/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/inferred-auth-implicit/src/core/headers.ts
+++ b/seed/ts-sdk/inferred-auth-implicit/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/license/src/core/headers.ts
+++ b/seed/ts-sdk/license/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/literal/src/core/headers.ts
+++ b/seed/ts-sdk/literal/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/literals-unions/src/core/headers.ts
+++ b/seed/ts-sdk/literals-unions/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/mixed-case/no-custom-config/src/core/headers.ts
+++ b/seed/ts-sdk/mixed-case/no-custom-config/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/mixed-case/retain-original-casing/src/core/headers.ts
+++ b/seed/ts-sdk/mixed-case/retain-original-casing/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/mixed-file-directory/src/core/headers.ts
+++ b/seed/ts-sdk/mixed-file-directory/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/multi-line-docs/src/core/headers.ts
+++ b/seed/ts-sdk/multi-line-docs/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/multi-url-environment-no-default/src/core/headers.ts
+++ b/seed/ts-sdk/multi-url-environment-no-default/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/multi-url-environment/src/core/headers.ts
+++ b/seed/ts-sdk/multi-url-environment/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/multiple-request-bodies/src/core/headers.ts
+++ b/seed/ts-sdk/multiple-request-bodies/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/no-environment/src/core/headers.ts
+++ b/seed/ts-sdk/no-environment/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/nullable-optional/src/core/headers.ts
+++ b/seed/ts-sdk/nullable-optional/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/nullable/src/core/headers.ts
+++ b/seed/ts-sdk/nullable/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/oauth-client-credentials-custom/src/core/headers.ts
+++ b/seed/ts-sdk/oauth-client-credentials-custom/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/oauth-client-credentials-default/src/core/headers.ts
+++ b/seed/ts-sdk/oauth-client-credentials-default/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/src/core/headers.ts
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/core/headers.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/core/headers.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/oauth-client-credentials-with-variables/src/core/headers.ts
+++ b/seed/ts-sdk/oauth-client-credentials-with-variables/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/oauth-client-credentials/no-custom-config/src/core/headers.ts
+++ b/seed/ts-sdk/oauth-client-credentials/no-custom-config/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/oauth-client-credentials/serde/src/core/headers.ts
+++ b/seed/ts-sdk/oauth-client-credentials/serde/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/object/src/core/headers.ts
+++ b/seed/ts-sdk/object/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/objects-with-imports/src/core/headers.ts
+++ b/seed/ts-sdk/objects-with-imports/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/optional/src/core/headers.ts
+++ b/seed/ts-sdk/optional/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/package-yml/src/core/headers.ts
+++ b/seed/ts-sdk/package-yml/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/pagination-custom/src/core/headers.ts
+++ b/seed/ts-sdk/pagination-custom/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/pagination/src/core/headers.ts
+++ b/seed/ts-sdk/pagination/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/path-parameters/inline-path-parameters-retain-original-casing/src/core/headers.ts
+++ b/seed/ts-sdk/path-parameters/inline-path-parameters-retain-original-casing/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/path-parameters/inline-path-parameters-serde/src/core/headers.ts
+++ b/seed/ts-sdk/path-parameters/inline-path-parameters-serde/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/path-parameters/inline-path-parameters/src/core/headers.ts
+++ b/seed/ts-sdk/path-parameters/inline-path-parameters/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/path-parameters/no-custom-config/src/core/headers.ts
+++ b/seed/ts-sdk/path-parameters/no-custom-config/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/path-parameters/retain-original-casing/src/core/headers.ts
+++ b/seed/ts-sdk/path-parameters/retain-original-casing/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/plain-text/src/core/headers.ts
+++ b/seed/ts-sdk/plain-text/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/property-access/generate-read-write-only-types/src/core/headers.ts
+++ b/seed/ts-sdk/property-access/generate-read-write-only-types/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/property-access/no-custom-config/src/core/headers.ts
+++ b/seed/ts-sdk/property-access/no-custom-config/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/public-object/src/core/headers.ts
+++ b/seed/ts-sdk/public-object/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/query-parameters-openapi-as-objects/src/core/headers.ts
+++ b/seed/ts-sdk/query-parameters-openapi-as-objects/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/query-parameters-openapi/src/core/headers.ts
+++ b/seed/ts-sdk/query-parameters-openapi/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/query-parameters/no-custom-config/src/core/headers.ts
+++ b/seed/ts-sdk/query-parameters/no-custom-config/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/query-parameters/serde/src/core/headers.ts
+++ b/seed/ts-sdk/query-parameters/serde/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/request-parameters/flatten-request-parameters/src/core/headers.ts
+++ b/seed/ts-sdk/request-parameters/flatten-request-parameters/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/request-parameters/no-custom-config/src/core/headers.ts
+++ b/seed/ts-sdk/request-parameters/no-custom-config/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/src/core/headers.ts
+++ b/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/request-parameters/use-default-request-parameter-values/src/core/headers.ts
+++ b/seed/ts-sdk/request-parameters/use-default-request-parameter-values/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/required-nullable/src/core/headers.ts
+++ b/seed/ts-sdk/required-nullable/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/reserved-keywords/src/core/headers.ts
+++ b/seed/ts-sdk/reserved-keywords/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/response-property/src/core/headers.ts
+++ b/seed/ts-sdk/response-property/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/server-sent-event-examples/src/core/headers.ts
+++ b/seed/ts-sdk/server-sent-event-examples/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/server-sent-events/src/core/headers.ts
+++ b/seed/ts-sdk/server-sent-events/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/simple-api/allow-custom-fetcher/src/core/headers.ts
+++ b/seed/ts-sdk/simple-api/allow-custom-fetcher/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/simple-api/allow-extra-fields/src/core/headers.ts
+++ b/seed/ts-sdk/simple-api/allow-extra-fields/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/simple-api/bundle/src/core/headers.ts
+++ b/seed/ts-sdk/simple-api/bundle/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/simple-api/custom-package-json/src/core/headers.ts
+++ b/seed/ts-sdk/simple-api/custom-package-json/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/simple-api/jsr/src/core/headers.ts
+++ b/seed/ts-sdk/simple-api/jsr/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/simple-api/legacy-exports/src/core/headers.ts
+++ b/seed/ts-sdk/simple-api/legacy-exports/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/simple-api/no-custom-config/src/core/headers.ts
+++ b/seed/ts-sdk/simple-api/no-custom-config/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/simple-api/no-linter/src/core/headers.ts
+++ b/seed/ts-sdk/simple-api/no-linter/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/simple-api/no-scripts/src/core/headers.ts
+++ b/seed/ts-sdk/simple-api/no-scripts/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/simple-api/oidc-token/src/core/headers.ts
+++ b/seed/ts-sdk/simple-api/oidc-token/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/simple-api/omit-fern-headers/src/core/headers.ts
+++ b/seed/ts-sdk/simple-api/omit-fern-headers/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/simple-api/use-prettier-no-linter/src/core/headers.ts
+++ b/seed/ts-sdk/simple-api/use-prettier-no-linter/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/simple-api/use-prettier/src/core/headers.ts
+++ b/seed/ts-sdk/simple-api/use-prettier/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/simple-api/use-yarn/src/core/headers.ts
+++ b/seed/ts-sdk/simple-api/use-yarn/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/simple-fhir/src/core/headers.ts
+++ b/seed/ts-sdk/simple-fhir/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/single-url-environment-default/src/core/headers.ts
+++ b/seed/ts-sdk/single-url-environment-default/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/single-url-environment-no-default/src/core/headers.ts
+++ b/seed/ts-sdk/single-url-environment-no-default/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/streaming-parameter/src/core/headers.ts
+++ b/seed/ts-sdk/streaming-parameter/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/streaming/no-custom-config/src/core/headers.ts
+++ b/seed/ts-sdk/streaming/no-custom-config/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/streaming/serde-layer/src/core/headers.ts
+++ b/seed/ts-sdk/streaming/serde-layer/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/streaming/wrapper/src/core/headers.ts
+++ b/seed/ts-sdk/streaming/wrapper/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/trace/exhaustive/src/core/headers.ts
+++ b/seed/ts-sdk/trace/exhaustive/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/trace/no-custom-config/src/core/headers.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/trace/serde-no-throwing/src/core/headers.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/trace/serde/src/core/headers.ts
+++ b/seed/ts-sdk/trace/serde/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/ts-express-casing/src/core/headers.ts
+++ b/seed/ts-sdk/ts-express-casing/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/ts-inline-types/inline/src/core/headers.ts
+++ b/seed/ts-sdk/ts-inline-types/inline/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/ts-inline-types/no-inline/src/core/headers.ts
+++ b/seed/ts-sdk/ts-inline-types/no-inline/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/undiscriminated-union-with-response-property/src/core/headers.ts
+++ b/seed/ts-sdk/undiscriminated-union-with-response-property/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/undiscriminated-unions/no-custom-config/src/core/headers.ts
+++ b/seed/ts-sdk/undiscriminated-unions/no-custom-config/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/undiscriminated-unions/skip-response-validation/src/core/headers.ts
+++ b/seed/ts-sdk/undiscriminated-unions/skip-response-validation/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/unions/src/core/headers.ts
+++ b/seed/ts-sdk/unions/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/unknown/no-custom-config/src/core/headers.ts
+++ b/seed/ts-sdk/unknown/no-custom-config/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/unknown/unknown-as-any/src/core/headers.ts
+++ b/seed/ts-sdk/unknown/unknown-as-any/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/url-form-encoded/src/core/headers.ts
+++ b/seed/ts-sdk/url-form-encoded/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/validation/src/core/headers.ts
+++ b/seed/ts-sdk/validation/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/variables/src/core/headers.ts
+++ b/seed/ts-sdk/variables/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/version-no-default/src/core/headers.ts
+++ b/seed/ts-sdk/version-no-default/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/version/src/core/headers.ts
+++ b/seed/ts-sdk/version/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/websocket-bearer-auth/websockets/src/core/headers.ts
+++ b/seed/ts-sdk/websocket-bearer-auth/websockets/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/websocket-inferred-auth/websockets/src/core/headers.ts
+++ b/seed/ts-sdk/websocket-inferred-auth/websockets/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/websocket/no-serde/src/core/headers.ts
+++ b/seed/ts-sdk/websocket/no-serde/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/websocket/no-websocket-clients/src/core/headers.ts
+++ b/seed/ts-sdk/websocket/no-websocket-clients/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 

--- a/seed/ts-sdk/websocket/serde/src/core/headers.ts
+++ b/seed/ts-sdk/websocket/serde/src/core/headers.ts
@@ -6,10 +6,11 @@ export function mergeHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
-        } else if (key in result) {
-            delete result[key];
+            result[insensitiveKey] = value;
+        } else if (insensitiveKey in result) {
+            delete result[insensitiveKey];
         }
     }
 
@@ -24,8 +25,9 @@ export function mergeOnlyDefinedHeaders<THeaderValue>(
     for (const [key, value] of headersArray
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
+        const insensitiveKey = key.toLowerCase();
         if (value != null) {
-            result[key] = value;
+            result[insensitiveKey] = value;
         }
     }
 


### PR DESCRIPTION
## Description
Linear ticket: Closes FER-7548.
`mergeHeaders` and `mergeOnlyDefinedHeaders` should be case-insensitive by RFC 2616, but weren't.

## Changes Made
Currently doing the simplest possible version of this change by just running .toLowerCase() in each of these functions.

## Testing
Running seed now!
- [X] Unit tests added/updated
- [X] Manual testing completed
