### PR TITLE
fix(cli): AsyncAPI correctly resolves message references

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/asyncapi/v3/AsyncAPIV3ParserContext.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/asyncapi/v3/AsyncAPIV3ParserContext.ts
@@ -56,8 +56,8 @@ export class AsyncAPIV3ParserContext extends AbstractAsyncAPIParserContext<Async
                 return this.resolveMessageReference(resolvedInChannel as OpenAPIV3.ReferenceObject);
             } else {
                 return {
-                    name: messageKey,
-                    ...resolvedInChannel
+                    ...resolvedInChannel,
+                    name: messageKey
                 };
             }
         }
@@ -74,8 +74,8 @@ export class AsyncAPIV3ParserContext extends AbstractAsyncAPIParserContext<Async
         }
 
         return {
-            name: messageKey,
-            ...resolvedInComponents
+            ...resolvedInComponents,
+            name: messageKey
         };
     }
 

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/asyncapi-v3-message-refs.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/asyncapi-v3-message-refs.json
@@ -1,0 +1,124 @@
+{
+  "absoluteFilePath": "/DUMMY_PATH",
+  "importedDefinitions": {},
+  "namedDefinitionFiles": {
+    "__package__.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {
+        "types": {
+          "ServerResponsePayload": {
+            "docs": undefined,
+            "inline": undefined,
+            "properties": {
+              "reply": {
+                "docs": "Response text",
+                "type": "string",
+              },
+            },
+            "source": {
+              "openapi": "../asyncapi.yml",
+            },
+          },
+          "UserMessagePayload": {
+            "docs": undefined,
+            "inline": undefined,
+            "properties": {
+              "text": {
+                "docs": "Message text",
+                "type": "string",
+              },
+            },
+            "source": {
+              "openapi": "../asyncapi.yml",
+            },
+          },
+        },
+      },
+      "rawContents": "types:
+  UserMessagePayload:
+    properties:
+      text:
+        type: string
+        docs: Message text
+    source:
+      openapi: ../asyncapi.yml
+  ServerResponsePayload:
+    properties:
+      reply:
+        type: string
+        docs: Response text
+    source:
+      openapi: ../asyncapi.yml
+",
+    },
+    "chat.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {
+        "channel": {
+          "auth": false,
+          "docs": "Chat channel for testing message references",
+          "examples": [
+            {
+              "messages": [],
+            },
+          ],
+          "messages": {
+            "serverResponse": {
+              "body": "root.ServerResponsePayload",
+              "origin": "server",
+            },
+            "userMessage": {
+              "body": "root.UserMessagePayload",
+              "origin": "client",
+            },
+          },
+          "path": "/v1/ws/chat",
+          "url": "production",
+        },
+        "imports": {
+          "root": "__package__.yml",
+        },
+      },
+      "rawContents": "channel:
+  path: /v1/ws/chat
+  url: production
+  auth: false
+  docs: Chat channel for testing message references
+  messages:
+    serverResponse:
+      origin: server
+      body: root.ServerResponsePayload
+    userMessage:
+      origin: client
+      body: root.UserMessagePayload
+  examples:
+    - messages: []
+imports:
+  root: __package__.yml
+",
+    },
+  },
+  "packageMarkers": {},
+  "rootApiFile": {
+    "contents": {
+      "default-environment": "production",
+      "default-url": "Base",
+      "environments": {
+        "production": "wss://api.example.com",
+      },
+      "error-discrimination": {
+        "strategy": "status-code",
+      },
+      "name": "api",
+    },
+    "defaultUrl": "Base",
+    "rawContents": "name: api
+error-discrimination:
+  strategy: status-code
+environments:
+  production: wss://api.example.com
+default-environment: production
+default-url: Base
+",
+  },
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/asyncapi-v3-message-refs.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/asyncapi-v3-message-refs.json
@@ -1,0 +1,129 @@
+{
+  "type": "openapi",
+  "value": {
+    "asyncapi": "3.0.0",
+    "info": {
+      "title": "Message Reference Test API",
+      "version": "1.0.0",
+      "description": "Tests that channel messages with component references are correctly resolved"
+    },
+    "servers": {
+      "production": {
+        "host": "api.example.com",
+        "protocol": "wss",
+        "pathname": "/v1/ws"
+      }
+    },
+    "channels": {
+      "chat": {
+        "address": "/v1/ws/chat",
+        "description": "Chat channel for testing message references",
+        "messages": {
+          "userMessage": {
+            "$ref": "#/components/messages/UserMessage"
+          },
+          "serverResponse": {
+            "$ref": "#/components/messages/ServerResponse"
+          }
+        }
+      }
+    },
+    "operations": {
+      "sendMessage": {
+        "action": "send",
+        "channel": {
+          "$ref": "#/channels/chat"
+        },
+        "messages": [
+          {
+            "$ref": "#/channels/chat/messages/userMessage"
+          }
+        ]
+      },
+      "receiveResponse": {
+        "action": "receive",
+        "channel": {
+          "$ref": "#/channels/chat"
+        },
+        "messages": [
+          {
+            "$ref": "#/channels/chat/messages/serverResponse"
+          }
+        ]
+      }
+    },
+    "components": {
+      "messages": {
+        "UserMessage": {
+          "name": "UserMessage",
+          "title": "User Message",
+          "contentType": "application/json",
+          "payload": {
+            "$ref": "#/components/schemas/UserMessagePayload"
+          }
+        },
+        "ServerResponse": {
+          "name": "ServerResponse",
+          "title": "Server Response",
+          "contentType": "application/json",
+          "payload": {
+            "$ref": "#/components/schemas/ServerResponsePayload"
+          }
+        }
+      },
+      "schemas": {
+        "UserMessagePayload": {
+          "type": "object",
+          "required": [
+            "text"
+          ],
+          "properties": {
+            "text": {
+              "type": "string",
+              "description": "Message text"
+            }
+          }
+        },
+        "ServerResponsePayload": {
+          "type": "object",
+          "required": [
+            "reply"
+          ],
+          "properties": {
+            "reply": {
+              "type": "string",
+              "description": "Response text"
+            }
+          }
+        }
+      }
+    }
+  },
+  "settings": {
+    "disableExamples": false,
+    "discriminatedUnionV2": false,
+    "useTitlesAsName": true,
+    "optionalAdditionalProperties": true,
+    "coerceEnumsToLiterals": true,
+    "respectReadonlySchemas": false,
+    "respectNullableSchemas": false,
+    "onlyIncludeReferencedSchemas": false,
+    "inlinePathParameters": false,
+    "preserveSchemaIds": false,
+    "shouldUseUndiscriminatedUnionsWithLiterals": false,
+    "shouldUseIdiomaticRequestNames": false,
+    "objectQueryParameters": false,
+    "asyncApiNaming": "v1",
+    "useBytesForBinaryResponse": false,
+    "respectForwardCompatibleEnums": false,
+    "additionalPropertiesDefaultsTo": false,
+    "typeDatesAsStrings": true,
+    "preserveSingleSchemaOneOf": false,
+    "inlineAllOfSchemas": false,
+    "resolveAliases": false,
+    "groupMultiApiEnvironments": false,
+    "groupEnvironmentsByHost": false,
+    "wrapReferencesToNullableInOptional": true,
+    "coerceOptionalSchemasToNullable": true
+  }
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/asyncapi-v3-message-refs.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/asyncapi-v3-message-refs.json
@@ -1,0 +1,146 @@
+{
+  "servers": [],
+  "websocketServers": [
+    {
+      "name": "production",
+      "url": "wss://api.example.com"
+    }
+  ],
+  "tags": {
+    "tagsById": {}
+  },
+  "hasEndpointsMarkedInternal": false,
+  "endpoints": [],
+  "webhooks": [],
+  "channels": {
+    "chat": {
+      "audiences": [],
+      "handshake": {
+        "headers": [],
+        "queryParameters": [],
+        "pathParameters": []
+      },
+      "groupName": [
+        "chat"
+      ],
+      "messages": [
+        {
+          "origin": "server",
+          "name": "serverResponse",
+          "body": {
+            "generatedName": "ServerResponse",
+            "schema": "ServerResponsePayload",
+            "source": {
+              "file": "../asyncapi.yml",
+              "type": "openapi"
+            },
+            "type": "reference"
+          }
+        },
+        {
+          "origin": "client",
+          "name": "userMessage",
+          "body": {
+            "generatedName": "UserMessage",
+            "schema": "UserMessagePayload",
+            "source": {
+              "file": "../asyncapi.yml",
+              "type": "openapi"
+            },
+            "type": "reference"
+          }
+        }
+      ],
+      "servers": [
+        {
+          "name": "production",
+          "url": "wss://api.example.com"
+        }
+      ],
+      "path": "/v1/ws/chat",
+      "description": "Chat channel for testing message references",
+      "examples": [
+        {
+          "queryParameters": [],
+          "headers": [],
+          "messages": []
+        }
+      ],
+      "source": {
+        "file": "../asyncapi.yml",
+        "type": "openapi"
+      }
+    }
+  },
+  "groupedSchemas": {
+    "rootSchemas": {
+      "UserMessagePayload": {
+        "properties": [
+          {
+            "key": "text",
+            "schema": {
+              "generatedName": "UserMessagePayloadText",
+              "schema": {
+                "type": "string"
+              },
+              "description": "Message text",
+              "groupName": [],
+              "type": "primitive"
+            },
+            "audiences": [],
+            "conflict": {},
+            "generatedName": "userMessagePayloadText"
+          }
+        ],
+        "generatedName": "UserMessagePayload",
+        "allOf": [],
+        "allOfPropertyConflicts": [],
+        "groupName": [],
+        "fullExamples": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../asyncapi.yml",
+          "type": "openapi"
+        },
+        "type": "object"
+      },
+      "ServerResponsePayload": {
+        "properties": [
+          {
+            "key": "reply",
+            "schema": {
+              "generatedName": "ServerResponsePayloadReply",
+              "schema": {
+                "type": "string"
+              },
+              "description": "Response text",
+              "groupName": [],
+              "type": "primitive"
+            },
+            "audiences": [],
+            "conflict": {},
+            "generatedName": "serverResponsePayloadReply"
+          }
+        ],
+        "generatedName": "ServerResponsePayload",
+        "allOf": [],
+        "allOfPropertyConflicts": [],
+        "groupName": [],
+        "fullExamples": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../asyncapi.yml",
+          "type": "openapi"
+        },
+        "type": "object"
+      }
+    },
+    "namespacedSchemas": {}
+  },
+  "variables": {},
+  "nonRequestReferencedSchemas": {},
+  "securitySchemes": {},
+  "globalHeaders": [],
+  "idempotencyHeaders": [],
+  "groups": {}
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/asyncapi-v3-message-refs.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/asyncapi-v3-message-refs.json
@@ -1,0 +1,124 @@
+{
+  "absoluteFilePath": "/DUMMY_PATH",
+  "importedDefinitions": {},
+  "namedDefinitionFiles": {
+    "__package__.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {
+        "types": {
+          "ServerResponsePayload": {
+            "docs": undefined,
+            "inline": undefined,
+            "properties": {
+              "reply": {
+                "docs": "Response text",
+                "type": "string",
+              },
+            },
+            "source": {
+              "openapi": "../asyncapi.yml",
+            },
+          },
+          "UserMessagePayload": {
+            "docs": undefined,
+            "inline": undefined,
+            "properties": {
+              "text": {
+                "docs": "Message text",
+                "type": "string",
+              },
+            },
+            "source": {
+              "openapi": "../asyncapi.yml",
+            },
+          },
+        },
+      },
+      "rawContents": "types:
+  UserMessagePayload:
+    properties:
+      text:
+        type: string
+        docs: Message text
+    source:
+      openapi: ../asyncapi.yml
+  ServerResponsePayload:
+    properties:
+      reply:
+        type: string
+        docs: Response text
+    source:
+      openapi: ../asyncapi.yml
+",
+    },
+    "chat.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {
+        "channel": {
+          "auth": false,
+          "docs": "Chat channel for testing message references",
+          "examples": [
+            {
+              "messages": [],
+            },
+          ],
+          "messages": {
+            "serverResponse": {
+              "body": "root.ServerResponsePayload",
+              "origin": "server",
+            },
+            "userMessage": {
+              "body": "root.UserMessagePayload",
+              "origin": "client",
+            },
+          },
+          "path": "/v1/ws/chat",
+          "url": "production",
+        },
+        "imports": {
+          "root": "__package__.yml",
+        },
+      },
+      "rawContents": "channel:
+  path: /v1/ws/chat
+  url: production
+  auth: false
+  docs: Chat channel for testing message references
+  messages:
+    serverResponse:
+      origin: server
+      body: root.ServerResponsePayload
+    userMessage:
+      origin: client
+      body: root.UserMessagePayload
+  examples:
+    - messages: []
+imports:
+  root: __package__.yml
+",
+    },
+  },
+  "packageMarkers": {},
+  "rootApiFile": {
+    "contents": {
+      "default-environment": "production",
+      "default-url": "Base",
+      "environments": {
+        "production": "wss://api.example.com",
+      },
+      "error-discrimination": {
+        "strategy": "status-code",
+      },
+      "name": "api",
+    },
+    "defaultUrl": "Base",
+    "rawContents": "name: api
+error-discrimination:
+  strategy: status-code
+environments:
+  production: wss://api.example.com
+default-environment: production
+default-url: Base
+",
+  },
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/asyncapi-v3-message-refs/asyncapi.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/asyncapi-v3-message-refs/asyncapi.yml
@@ -1,0 +1,72 @@
+asyncapi: 3.0.0
+
+info:
+  title: Message Reference Test API
+  version: 1.0.0
+  description: Tests that channel messages with component references are correctly resolved
+
+servers:
+  production:
+    host: api.example.com
+    protocol: wss
+    pathname: /v1/ws
+
+channels:
+  chat:
+    address: /v1/ws/chat
+    description: Chat channel for testing message references
+    messages:
+      userMessage:
+        $ref: '#/components/messages/UserMessage'
+      serverResponse:
+        $ref: '#/components/messages/ServerResponse'
+
+operations:
+  sendMessage:
+    action: send
+    channel:
+      $ref: '#/channels/chat'
+    messages:
+      - $ref: '#/channels/chat/messages/userMessage'
+
+  receiveResponse:
+    action: receive
+    channel:
+      $ref: '#/channels/chat'
+    messages:
+      - $ref: '#/channels/chat/messages/serverResponse'
+
+components:
+  messages:
+    UserMessage:
+      name: UserMessage
+      title: User Message
+      contentType: application/json
+      payload:
+        $ref: '#/components/schemas/UserMessagePayload'
+
+    ServerResponse:
+      name: ServerResponse
+      title: Server Response
+      contentType: application/json
+      payload:
+        $ref: '#/components/schemas/ServerResponsePayload'
+
+  schemas:
+    UserMessagePayload:
+      type: object
+      required:
+        - text
+      properties:
+        text:
+          type: string
+          description: Message text
+
+    ServerResponsePayload:
+      type: object
+      required:
+        - reply
+      properties:
+        reply:
+          type: string
+          description: Response text

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/asyncapi-v3-message-refs/asyncapi.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/asyncapi-v3-message-refs/asyncapi.yml
@@ -17,24 +17,24 @@ channels:
     description: Chat channel for testing message references
     messages:
       userMessage:
