### PR TITLE
fix(docs): do background validation for docs dev

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Perform fern docs dev validation in the background instead of foreground
+      type: fix
+  irVersion: 61
+  createdAt: "2025-11-04"
+  version: 0.107.5
+
+- changelogEntry:
+    - summary: |
         Fix the dereferencing of message $refs in the operations section of AsyncAPI specs.
       type: fix
   irVersion: 61


### PR DESCRIPTION
## Description

no longer block front-end updates on docs validation during `fern docs dev`

## Testing

tested locally
