### PR TITLE
fix(csharp): Fix auth-environment-variables fixture 

### DIFF
--- a/generators/csharp/codegen/src/ast/types/Type.ts
+++ b/generators/csharp/codegen/src/ast/types/Type.ts
@@ -1,6 +1,7 @@
 import { fail } from "node:assert";
 import { PrimitiveTypeV1 } from "@fern-fern/ir-sdk/api";
 import { type Generation } from "../../context/generation-info";
+import { hash, uniqueId } from "../../utils/text";
 import { TypeLiteral } from "../code/TypeLiteral";
 import { AstNode } from "../core/AstNode";
 import { Writer } from "../core/Writer";
@@ -114,6 +115,20 @@ export abstract class Type extends AstNode {
     public writeEmptyCollectionInitializer(writer: Writer): void {
         // default - no-op
     }
+
+    /**
+     * This returns a typeLiteral for the appropriate type with a value,
+     * derived from the getDefaultFor string
+     *
+     * The value should give a deterministic result for the same input string.
+     * This is used to generate a default value for a type when no value is provided.
+     *
+     * @param input - The input string to derive the default value from
+     * @returns A typeLiteral for the appropriate type with a value, derived from the input string
+     * */
+    public getDeterminsticDefault(input: string): TypeLiteral {
+        return this.csharp.TypeLiteral.nop();
+    }
 }
 
 /**
@@ -181,6 +196,10 @@ export namespace Type {
     export class Integer extends PrimitiveType {
         public override type = "int";
         public override defaultValue = this.csharp.TypeLiteral.integer(0);
+        public override getDeterminsticDefault(input: string): TypeLiteral {
+            // make a unique number using the defualtWith string as the seed.
+            return this.csharp.TypeLiteral.integer(hash(input) & 0x7fffffff);
+        }
     }
 
     /**
@@ -189,6 +208,10 @@ export namespace Type {
     export class Long extends PrimitiveType {
         public override type = "long";
         public override defaultValue = this.csharp.TypeLiteral.long(0);
+        public override getDeterminsticDefault(input: string): TypeLiteral {
+            // make a unique number using the defualtWith string as the seed.
+            return this.csharp.TypeLiteral.long(hash(input) & 0x7ffffffffffff);
+        }
     }
 
     /**
@@ -197,6 +220,10 @@ export namespace Type {
     export class Uint extends PrimitiveType {
         public override type = "uint";
         public override defaultValue = this.csharp.TypeLiteral.uint(0);
+        public override getDeterminsticDefault(input: string): TypeLiteral {
+            // make a unique number using the defualtWith string as the seed.
+            return this.csharp.TypeLiteral.uint(hash(input) & 0x7fffffff);
+        }
     }
 
     /**
@@ -205,6 +232,10 @@ export namespace Type {
     export class ULong extends PrimitiveType {
         public override type = "ulong";
         public override defaultValue = this.csharp.TypeLiteral.ulong(0);
+        public override getDeterminsticDefault(input: string): TypeLiteral {
+            // make a unique number using the defualtWith string as the seed.
+            return this.csharp.TypeLiteral.ulong(hash(input) & 0x7ffffffffffff);
+        }
     }
 
     /**
@@ -215,6 +246,10 @@ export namespace Type {
         public override type = "string";
         public override defaultValue = this.csharp.TypeLiteral.string("");
         public override readonly isReferenceType: boolean | undefined = true;
+        public override getDeterminsticDefault(input: string): TypeLiteral {
+            // make a unique string using the defualtWith string as the seed.
+            return this.csharp.TypeLiteral.string(`<${input}>`);
+        }
     }
 
     /**
@@ -223,6 +258,10 @@ export namespace Type {
     export class Boolean extends PrimitiveType {
         public override type = "bool";
         public override defaultValue = this.csharp.TypeLiteral.boolean(false);
+        public override getDeterminsticDefault(input: string): TypeLiteral {
+            // make a unique boolean using the defualtWith string as the seed.
+            return this.csharp.TypeLiteral.boolean(hash(input) % 2 === 0);
+        }
     }
 
     /**
@@ -231,6 +270,10 @@ export namespace Type {
     export class Float extends PrimitiveType {
         public override type = "float";
         public override defaultValue = this.csharp.TypeLiteral.float(0);
+        public override getDeterminsticDefault(input: string): TypeLiteral {
+            // make a unique float using the defualtWith string as the seed.
+            return this.csharp.TypeLiteral.float((hash(input) & 0x7fffffff) / 100);
+        }
     }
 
     /**
@@ -239,6 +282,10 @@ export namespace Type {
     export class Double extends PrimitiveType {
         public override type = "double";
         public override defaultValue = this.csharp.TypeLiteral.double(0);
+        public override getDeterminsticDefault(input: string): TypeLiteral {
+            // make a unique double using the defualtWith string as the seed.
+            return this.csharp.TypeLiteral.double((hash(input) & 0x7ffffffffffff) / 100);
+        }
     }
 
     /**
@@ -246,6 +293,11 @@ export namespace Type {
      */
     export class DateOnly extends PrimitiveType {
         public override type = "DateOnly";
+        public override getDeterminsticDefault(input: string): TypeLiteral {
+            // make a unique date using the defualtWith string as the seed.
+            const date = new Date(hash(input) & 0x7ffffffffffff);
+            return this.csharp.TypeLiteral.date(date.toISOString());
+        }
     }
 
     /**
@@ -253,6 +305,11 @@ export namespace Type {
      */
     export class DateTime extends PrimitiveType {
         public override type = "DateTime";
+        public override getDeterminsticDefault(input: string): TypeLiteral {
+            // make a unique date using the defualtWith string as the seed.
+            const date = new Date(hash(input) & 0x7ffffffffffff);
+            return this.csharp.TypeLiteral.datetime(date.toISOString());
+        }
     }
 
     /**
@@ -265,6 +322,10 @@ export namespace Type {
 
         // C# GUID is a value type, but we use string for UUID
         public override readonly isReferenceType: boolean | undefined = true;
+        public override getDeterminsticDefault(input: string): TypeLiteral {
+            // make a unique UUID using the defualtWith string as the seed.
+            return this.csharp.TypeLiteral.string(uniqueId(input));
+        }
     }
 
     /**

--- a/generators/csharp/codegen/src/utils/__test__/text.test.ts
+++ b/generators/csharp/codegen/src/utils/__test__/text.test.ts
@@ -1,4 +1,4 @@
-import { camelCase, upperFirst } from "../text";
+import { camelCase, hash, uniqueId, upperFirst } from "../text";
 
 describe("text utilities", () => {
     describe("upperFirst", () => {
@@ -233,6 +233,394 @@ describe("text utilities", () => {
             it("should convert improper camelCase correctly", () => {
                 expect(camelCase("FirstName")).toBe("firstName"); // PascalCase -> camelCase
                 expect(camelCase("fIRSTnAME")).toBe("fIrsTnAme"); // Weird case keeps weird transitions
+            });
+        });
+    });
+
+    describe("hash", () => {
+        describe("basic hashing", () => {
+            it("should generate a hash from a string", () => {
+                const result = hash("hello");
+                expect(typeof result).toBe("number");
+            });
+
+            it("should generate different hashes for different strings", () => {
+                const hash1 = hash("hello");
+                const hash2 = hash("world");
+                const hash3 = hash("foo");
+
+                expect(hash1).not.toBe(hash2);
+                expect(hash2).not.toBe(hash3);
+                expect(hash1).not.toBe(hash3);
+            });
+
+            it("should generate the same hash for the same string", () => {
+                const hash1 = hash("hello");
+                const hash2 = hash("hello");
+                const hash3 = hash("hello");
+
+                expect(hash1).toBe(hash2);
+                expect(hash2).toBe(hash3);
+            });
+
+            it("should handle empty strings", () => {
+                const result = hash("");
+                expect(typeof result).toBe("number");
+                expect(result).toBe(0);
+            });
+        });
+
+        describe("edge cases", () => {
+            it("should handle single characters", () => {
+                const hash1 = hash("a");
+                const hash2 = hash("b");
+                const hash3 = hash("z");
+
+                expect(typeof hash1).toBe("number");
+                expect(typeof hash2).toBe("number");
+                expect(typeof hash3).toBe("number");
+                expect(hash1).not.toBe(hash2);
+                expect(hash2).not.toBe(hash3);
+            });
+
+            it("should be case sensitive", () => {
+                const hash1 = hash("hello");
+                const hash2 = hash("Hello");
+                const hash3 = hash("HELLO");
+
+                expect(hash1).not.toBe(hash2);
+                expect(hash2).not.toBe(hash3);
+                expect(hash1).not.toBe(hash3);
+            });
+
+            it("should handle special characters", () => {
+                const hash1 = hash("hello!");
+                const hash2 = hash("hello@");
+                const hash3 = hash("hello#");
+
+                expect(hash1).not.toBe(hash2);
+                expect(hash2).not.toBe(hash3);
+                expect(hash1).not.toBe(hash3);
+            });
+
+            it("should handle numbers", () => {
+                const hash1 = hash("123");
+                const hash2 = hash("456");
+                const hash3 = hash("789");
+
+                expect(hash1).not.toBe(hash2);
+                expect(hash2).not.toBe(hash3);
+            });
+
+            it("should handle whitespace", () => {
+                const hash1 = hash("hello world");
+                const hash2 = hash("hello  world");
+                const hash3 = hash("helloworld");
+
+                expect(hash1).not.toBe(hash2);
+                expect(hash1).not.toBe(hash3);
+                expect(hash2).not.toBe(hash3);
+            });
+
+            it("should handle unicode characters", () => {
+                const hash1 = hash("café");
+                const hash2 = hash("naïve");
+                const hash3 = hash("über");
+
+                expect(typeof hash1).toBe("number");
+                expect(typeof hash2).toBe("number");
+                expect(typeof hash3).toBe("number");
+                expect(hash1).not.toBe(hash2);
+                expect(hash2).not.toBe(hash3);
+            });
+
+            it("should handle emojis", () => {
+                const hash1 = hash("hello 👋");
+                const hash2 = hash("world 🌍");
+
+                expect(typeof hash1).toBe("number");
+                expect(typeof hash2).toBe("number");
+                expect(hash1).not.toBe(hash2);
+            });
+        });
+
+        describe("real-world usage", () => {
+            it("should handle long strings", () => {
+                const longString = "The quick brown fox jumps over the lazy dog. ".repeat(10);
+                const result = hash(longString);
+
+                expect(typeof result).toBe("number");
+            });
+
+            it("should handle repeated substrings differently", () => {
+                const hash1 = hash("aaaa");
+                const hash2 = hash("bbbb");
+                const hash3 = hash("aaab");
+
+                expect(hash1).not.toBe(hash2);
+                expect(hash1).not.toBe(hash3);
+                expect(hash2).not.toBe(hash3);
+            });
+
+            it("should be deterministic across multiple runs", () => {
+                const testString = "test string for determinism";
+                const results = [];
+
+                for (let i = 0; i < 100; i++) {
+                    results.push(hash(testString));
+                }
+
+                // All results should be the same
+                expect(new Set(results).size).toBe(1);
+            });
+        });
+    });
+
+    describe("uniqueId", () => {
+        describe("basic functionality", () => {
+            it("should generate a UUID-like string", () => {
+                const result = uniqueId("hello");
+                expect(typeof result).toBe("string");
+                expect(result).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+            });
+
+            it("should generate the same ID for the same input", () => {
+                const id1 = uniqueId("hello");
+                const id2 = uniqueId("hello");
+                const id3 = uniqueId("hello");
+
+                expect(id1).toBe(id2);
+                expect(id2).toBe(id3);
+            });
+
+            it("should generate different IDs for different inputs", () => {
+                const id1 = uniqueId("hello");
+                const id2 = uniqueId("world");
+                const id3 = uniqueId("foo");
+
+                expect(id1).not.toBe(id2);
+                expect(id2).not.toBe(id3);
+                expect(id1).not.toBe(id3);
+            });
+
+            it("should handle empty strings", () => {
+                const result = uniqueId("");
+                expect(typeof result).toBe("string");
+                expect(result).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+            });
+
+            it("should follow UUID v4 format", () => {
+                const result = uniqueId("test");
+                const parts = result.split("-");
+
+                expect(parts).toHaveLength(5);
+                expect(parts[0]).toHaveLength(8);
+                expect(parts[1]).toHaveLength(4);
+                expect(parts[2]).toHaveLength(4);
+                expect(parts[3]).toHaveLength(4);
+                expect(parts[4]).toHaveLength(12);
+
+                // UUID v4 has a '4' at the beginning of the third group
+                expect(parts[2]?.[0]).toBe("4");
+
+                // UUID v4 has specific bits in the fourth group (8, 9, a, or b)
+                expect(["8", "9", "a", "b"]).toContain(parts[3]?.[0]);
+            });
+        });
+
+        describe("edge cases", () => {
+            it("should handle single characters", () => {
+                const id1 = uniqueId("a");
+                const id2 = uniqueId("b");
+                const id3 = uniqueId("z");
+
+                expect(id1).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+                expect(id2).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+                expect(id3).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+                expect(id1).not.toBe(id2);
+                expect(id2).not.toBe(id3);
+            });
+
+            it("should be case sensitive", () => {
+                const id1 = uniqueId("hello");
+                const id2 = uniqueId("Hello");
+                const id3 = uniqueId("HELLO");
+
+                expect(id1).not.toBe(id2);
+                expect(id2).not.toBe(id3);
+                expect(id1).not.toBe(id3);
+            });
+
+            it("should handle special characters", () => {
+                const id1 = uniqueId("hello!");
+                const id2 = uniqueId("hello@");
+                const id3 = uniqueId("hello#");
+
+                expect(id1).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+                expect(id1).not.toBe(id2);
+                expect(id2).not.toBe(id3);
+            });
+
+            it("should handle numbers", () => {
+                const id1 = uniqueId("123");
+                const id2 = uniqueId("456");
+                const id3 = uniqueId("789");
+
+                expect(id1).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+                expect(id1).not.toBe(id2);
+                expect(id2).not.toBe(id3);
+            });
+
+            it("should handle whitespace", () => {
+                const id1 = uniqueId("hello world");
+                const id2 = uniqueId("hello  world");
+                const id3 = uniqueId("helloworld");
+
+                expect(id1).not.toBe(id2);
+                expect(id1).not.toBe(id3);
+                expect(id2).not.toBe(id3);
+            });
+
+            it("should handle unicode characters", () => {
+                const id1 = uniqueId("café");
+                const id2 = uniqueId("naïve");
+                const id3 = uniqueId("über");
+
+                expect(id1).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+                expect(id2).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+                expect(id3).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+                expect(id1).not.toBe(id2);
+                expect(id2).not.toBe(id3);
+            });
+
+            it("should handle emojis", () => {
+                const id1 = uniqueId("hello 👋");
+                const id2 = uniqueId("world 🌍");
+
+                expect(id1).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+                expect(id2).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+                expect(id1).not.toBe(id2);
+            });
+        });
+
+        describe("determinism and consistency", () => {
+            it("should be deterministic across multiple runs", () => {
+                const testString = "test string for determinism";
+                const results = [];
+
+                for (let i = 0; i < 100; i++) {
+                    results.push(uniqueId(testString));
+                }
+
+                // All results should be the same
+                expect(new Set(results).size).toBe(1);
+            });
+
+            it("should generate consistent IDs for long strings", () => {
+                const longString = "The quick brown fox jumps over the lazy dog. ".repeat(10);
+                const id1 = uniqueId(longString);
+                const id2 = uniqueId(longString);
+
+                expect(id1).toBe(id2);
+                expect(id1).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+            });
+
+            it("should handle similar but different strings", () => {
+                const id1 = uniqueId("test");
+                const id2 = uniqueId("test ");
+                const id3 = uniqueId("test1");
+                const id4 = uniqueId("Test");
+
+                expect(id1).not.toBe(id2);
+                expect(id1).not.toBe(id3);
+                expect(id1).not.toBe(id4);
+                expect(id2).not.toBe(id3);
+                expect(id2).not.toBe(id4);
+                expect(id3).not.toBe(id4);
+            });
+        });
+
+        describe("real-world usage", () => {
+            it("should generate unique IDs for typical use cases", () => {
+                const inputs = [
+                    "user-123",
+                    "session-abc-def",
+                    "transaction-2024-01-01",
+                    "order-item-456",
+                    "product-sku-789"
+                ];
+
+                const ids = inputs.map((input) => uniqueId(input));
+
+                // All IDs should be unique
+                expect(new Set(ids).size).toBe(ids.length);
+
+                // All IDs should be valid UUID v4 format
+                ids.forEach((id) => {
+                    expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+                });
+            });
+
+            it("should maintain consistency for repeated inputs in practical scenarios", () => {
+                const userId = "user-12345";
+                const sessionId = "session-abcde";
+
+                // Generate IDs multiple times
+                const userIds = Array(10)
+                    .fill(null)
+                    .map(() => uniqueId(userId));
+                const sessionIds = Array(10)
+                    .fill(null)
+                    .map(() => uniqueId(sessionId));
+
+                // All user IDs should be the same
+                expect(new Set(userIds).size).toBe(1);
+
+                // All session IDs should be the same
+                expect(new Set(sessionIds).size).toBe(1);
+
+                // But user and session IDs should be different
+                expect(userIds[0]).not.toBe(sessionIds[0]);
+            });
+
+            it("should generate valid IDs for paths and URLs", () => {
+                const id1 = uniqueId("/api/users/123");
+                const id2 = uniqueId("https://example.com/resource");
+                const id3 = uniqueId("file:///path/to/file.txt");
+
+                expect(id1).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+                expect(id2).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+                expect(id3).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+                expect(id1).not.toBe(id2);
+                expect(id2).not.toBe(id3);
+            });
+        });
+
+        describe("collision resistance", () => {
+            it("should generate different IDs for a large set of inputs", () => {
+                const ids = new Set<string>();
+                const numInputs = 1000;
+
+                for (let i = 0; i < numInputs; i++) {
+                    const id = uniqueId(`input-${i}`);
+                    ids.add(id);
+                }
+
+                // All IDs should be unique (no collisions)
+                expect(ids.size).toBe(numInputs);
+            });
+
+            it("should generate different IDs for inputs that differ by one character", () => {
+                const ids = [];
+                const baseString = "test-string";
+
+                for (let i = 0; i < 26; i++) {
+                    const char = String.fromCharCode(97 + i); // a-z
+                    ids.push(uniqueId(baseString + char));
+                }
+
+                // All IDs should be unique
+                expect(new Set(ids).size).toBe(26);
             });
         });
     });

--- a/generators/csharp/codegen/src/utils/text.ts
+++ b/generators/csharp/codegen/src/utils/text.ts
@@ -67,3 +67,53 @@ export function camelCase(str: string): string {
         })
         .join("");
 }
+
+/**
+ * Hashes a string to a number.
+ * @param input - The input string to hash
+ * @returns A number generated from the input string
+ *
+ * @example
+ * ```ts
+ * hash("hello") // returns 1000000
+ * hash("WORLD") // returns 1000000
+ * hash("") // returns 0
+ * ```
+ */
+export function hash(input: string): number {
+    let hash = 0;
+    for (const char of input) {
+        hash = (hash << 5) - hash + char.charCodeAt(0);
+    }
+    return hash;
+}
+
+/**
+ * Generates a deterministic unique id from a string.
+ * @param input - The input string to generate a unique id for
+ * @returns A unique id generated from the input string
+ *
+ * @example
+ * ```ts
+ * uniqueId("hello") // returns "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx"
+ * uniqueId("WORLD") // returns "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx"
+ * uniqueId("") // returns "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx"
+ * ```
+ */
+export function uniqueId(input: string): string {
+    // create a unique guid without using thecrypto library.
+    // Seeded pseudo-random number generator
+    function iterate(seed: number): number {
+        const x = Math.sin(seed++) * 10000;
+        return x - Math.floor(x);
+    }
+
+    let seed = hash(input);
+
+    // Generate UUID v4 format using seeded random
+    return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, function (c) {
+        const r = (iterate(seed++) * 16) | 0;
+        const v = c === "x" ? r : (r & 0x3) | 0x8;
+        return v.toString(16);
+    });
+}

