### PR TITLE
fix(internal): fix operation message referencing in v3 asyncapi parser

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/asyncapi/v3/AsyncAPIV3ParserContext.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/asyncapi/v3/AsyncAPIV3ParserContext.ts
@@ -30,7 +30,11 @@ export class AsyncAPIV3ParserContext extends AbstractAsyncAPIParserContext<Async
         return resolvedParameter as AsyncAPIV3.ChannelParameter;
     }
 
-    public resolveMessageReference(message: OpenAPIV3.ReferenceObject): AsyncAPIV3.ChannelMessage {
+    // Resolve a message reference. Use 'shallow' to prevent resolving nested references.
+    public resolveMessageReference(
+        message: OpenAPIV3.ReferenceObject,
+        shallow: boolean = false
+    ): AsyncAPIV3.ChannelMessage {
         const CHANNELS_PATH_PART = "#/channels/";
         const MESSAGE_REFERENCE_PREFIX = "#/components/messages/";
 
@@ -48,7 +52,7 @@ export class AsyncAPIV3ParserContext extends AbstractAsyncAPIParserContext<Async
             if (resolvedInChannel == null) {
                 throw new Error(`${message.$ref} is undefined`);
             }
-            if ("$ref" in resolvedInChannel) {
+            if ("$ref" in resolvedInChannel && !shallow) {
                 return this.resolveMessageReference(resolvedInChannel as OpenAPIV3.ReferenceObject);
             } else {
                 return {

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/deepgram-mini.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/deepgram-mini.json
@@ -1,0 +1,90 @@
+{
+  "absoluteFilePath": "/DUMMY_PATH",
+  "importedDefinitions": {},
+  "namedDefinitionFiles": {
+    "__package__.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {},
+      "rawContents": "{}
+",
+    },
+    "speakV1.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {
+        "channel": {
+          "auth": false,
+          "examples": [
+            {
+              "messages": [
+                {
+                  "body": {
+                    "type": "Text",
+                  },
+                  "type": "SpeakV1Text",
+                },
+              ],
+            },
+          ],
+          "messages": {
+            "SpeakV1Text": {
+              "body": "SpeakV1Text",
+              "origin": "client",
+            },
+          },
+          "path": "/SpeakV1",
+          "url": undefined,
+        },
+        "types": {
+          "SpeakV1Text": {
+            "docs": undefined,
+            "inline": undefined,
+            "properties": {
+              "type": {
+                "docs": "Message type identifier",
+                "type": "string",
+              },
+            },
+            "source": {
+              "openapi": "../asyncapi.yml",
+            },
+          },
+        },
+      },
+      "rawContents": "channel:
+  path: /SpeakV1
+  auth: false
+  messages:
+    SpeakV1Text:
+      origin: client
+      body: SpeakV1Text
+  examples:
+    - messages:
+        - type: SpeakV1Text
+          body:
+            type: Text
+types:
+  SpeakV1Text:
+    properties:
+      type:
+        type: string
+        docs: Message type identifier
+    source:
+      openapi: ../asyncapi.yml
+",
+    },
+  },
+  "packageMarkers": {},
+  "rootApiFile": {
+    "contents": {
+      "error-discrimination": {
+        "strategy": "status-code",
+      },
+      "name": "api",
+    },
+    "defaultUrl": undefined,
+    "rawContents": "name: api
+error-discrimination:
+  strategy: status-code
+",
+  },
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/deepgram-mini.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/deepgram-mini.json
@@ -1,0 +1,96 @@
+{
+  "type": "openapi",
+  "value": {
+    "asyncapi": "3.0.0",
+    "info": {
+      "title": "Deepgram-mini API Specification",
+      "version": "1.0.0"
+    },
+    "components": {
+      "messages": {
+        "SpeakV1TextMessage": {
+          "name": "SpeakV1TextMessage",
+          "description": "Request to convert text to speech",
+          "payload": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "description": "Message type identifier",
+                "example": "Speak"
+              }
+            },
+            "required": [
+              "type"
+            ]
+          }
+        }
+      }
+    },
+    "channels": {
+      "SpeakV1": {
+        "messages": {
+          "SpeakV1Text": {
+            "$ref": "#/components/messages/SpeakV1TextMessage"
+          }
+        },
+        "x-fern-examples": [
+          {
+            "name": "WebSocket Example Messages",
+            "messages": [
+              {
+                "type": "SpeakV1Text",
+                "channelId": "SpeakV1",
+                "messageId": "SpeakV1Text",
+                "value": {
+                  "type": "Text"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "operations": {
+      "SpeakV1Text": {
+        "description": "Text to convert to audio",
+        "action": "send",
+        "channel": {
+          "$ref": "#/channels/SpeakV1"
+        },
+        "messages": [
+          {
+            "$ref": "#/channels/SpeakV1/messages/SpeakV1Text"
+          }
+        ]
+      }
+    }
+  },
+  "settings": {
+    "disableExamples": false,
+    "discriminatedUnionV2": false,
+    "useTitlesAsName": true,
+    "optionalAdditionalProperties": true,
+    "coerceEnumsToLiterals": true,
+    "respectReadonlySchemas": false,
+    "respectNullableSchemas": false,
+    "onlyIncludeReferencedSchemas": false,
+    "inlinePathParameters": false,
+    "preserveSchemaIds": false,
+    "shouldUseUndiscriminatedUnionsWithLiterals": false,
+    "shouldUseIdiomaticRequestNames": false,
+    "objectQueryParameters": false,
+    "asyncApiNaming": "v1",
+    "useBytesForBinaryResponse": false,
+    "respectForwardCompatibleEnums": false,
+    "additionalPropertiesDefaultsTo": false,
+    "typeDatesAsStrings": true,
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false,
+    "resolveAliases": false,
+    "groupMultiApiEnvironments": false,
+    "groupEnvironmentsByHost": false,
+    "wrapReferencesToNullableInOptional": true,
+    "coerceOptionalSchemasToNullable": true
+  }
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/deepgram-mini.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/deepgram-mini.json
@@ -1,0 +1,98 @@
+{
+  "servers": [],
+  "websocketServers": [],
+  "tags": {
+    "tagsById": {}
+  },
+  "hasEndpointsMarkedInternal": false,
+  "endpoints": [],
+  "webhooks": [],
+  "channels": {
+    "SpeakV1": {
+      "audiences": [],
+      "handshake": {
+        "headers": [],
+        "queryParameters": [],
+        "pathParameters": []
+      },
+      "groupName": [
+        "SpeakV1"
+      ],
+      "messages": [
+        {
+          "origin": "client",
+          "name": "SpeakV1Text",
+          "body": {
+            "allOf": [],
+            "properties": [
+              {
+                "conflict": {},
+                "generatedName": "speakV1TextType",
+                "key": "type",
+                "schema": {
+                  "description": "Message type identifier",
+                  "schema": {
+                    "example": "Speak",
+                    "type": "string"
+                  },
+                  "generatedName": "SpeakV1TextType",
+                  "groupName": [],
+                  "type": "primitive"
+                },
+                "audiences": []
+              }
+            ],
+            "allOfPropertyConflicts": [],
+            "generatedName": "SpeakV1Text",
+            "groupName": [],
+            "additionalProperties": false,
+            "source": {
+              "file": "../asyncapi.yml",
+              "type": "openapi"
+            },
+            "type": "object"
+          }
+        }
+      ],
+      "servers": [],
+      "path": "/SpeakV1",
+      "examples": [
+        {
+          "queryParameters": [],
+          "headers": [],
+          "messages": [
+            {
+              "messageType": "SpeakV1Text",
+              "payload": {
+                "properties": {
+                  "type": {
+                    "value": {
+                      "value": "Text",
+                      "type": "string"
+                    },
+                    "type": "primitive"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          ]
+        }
+      ],
+      "source": {
+        "file": "../asyncapi.yml",
+        "type": "openapi"
+      }
+    }
+  },
+  "groupedSchemas": {
+    "rootSchemas": {},
+    "namespacedSchemas": {}
+  },
+  "variables": {},
+  "nonRequestReferencedSchemas": {},
+  "securitySchemes": {},
+  "globalHeaders": [],
+  "idempotencyHeaders": [],
+  "groups": {}
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/deepgram-mini.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/deepgram-mini.json
@@ -1,0 +1,90 @@
+{
+  "absoluteFilePath": "/DUMMY_PATH",
+  "importedDefinitions": {},
+  "namedDefinitionFiles": {
+    "__package__.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {},
+      "rawContents": "{}
+",
+    },
+    "speakV1.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {
+        "channel": {
+          "auth": false,
+          "examples": [
+            {
+              "messages": [
+                {
+                  "body": {
+                    "type": "Text",
+                  },
+                  "type": "SpeakV1Text",
+                },
+              ],
+            },
+          ],
+          "messages": {
+            "SpeakV1Text": {
+              "body": "SpeakV1Text",
+              "origin": "client",
+            },
+          },
+          "path": "/SpeakV1",
+          "url": undefined,
+        },
+        "types": {
+          "SpeakV1Text": {
+            "docs": undefined,
+            "inline": undefined,
+            "properties": {
+              "type": {
+                "docs": "Message type identifier",
+                "type": "string",
+              },
+            },
+            "source": {
+              "openapi": "../asyncapi.yml",
+            },
+          },
+        },
+      },
+      "rawContents": "channel:
+  path: /SpeakV1
+  auth: false
+  messages:
+    SpeakV1Text:
+      origin: client
+      body: SpeakV1Text
+  examples:
+    - messages:
+        - type: SpeakV1Text
+          body:
+            type: Text
+types:
+  SpeakV1Text:
+    properties:
+      type:
+        type: string
+        docs: Message type identifier
+    source:
+      openapi: ../asyncapi.yml
+",
+    },
+  },
+  "packageMarkers": {},
+  "rootApiFile": {
+    "contents": {
+      "error-discrimination": {
+        "strategy": "status-code",
+      },
+      "name": "api",
+    },
+    "defaultUrl": undefined,
+    "rawContents": "name: api
+error-discrimination:
+  strategy: status-code
+",
+  },
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/deepgram-mini/asyncapi.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/deepgram-mini/asyncapi.yml
@@ -20,22 +20,19 @@ channels:
   SpeakV1:
     messages:
       SpeakV1Text:
-        $ref: '#/components/messages/SpeakV1TextMessage'
+        $ref: "#/components/messages/SpeakV1TextMessage"
     x-fern-examples:
       - name: WebSocket Example Messages
         messages:
           - type: SpeakV1Text
             channelId: SpeakV1
             messageId: SpeakV1Text
-            value:
-              {
-                "type": "Text"
-              }
+            value: { "type": "Text" }
 operations:
   SpeakV1Text:
     description: Text to convert to audio
     action: send
     channel:
-      $ref: '#/channels/SpeakV1'
+      $ref: "#/channels/SpeakV1"
     messages:
-      - $ref: '#/channels/SpeakV1/messages/SpeakV1Text'
+      - $ref: "#/channels/SpeakV1/messages/SpeakV1Text"

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/deepgram-mini/asyncapi.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/deepgram-mini/asyncapi.yml
@@ -1,0 +1,41 @@
+asyncapi: 3.0.0
+info:
+  title: Deepgram-mini API Specification
+  version: 1.0.0
+components:
+  messages:
+    SpeakV1TextMessage:
+      name: SpeakV1TextMessage
+      description: Request to convert text to speech
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            description: Message type identifier
+            example: Speak
+        required:
+          - type
+channels:
+  SpeakV1:
+    messages:
+      SpeakV1Text:
+        $ref: '#/components/messages/SpeakV1TextMessage'
+    x-fern-examples:
+      - name: WebSocket Example Messages
+        messages:
+          - type: SpeakV1Text
+            channelId: SpeakV1
+            messageId: SpeakV1Text
+            value:
+              {
+                "type": "Text"
+              }
+operations:
+  SpeakV1Text:
+    description: Text to convert to audio
+    action: send
+    channel:
+      $ref: '#/channels/SpeakV1'
+    messages:
+      - $ref: '#/channels/SpeakV1/messages/SpeakV1Text'

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/deepgram-mini/fern/fern.config.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/deepgram-mini/fern/fern.config.json
@@ -1,0 +1,4 @@
+{
+    "organization": "fern",
+    "version": "*"
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/deepgram-mini/fern/generators.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/deepgram-mini/fern/generators.yml
@@ -1,0 +1,4 @@
+# yaml-language-server: $schema=https://schema.buildwithfern.dev/generators-yml.json
+api:
+  specs:
+    - asyncapi: ../asyncapi.yml

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/openapi-ir.test.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/openapi-ir.test.ts
@@ -86,6 +86,9 @@ async function getTestFixturePath(fixtureFilePath: AbsoluteFilePath): Promise<Ab
     const yamlFixturePath = join(fixtureFilePath, RelativeFilePath.of("openapi.yaml"));
     const ymlFixturePath = join(fixtureFilePath, RelativeFilePath.of("openapi.yml"));
     const jsonFixturePath = join(fixtureFilePath, RelativeFilePath.of("openapi.json"));
+    const asyncYamlFixturePath = join(fixtureFilePath, RelativeFilePath.of("asyncapi.yaml"));
+    const asyncYmlFixturePath = join(fixtureFilePath, RelativeFilePath.of("asyncapi.yml"));
+    const asyncJsonFixturePath = join(fixtureFilePath, RelativeFilePath.of("asyncapi.json"));
     const swaggerFixturePath = join(fixtureFilePath, RelativeFilePath.of("swagger.json"));
     return (await doesPathExist(yamlFixturePath))
         ? yamlFixturePath
@@ -93,7 +96,13 @@ async function getTestFixturePath(fixtureFilePath: AbsoluteFilePath): Promise<Ab
           ? ymlFixturePath
           : (await doesPathExist(jsonFixturePath))
             ? jsonFixturePath
-            : swaggerFixturePath;
+            : (await doesPathExist(asyncYamlFixturePath))
+              ? asyncYamlFixturePath
+              : (await doesPathExist(asyncYmlFixturePath))
+                ? asyncYmlFixturePath
+                : (await doesPathExist(asyncJsonFixturePath))
+                  ? asyncJsonFixturePath
+                  : swaggerFixturePath;
 }
 
 const SWAGGER_OPENAPI_FIXTURES = new Set(["suger"]);

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Fix the dereferencing of message $refs in the operations section of AsyncAPI specs.
+      type: fix
+  irVersion: 61
+  createdAt: "2025-11-04"
+  version: 0.107.4
+
+- changelogEntry:
+    - summary: |
         Revert the change in 0.107.0 which didn't deduplicate types as expected
       type: chore
   irVersion: 61
@@ -117,7 +125,7 @@
 
         - `theme.[sidebar, body, tabs]`: controls the theme of the docs
         - `settings.disable-explorer-proxy`: controls whether the explorer uses a proxy
-        - `languages`: initializes localization within fern docs 
+        - `languages`: initializes localization within fern docs
         - `navbarLinks.[dropdown]`: adds a dropdown option for navbar links
         - `navbarLinks.[].viewers`: allows navbar links to be controlled with RBAC
       type: feat


### PR DESCRIPTION
## Description
Linear ticket: Closes FER-7559.
Fixing v3 AsyncAPI parsing weirdness around dereferencing the messages referenced in operations.

In particular, it seems that `operations.messages` would be dereferenced fully, occasionally dereferencing `channel.messages` to get all the way to `component.messages`, but we needed to use the message ID from the channel and not the one from the component.

## Changes Made
Changes to `parseAsyncAPIV3.ts`, mostly.

## Testing
Regenerating seed now!