-        $ref: '#/components/messages/UserMessage'
+        $ref: "#/components/messages/UserMessage"
       serverResponse:
-        $ref: '#/components/messages/ServerResponse'
+        $ref: "#/components/messages/ServerResponse"
 
 operations:
   sendMessage:
     action: send
     channel:
-      $ref: '#/channels/chat'
+      $ref: "#/channels/chat"
     messages:
-      - $ref: '#/channels/chat/messages/userMessage'
+      - $ref: "#/channels/chat/messages/userMessage"
 
   receiveResponse:
     action: receive
     channel:
-      $ref: '#/channels/chat'
+      $ref: "#/channels/chat"
     messages:
-      - $ref: '#/channels/chat/messages/serverResponse'
+      - $ref: "#/channels/chat/messages/serverResponse"
 
 components:
   messages:
@@ -43,14 +43,14 @@ components:
       title: User Message
       contentType: application/json
       payload:
-        $ref: '#/components/schemas/UserMessagePayload'
+        $ref: "#/components/schemas/UserMessagePayload"
 
     ServerResponse:
       name: ServerResponse
       title: Server Response
       contentType: application/json
       payload:
-        $ref: '#/components/schemas/ServerResponsePayload'
+        $ref: "#/components/schemas/ServerResponsePayload"
 
   schemas:
     UserMessagePayload:

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/asyncapi-v3-message-refs/fern/fern.config.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/asyncapi-v3-message-refs/fern/fern.config.json
@@ -1,0 +1,4 @@
+{
+    "organization": "fern",
+    "version": "*"
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/asyncapi-v3-message-refs/fern/generators.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/asyncapi-v3-message-refs/fern/generators.yml
@@ -1,0 +1,4 @@
+# yaml-language-server: $schema=https://schema.buildwithfern.dev/generators-yml.json
+api:
+  specs:
+    - asyncapi: ../asyncapi.yml

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -9,6 +9,14 @@
 
 - changelogEntry:
     - summary: |
+        Fix AsyncAPI v3 message parsing where channel messages were not being included in generated WebSocket clients. Messages defined in AsyncAPI v3 specs are now correctly resolved and included in the SDK.
+      type: fix
+  irVersion: 61
+  createdAt: "2025-11-05"
+  version: 0.107.10
+
+- changelogEntry:
+    - summary: |
         Implement variant ranking in anyOf/oneOf example generation to prefer variants that use provided examples without coercion over variants that require coercion or generate fallback examples. When a schema has anyOf: [number, string] with examples: ["2500"], the string variant is now preferred since it can use the provided example as-is, rather than the number variant which would coerce it to a number.
       type: fix
   irVersion: 61

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,16 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
-        Update migration logic to support new generator versions with ir v61.
-      type: chore
+        Fix AsyncAPI v3 message parsing where channel messages were not being included in generated WebSocket clients. Messages defined in AsyncAPI v3 specs are now correctly resolved and included in the SDK.
+      type: fix
   irVersion: 61
   createdAt: "2025-11-05"
-  version: 0.107.10
+  version: 0.107.11
 
 - changelogEntry:
     - summary: |
-        Fix AsyncAPI v3 message parsing where channel messages were not being included in generated WebSocket clients. Messages defined in AsyncAPI v3 specs are now correctly resolved and included in the SDK.
-      type: fix
+        Update migration logic to support new generator versions with ir v61.
+      type: chore
   irVersion: 61
   createdAt: "2025-11-05"
   version: 0.107.10


### PR DESCRIPTION
  Fixes AsyncAPI v3 message parsing where channel messages weren't being included in generated SDKs.

  **Problem:** The spread operator in `AsyncAPIV3ParserContext.ts` was overwriting the message `name`
  property during resolution, causing lookup mismatches.

  **Solution:** Move `name: messageKey` after the spread operator to ensure it takes precedence.

  **Result:** Messages now correctly appear in generated IR and SDKs (tested: 0 → 4 messages).