--- a/generators/csharp/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/csharp/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -3,9 +3,7 @@ import { assertNever } from "@fern-api/core-utils";
 import { ast, is, WithGeneration } from "@fern-api/csharp-codegen";
 import { FernIr } from "@fern-api/dynamic-ir-sdk";
 import { camelCase, upperFirst } from "lodash-es";
-
 import { Config } from "./Config";
-
 import { DynamicSnippetsGeneratorContext } from "./context/DynamicSnippetsGeneratorContext";
 import { FilePropertyInfo } from "./context/FilePropertyMapper";
 
@@ -375,7 +373,8 @@ export class EndpointSnippetGenerator extends WithGeneration {
                 name: this.context.getParameterName(auth.header.name.name),
                 assignment: this.context.dynamicTypeLiteralMapper.convert({
                     typeReference: auth.header.typeReference,
-                    value: values.value
+                    value: values.value,
+                    fallbackToDefault: auth.header.name.wireValue
                 })
             }
         ];
@@ -429,7 +428,8 @@ export class EndpointSnippetGenerator extends WithGeneration {
     }): ast.TypeLiteral | undefined {
         const typeLiteral = this.context.dynamicTypeLiteralMapper.convert({
             typeReference: header.typeReference,
-            value
+            value,
+            fallbackToDefault: header.name.wireValue
         });
         if (is.TypeLiteral.nop(typeLiteral)) {
             // Literal header values (e.g. "X-API-Version") should not be included in the
@@ -551,7 +551,10 @@ export class EndpointSnippetGenerator extends WithGeneration {
         });
         const headerFields = headers.map((header) => ({
             name: this.context.getPropertyName(header.name.name),
-            value: this.context.dynamicTypeLiteralMapper.convert(header)
+            value: this.context.dynamicTypeLiteralMapper.convert({
+                ...header,
+                fallbackToDefault: header.name.wireValue
+            })
         }));
         this.context.errors.unscope();
 
@@ -612,7 +615,10 @@ export class EndpointSnippetGenerator extends WithGeneration {
         for (const parameter of bodyProperties) {
             fields.push({
                 name: this.context.getPropertyName(parameter.name.name),
-                value: this.context.dynamicTypeLiteralMapper.convert(parameter)
+                value: this.context.dynamicTypeLiteralMapper.convert({
+                    ...parameter,
+                    fallbackToDefault: parameter.name.wireValue
+                })
             });
         }
 
@@ -651,7 +657,11 @@ export class EndpointSnippetGenerator extends WithGeneration {
             case "bytes":
                 return this.getBytesBodyRequestArg({ value });
             case "typeReference":
-                return this.context.dynamicTypeLiteralMapper.convert({ typeReference: body.value, value });
+                return this.context.dynamicTypeLiteralMapper.convert({
+                    typeReference: body.value,
+                    value,
+                    fallbackToDefault: JSON.stringify(body.value)
+                });
             default:
                 assertNever(body);
         }
@@ -700,7 +710,11 @@ export class EndpointSnippetGenerator extends WithGeneration {
                 if (body.value.type === "optional" && value == undefined) {
                     return this.csharp.TypeLiteral.null();
                 }
-                return this.context.dynamicTypeLiteralMapper.convert({ typeReference: body.value, value });
+                return this.context.dynamicTypeLiteralMapper.convert({
+                    typeReference: body.value,
+                    value,
+                    fallbackToDefault: JSON.stringify(body.value)
+                });
             default:
                 assertNever(body);
         }
@@ -744,7 +758,10 @@ export class EndpointSnippetGenerator extends WithGeneration {
         for (const parameter of pathParameters) {
             args.push({
                 name: this.context.getPropertyName(parameter.name.name),
-                value: this.context.dynamicTypeLiteralMapper.convert(parameter)
+                value: this.context.dynamicTypeLiteralMapper.convert({
+                    ...parameter,
+                    fallbackToDefault: parameter.name.wireValue
+                })
             });
         }
         return args;

--- a/generators/csharp/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
+++ b/generators/csharp/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
@@ -9,6 +9,7 @@ export declare namespace DynamicTypeLiteralMapper {
         typeReference: FernIr.dynamic.TypeReference;
         value: unknown;
         as?: ConvertedAs;
+        fallbackToDefault?: string;
     }
 
     // Identifies what the type is being converted as, which sometimes influences how
@@ -36,39 +37,80 @@ export class DynamicTypeLiteralMapper extends WithGeneration {
             });
             return this.csharp.TypeLiteral.nop();
         }
-        if (args.value === undefined) {
+        if (args.value === undefined && !args.fallbackToDefault) {
             return this.csharp.TypeLiteral.nop();
         }
         switch (args.typeReference.type) {
             case "list":
-                return this.convertList({ list: args.typeReference.value, value: args.value });
+                return this.convertList({
+                    list: args.typeReference.value,
+                    value: args.value,
+                    fallbackToDefault: args.fallbackToDefault
+                });
             case "literal":
-                return this.convertLiteral({ literal: args.typeReference.value, value: args.value });
+                return this.convertLiteral({
+                    literal: args.typeReference.value,
+                    value: args.value
+                });
             case "map":
-                return this.convertMap({ map: args.typeReference, value: args.value });
+                return this.convertMap({
+                    map: args.typeReference,
+                    value: args.value,
+                    fallbackToDefault: args.fallbackToDefault
+                });
             case "named": {
                 const named = this.context.resolveNamedType({ typeId: args.typeReference.value });
                 if (named == null) {
                     return this.csharp.TypeLiteral.nop();
                 }
-                return this.convertNamed({ named, value: args.value, as: args.as });
+                return this.convertNamed({
+                    named,
+                    value: args.value,
+                    as: args.as,
+                    fallbackToDefault: args.fallbackToDefault
+                });
             }
             case "nullable":
-                return this.convert({ typeReference: args.typeReference.value, value: args.value, as: args.as });
+                return this.convert({
+                    typeReference: args.typeReference.value,
+                    value: args.value,
+                    as: args.as
+                });
             case "optional":
-                return this.convert({ typeReference: args.typeReference.value, value: args.value, as: args.as });
+                return this.convert({
+                    typeReference: args.typeReference.value,
+                    value: args.value,
+                    as: args.as
+                });
             case "primitive":
-                return this.convertPrimitive({ primitive: args.typeReference.value, value: args.value, as: args.as });
+                return this.convertPrimitive({
+                    primitive: args.typeReference.value,
+                    value: args.value,
+                    as: args.as,
+                    fallbackToDefault: args.fallbackToDefault
+                });
             case "set":
-                return this.convertSet({ set: args.typeReference.value, value: args.value });
+                return this.convertSet({
+                    set: args.typeReference.value,
+                    value: args.value,
+                    fallbackToDefault: args.fallbackToDefault
+                });
             case "unknown":
-                return this.convertUnknown({ value: args.value });
+                return this.convertUnknown({ value: args.value, fallbackToDefault: args.fallbackToDefault });
             default:
                 assertNever(args.typeReference);
         }
     }
 
-    private convertList({ list, value }: { list: FernIr.dynamic.TypeReference; value: unknown }): ast.TypeLiteral {
+    private convertList({
+        list,
+        value,
+        fallbackToDefault
+    }: {
+        list: FernIr.dynamic.TypeReference;
+        value: unknown;
+        fallbackToDefault?: string;
+    }): ast.TypeLiteral {
         if (!Array.isArray(value)) {
             this.context.errors.add({
                 severity: Severity.Critical,
@@ -91,10 +133,12 @@ export class DynamicTypeLiteralMapper extends WithGeneration {
 
     private convertLiteral({
         literal,
-        value
+        value,
+        fallbackToDefault
     }: {
         literal: FernIr.dynamic.LiteralType;
         value: unknown;
+        fallbackToDefault?: string;
     }): ast.TypeLiteral {
         switch (literal.type) {
             case "boolean": {
@@ -107,7 +151,9 @@ export class DynamicTypeLiteralMapper extends WithGeneration {
             case "string": {
                 const str = this.context.getValueAsString({ value });
                 if (str == null) {
-                    return this.csharp.TypeLiteral.nop();
+                    return fallbackToDefault
+                        ? this.csharp.Type.string.getDeterminsticDefault(fallbackToDefault)
+                        : this.csharp.TypeLiteral.nop();
                 }
                 return this.csharp.TypeLiteral.string(str);
             }
@@ -116,7 +162,15 @@ export class DynamicTypeLiteralMapper extends WithGeneration {
         }
     }
 
-    private convertSet({ set, value }: { set: FernIr.dynamic.TypeReference; value: unknown }): ast.TypeLiteral {
+    private convertSet({
+        set,
+        value,
+        fallbackToDefault
+    }: {
+        set: FernIr.dynamic.TypeReference;
+        value: unknown;
+        fallbackToDefault?: string;
+    }): ast.TypeLiteral {
         if (!Array.isArray(value)) {
             this.context.errors.add({
                 severity: Severity.Critical,
@@ -137,7 +191,15 @@ export class DynamicTypeLiteralMapper extends WithGeneration {
         });
     }
 
-    private convertMap({ map, value }: { map: FernIr.dynamic.MapType; value: unknown }): ast.TypeLiteral {
+    private convertMap({
+        map,
+        value,
+        fallbackToDefault
+    }: {
+        map: FernIr.dynamic.MapType;
+        value: unknown;
+        fallbackToDefault?: string;
+    }): ast.TypeLiteral {
         if (typeof value !== "object" || value == null) {
             this.context.errors.add({
                 severity: Severity.Critical,
@@ -168,26 +230,28 @@ export class DynamicTypeLiteralMapper extends WithGeneration {
     private convertNamed({
         named,
         value,
-        as
+        as,
+        fallbackToDefault
     }: {
         named: FernIr.dynamic.NamedType;
         value: unknown;
         as?: DynamicTypeLiteralMapper.ConvertedAs;
+        fallbackToDefault?: string;
     }): ast.TypeLiteral {
         switch (named.type) {
             case "alias":
-                return this.convert({ typeReference: named.typeReference, value, as });
+                return this.convert({ typeReference: named.typeReference, value, as, fallbackToDefault });
             case "discriminatedUnion":
                 if (this.settings.shouldGeneratedDiscriminatedUnions) {
-                    return this.convertDiscriminatedUnion({ discriminatedUnion: named, value });
+                    return this.convertDiscriminatedUnion({ discriminatedUnion: named, value, fallbackToDefault });
                 }
-                return this.convertUnknown({ value });
+                return this.convertUnknown({ value, fallbackToDefault });
             case "enum":
                 return this.getEnumValue(named, value);
             case "object":
-                return this.convertObject({ object_: named, value });
+                return this.convertObject({ object_: named, value, fallbackToDefault });
             case "undiscriminatedUnion":
-                return this.convertUndiscriminatedUnion({ undiscriminatedUnion: named, value });
+                return this.convertUndiscriminatedUnion({ undiscriminatedUnion: named, value, fallbackToDefault });
             default:
                 assertNever(named);
         }
@@ -195,10 +259,12 @@ export class DynamicTypeLiteralMapper extends WithGeneration {
 
     private convertDiscriminatedUnion({
         discriminatedUnion,
-        value
+        value,
+        fallbackToDefault
     }: {
         discriminatedUnion: FernIr.dynamic.DiscriminatedUnionType;
         value: unknown;
+        fallbackToDefault?: string;
     }): ast.TypeLiteral {
         const classReference = this.csharp.classReference({
             origin: discriminatedUnion.declaration,
@@ -374,7 +440,15 @@ export class DynamicTypeLiteralMapper extends WithGeneration {
         );
     }
 
-    private convertObject({ object_, value }: { object_: FernIr.dynamic.ObjectType; value: unknown }): ast.TypeLiteral {
+    private convertObject({
+        object_,
+        value,
+        fallbackToDefault
+    }: {
+        object_: FernIr.dynamic.ObjectType;
+        value: unknown;
+        fallbackToDefault?: string;
+    }): ast.TypeLiteral {
         const properties = this.context.associateByWireValue({
             parameters: object_.properties,
             values: this.context.getRecord(value) ?? {}
@@ -401,10 +475,12 @@ export class DynamicTypeLiteralMapper extends WithGeneration {
 
     private convertUndiscriminatedUnion({
         undiscriminatedUnion,
-        value
+        value,
+        fallbackToDefault
     }: {
         undiscriminatedUnion: FernIr.dynamic.UndiscriminatedUnionType;
         value: unknown;
+        fallbackToDefault?: string;
     }): ast.TypeLiteral {
         const result = this.findMatchingUndiscriminatedUnionType({
             undiscriminatedUnion,
@@ -438,108 +514,142 @@ export class DynamicTypeLiteralMapper extends WithGeneration {
         return undefined;
     }
 
-    private convertUnknown({ value }: { value: unknown }): ast.TypeLiteral {
+    private convertUnknown({
+        value,
+        fallbackToDefault
+    }: {
+        value: unknown;
+        fallbackToDefault?: string;
+    }): ast.TypeLiteral {
         return this.csharp.TypeLiteral.unknown(value);
     }
 
     private convertPrimitive({
         primitive,
         value,
-        as
+        as,
+        fallbackToDefault
     }: {
         primitive: FernIr.dynamic.PrimitiveTypeV1;
         value: unknown;
         as?: DynamicTypeLiteralMapper.ConvertedAs;
+        fallbackToDefault?: string;
     }): ast.TypeLiteral {
         switch (primitive) {
             case "INTEGER": {
                 const num = this.getValueAsNumber({ value, as });
                 if (num == null) {
-                    return this.csharp.TypeLiteral.nop();
+                    return fallbackToDefault
+                        ? this.csharp.Type.integer.getDeterminsticDefault(fallbackToDefault)
+                        : this.csharp.TypeLiteral.nop();
                 }
                 return this.csharp.TypeLiteral.integer(num);
             }
             case "LONG": {
                 const num = this.getValueAsNumber({ value, as });
                 if (num == null) {
-                    return this.csharp.TypeLiteral.nop();
+                    return fallbackToDefault
+                        ? this.csharp.Type.long.getDeterminsticDefault(fallbackToDefault)
+                        : this.csharp.TypeLiteral.nop();
                 }
                 return this.csharp.TypeLiteral.long(num);
             }
             case "UINT": {
                 const num = this.getValueAsNumber({ value, as });
                 if (num == null) {
-                    return this.csharp.TypeLiteral.nop();
+                    return fallbackToDefault
+                        ? this.csharp.Type.uint.getDeterminsticDefault(fallbackToDefault)
+                        : this.csharp.TypeLiteral.nop();
                 }
                 return this.csharp.TypeLiteral.uint(num);
             }
             case "UINT_64": {
                 const num = this.getValueAsNumber({ value, as });
                 if (num == null) {
-                    return this.csharp.TypeLiteral.nop();
+                    return fallbackToDefault
+                        ? this.csharp.Type.ulong.getDeterminsticDefault(fallbackToDefault)
+                        : this.csharp.TypeLiteral.nop();
                 }
                 return this.csharp.TypeLiteral.ulong(num);
             }
             case "FLOAT": {
                 const num = this.getValueAsNumber({ value, as });
                 if (num == null) {
-                    return this.csharp.TypeLiteral.nop();
+                    return fallbackToDefault
+                        ? this.csharp.Type.float.getDeterminsticDefault(fallbackToDefault)
+                        : this.csharp.TypeLiteral.nop();
                 }
                 return this.csharp.TypeLiteral.float(num);
             }
             case "DOUBLE": {
                 const num = this.getValueAsNumber({ value, as });
                 if (num == null) {
-                    return this.csharp.TypeLiteral.nop();
+                    return fallbackToDefault
+                        ? this.csharp.Type.double.getDeterminsticDefault(fallbackToDefault)
+                        : this.csharp.TypeLiteral.nop();
                 }
                 return this.csharp.TypeLiteral.double(num);
             }
             case "BOOLEAN": {
                 const bool = this.getValueAsBoolean({ value, as });
                 if (bool == null) {
-                    return this.csharp.TypeLiteral.nop();
+                    return fallbackToDefault
+                        ? this.csharp.Type.boolean.getDeterminsticDefault(fallbackToDefault)
+                        : this.csharp.TypeLiteral.nop();
                 }
                 return this.csharp.TypeLiteral.boolean(bool);
             }
             case "STRING": {
                 const str = this.context.getValueAsString({ value });
                 if (str == null) {
-                    return this.csharp.TypeLiteral.nop();
+                    return fallbackToDefault
+                        ? this.csharp.Type.string.getDeterminsticDefault(fallbackToDefault)
+                        : this.csharp.TypeLiteral.nop();
                 }
                 return this.csharp.TypeLiteral.string(str);
             }
             case "DATE": {
                 const date = this.context.getValueAsString({ value });
                 if (date == null) {
-                    return this.csharp.TypeLiteral.nop();
+                    return fallbackToDefault
+                        ? this.csharp.Type.dateOnly.getDeterminsticDefault(fallbackToDefault)
+                        : this.csharp.TypeLiteral.nop();
                 }
                 return this.csharp.TypeLiteral.date(date);
             }
             case "DATE_TIME": {
                 const dateTime = this.context.getValueAsString({ value });
                 if (dateTime == null) {
-                    return this.csharp.TypeLiteral.nop();
+                    return fallbackToDefault
+                        ? this.csharp.Type.dateTime.getDeterminsticDefault(fallbackToDefault)
+                        : this.csharp.TypeLiteral.nop();
                 }
                 return this.csharp.TypeLiteral.datetime(dateTime);
             }
             case "UUID": {
                 const uuid = this.context.getValueAsString({ value });
                 if (uuid == null) {
-                    return this.csharp.TypeLiteral.nop();
+                    return fallbackToDefault
+                        ? this.csharp.Type.string.getDeterminsticDefault(fallbackToDefault)
+                        : this.csharp.TypeLiteral.nop();
                 }
                 return this.csharp.TypeLiteral.string(uuid);
             }
             case "BASE_64": {
                 const base64 = this.context.getValueAsString({ value });
                 if (base64 == null) {
-                    return this.csharp.TypeLiteral.nop();
+                    return fallbackToDefault
+                        ? this.csharp.Type.string.getDeterminsticDefault(fallbackToDefault)
+                        : this.csharp.TypeLiteral.nop();
                 }
                 return this.csharp.TypeLiteral.string(base64);
             }
             case "BIG_INTEGER": {
                 const bigInt = this.context.getValueAsString({ value });
                 if (bigInt == null) {
-                    return this.csharp.TypeLiteral.nop();
+                    return fallbackToDefault
+                        ? this.csharp.Type.string.getDeterminsticDefault(fallbackToDefault)
+                        : this.csharp.TypeLiteral.nop();
                 }
                 return this.csharp.TypeLiteral.string(bigInt);
             }

--- a/generators/csharp/sdk/src/endpoint/http/HttpEndpointGenerator.ts
+++ b/generators/csharp/sdk/src/endpoint/http/HttpEndpointGenerator.ts
@@ -821,7 +821,7 @@ export class HttpEndpointGenerator extends AbstractEndpointGenerator {
                                         .filter((each) => each.needsIntialization)
                                         .map((each) => ({
                                             name: each.name,
-                                            value: each.type.getDeterminsticDefault(each.name)
+                                            value: each.type.defaultValue
                                         }))
                                 })
                             );

--- a/generators/csharp/sdk/src/endpoint/http/HttpEndpointGenerator.ts
+++ b/generators/csharp/sdk/src/endpoint/http/HttpEndpointGenerator.ts
@@ -821,7 +821,7 @@ export class HttpEndpointGenerator extends AbstractEndpointGenerator {
                                         .filter((each) => each.needsIntialization)
                                         .map((each) => ({
                                             name: each.name,
-                                            value: each.type.defaultValue
+                                            value: each.type.getDeterminsticDefault(each.name)
                                         }))
                                 })
                             );

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.7.2
+  changelogEntry:
+    - type: fix
+      summary: |
+        Synthesize simple values for dynamic snippets when the example is missing data.
+  createdAt: "2025-11-05"
+  irVersion: 61
+
 - version: 2.7.1
   changelogEntry:
     - type: fix

--- a/seed/csharp-sdk/auth-environment-variables/src/SeedApi.DynamicSnippets/Example0.cs
+++ b/seed/csharp-sdk/auth-environment-variables/src/SeedApi.DynamicSnippets/Example0.cs
@@ -7,6 +7,7 @@ public class Example0
     public async Task Do() {
         var client = new SeedAuthEnvironmentVariablesClient(
             apiKey: "<value>",
+            xAnotherHeader: "<X-Another-Header>",
             clientOptions: new ClientOptions {
                 BaseUrl = "https://api.fern.com"
             }

--- a/seed/csharp-sdk/auth-environment-variables/src/SeedApi.DynamicSnippets/Example1.cs
+++ b/seed/csharp-sdk/auth-environment-variables/src/SeedApi.DynamicSnippets/Example1.cs
@@ -7,6 +7,7 @@ public class Example1
     public async Task Do() {
         var client = new SeedAuthEnvironmentVariablesClient(
             apiKey: "<value>",
+            xAnotherHeader: "<X-Another-Header>",
             clientOptions: new ClientOptions {
                 BaseUrl = "https://api.fern.com"
             }

--- a/seed/csharp-sdk/seed.yml
+++ b/seed/csharp-sdk/seed.yml
@@ -210,5 +210,4 @@ fixtures:
       outputFolder: with-websockets
 allowedFailures:
   - oauth-client-credentials-custom
-  - auth-environment-variables # TODO: Add global headers to ExampleEndpointCall.
  


### PR DESCRIPTION
# Fixing: auth-environment-variables fixture 
- Synthesize simple determininstic values for dynamic snippets when the example is missing data.

> Before
``` c#
 public async Task Do() {
    var client = new SeedAuthEnvironmentVariablesClient(
        apiKey: "<value>",
        clientOptions: new ClientOptions {
            BaseUrl = "https://api.fern.com"
        }
    );

    await client.Service.GetWithApiKeyAsync();
}

```

> After
``` c#
public async Task Do() {
    var client = new SeedAuthEnvironmentVariablesClient(
        apiKey: "<value>",
        xAnotherHeader: "<X-Another-Header>",
        clientOptions: new ClientOptions {
            BaseUrl = "https://api.fern.com"
        }
    );

    await client.Service.GetWithApiKeyAsync();
}
```

## Changes
- Added a new method to the Type class: `getDeterminsticDefault(input: string): TypeLiteral`
  - returns a deterministic default value for the type based on the input string
  - used to generate a default value for a type when no value is provided (we use the name of the field to make the output)


## Testing
- [X] generated seed fixtures
- [X] manual testing
- [X] added new unit tests for text utils
