### PR TITLE
fix(ci): Use org secret instead of repo one

### DIFF
--- a/.github/workflows/fix-lint.yml
+++ b/.github/workflows/fix-lint.yml
@@ -45,7 +45,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v5
         with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
+          token: ${{ secrets.ACTIONS_PAT }}
           commit-message: "fix(lint): auto-fix lint issues"
           title: "fix(lint): auto-fix lint issues"
           branch: automated-lint-fixes
@@ -55,7 +55,7 @@ jobs:
         if: steps.cpr.outputs.pull-request-operation == 'created'
         uses: peter-evans/enable-pull-request-automerge@v3
         with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
+          token: ${{ secrets.ACTIONS_PAT }}
           pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
           merge-method: squash
 

--- a/.github/workflows/nightly-seed-grouping.yml
+++ b/.github/workflows/nightly-seed-grouping.yml
@@ -141,7 +141,7 @@ jobs:
         with:
           path: ./artifacts
           name: ${{ matrix.sdk-name }}-seed-test-log.txt
-          github-token: ${{ secrets.FERN_GITHUB_PAT }}
+          github-token: ${{ secrets.ACTIONS_PAT }}
           repository: ${{ github.repository }}
           merge-multiple: true
 
@@ -228,7 +228,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v5
         with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
+          token: ${{ secrets.ACTIONS_PAT }}
           commit-message: "chore(internal): update seed group files"
           title: "chore(internal): update seed group files"
           branch: update-seed-group-files
@@ -266,7 +266,7 @@ jobs:
         if: steps.cpr.outputs.pull-request-operation == 'created'
         uses: peter-evans/enable-pull-request-automerge@v3
         with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
+          token: ${{ secrets.ACTIONS_PAT }}
           pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
           merge-method: squash
 

--- a/.github/workflows/nightly-seed-metrics.yml
+++ b/.github/workflows/nightly-seed-metrics.yml
@@ -16,6 +16,7 @@ jobs:
   trigger-seed-snapshot-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    if: ${{ github.ref == 'refs/heads/main' }}
     steps:
       # Note: this will trigger to the default branch of the repo, not the workflow_dispatch branch
       - name: Trigger Seed Tests with Metrics
@@ -23,7 +24,7 @@ jobs:
         with:
           token: ${{ secrets.ACTIONS_PAT }}
           event-type: seed-test-metrics
-          client-payload: '{"ref": "refs/heads/main"}'
+          client-payload: '{"ref": "${{ github.ref }}"}'
 
   log-dispatch-rejection:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly-seed-metrics.yml
+++ b/.github/workflows/nightly-seed-metrics.yml
@@ -16,7 +16,6 @@ jobs:
   trigger-seed-snapshot-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: ${{ github.ref == 'refs/heads/main' }}
     steps:
       # Note: this will trigger to the default branch of the repo, not the workflow_dispatch branch
       - name: Trigger Seed Tests with Metrics
@@ -24,7 +23,7 @@ jobs:
         with:
           token: ${{ secrets.ACTIONS_PAT }}
           event-type: seed-test-metrics
-          client-payload: '{"ref": "${{ github.ref }}"}'
+          client-payload: '{"ref": "refs/heads/main"}'
 
   log-dispatch-rejection:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly-seed-metrics.yml
+++ b/.github/workflows/nightly-seed-metrics.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Trigger Seed Tests with Metrics
         uses: peter-evans/repository-dispatch@v2
         with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
+          token: ${{ secrets.ACTIONS_PAT }}
           event-type: seed-test-metrics
           client-payload: '{"ref": "${{ github.ref }}"}'
 

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -1283,7 +1283,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v5
         with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
+          token: ${{ secrets.ACTIONS_PAT }}
           commit-message: "chore(${{ matrix.language-name }}): update ${{ matrix.sdk-name }} seed"
           title: "chore(${{ matrix.language-name }}): update ${{ matrix.sdk-name }} seed"
           branch: update-${{ matrix.sdk-name }}-seed
@@ -1311,7 +1311,7 @@ jobs:
         if: steps.cpr.outputs.pull-request-operation == 'created'
         uses: peter-evans/enable-pull-request-automerge@v3
         with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
+          token: ${{ secrets.ACTIONS_PAT }}
           pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
           merge-method: squash
 

--- a/.github/workflows/write-changelogs-to-docs.yml
+++ b/.github/workflows/write-changelogs-to-docs.yml
@@ -77,7 +77,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
+          token: ${{ secrets.ACTIONS_PAT }}
           commit-message: "update changelogs"
           title: "Update changelogs from fern repo"
           branch: update-changelogs
@@ -88,7 +88,7 @@ jobs:
         if: steps.cpr.outputs.pull-request-operation == 'created'
         uses: peter-evans/enable-pull-request-automerge@v3
         with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
+          token: ${{ secrets.ACTIONS_PAT }}
           pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
           repository: fern-api/docs
           merge-method: squash


### PR DESCRIPTION
## Description
Fix failing CI

## Changes Made
Use org-level secret

## Testing
CI failed last night: https://github.com/fern-api/fern/actions/runs/19163450722/job/54801882624
Passed on this branch: https://github.com/fern-api/fern/actions/runs/19172758456
