### PR TITLE
fix(docs): docs dev on windows

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Fix fern docs dev on windows
+      type: fix
+  irVersion: 61
+  createdAt: "2025-11-03"
+  version: 0.107.2
+
+- changelogEntry:
+    - summary: |
         Allow unknown types in query parameters
       type: fix
   irVersion: 61

--- a/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
+++ b/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
@@ -78,12 +78,6 @@ export declare namespace DownloadLocalBundle {
     }
 }
 
-// Config file contents as constants
-const PNPM_WORKSPACE_YAML_CONTENTS = `packages:
-  - "packages/**"
-  - "!**/dist"
-`;
-
 const PNPMFILE_CJS_CONTENTS = `module.exports = {
     hooks: {
         readPackage(pkg) {
@@ -295,11 +289,13 @@ export async function downloadBundle({
                     doesPathExist(absPathToInstrumentationJs)
                 ]);
 
-                // Write pnpm-workspace.yaml if it does not exist
+                // Warn if pnpm-workspace.yaml does not exist
                 if (!pnpmWorkspaceExists) {
-                    logger.debug(`Writing pnpm-workspace.yaml at ${pnpmWorkspacePath}`);
-                    await writeFile(pnpmWorkspacePath, PNPM_WORKSPACE_YAML_CONTENTS);
+                    logger.warn(
+                        `Expected pnpm-workspace.yaml at ${pnpmWorkspacePath} but it does not exist. If you are experiencing issues, please contact support@buildwithfern.com.`
+                    );
                 }
+
                 // Write pnpmfile.cjs if it does not exist
                 if (!pnpmfileExists) {
                     logger.debug(`Writing pnpmfile.cjs at ${pnpmfilePath}`);

--- a/packages/cli/docs-preview/src/runAppPreviewServer.ts
+++ b/packages/cli/docs-preview/src/runAppPreviewServer.ts
@@ -305,7 +305,7 @@ export async function runAppPreviewServer({
         NEXT_DISABLE_CACHE: "1",
         NODE_ENV: "production",
         NODE_PATH: bundleRoot,
-        NODE_OPTIONS: "--max-old-space-size=2048 --enable-source-maps"
+        NODE_OPTIONS: "--max-old-space-size=8096 --enable-source-maps"
     };
 
     const serverProcess = runExeca(context.logger, "node", [serverPath], {


### PR DESCRIPTION
## Description

Fixes fern docs dev on windows

## Changes Made

no longer write to pnpm-workspace.yaml and instead expect its presence from the local dev bundling process

## Testing

tested on a windows computer
