### PR TITLE
fix(ci): Use new org secret to update docs

### DIFF
--- a/.github/workflows/write-changelogs-to-docs.yml
+++ b/.github/workflows/write-changelogs-to-docs.yml
@@ -77,7 +77,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.ACTIONS_PAT }}
+          token: ${{ secrets.FERN_SUPPORT_GH_ACTIONS_PAT }}
           commit-message: "update changelogs"
           title: "Update changelogs from fern repo"
           branch: update-changelogs
@@ -88,7 +88,7 @@ jobs:
         if: steps.cpr.outputs.pull-request-operation == 'created'
         uses: peter-evans/enable-pull-request-automerge@v3
         with:
-          token: ${{ secrets.ACTIONS_PAT }}
+          token: ${{ secrets.FERN_SUPPORT_GH_ACTIONS_PAT }}
           pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
           repository: fern-api/docs
           merge-method: squash


### PR DESCRIPTION
## Description
Automated PRs for updating the docs repo were failing

## Changes Made
Moved to a newly created org-level secret

## Testing
Testing in CI: https://github.com/fern-api/fern/actions/runs/19173703587/job/54812795075
Successfully updated docs here: https://github.com/fern-api/docs/pull/1839
