### PR TITLE
fix(swift): encode query params with string enum type to string

### DIFF
--- a/generators/swift/sdk/src/generators/client/EndpointMethodGenerator.ts
+++ b/generators/swift/sdk/src/generators/client/EndpointMethodGenerator.ts
@@ -438,7 +438,10 @@ export class EndpointMethodGenerator {
         if (typeReference.variant.type === "nullable") {
             return this.inferQueryParamCaseName(typeReference.nonNullable());
         }
-        if (this.referencer.resolvesToTheSwiftType(typeReference, "String")) {
+        if (
+            this.referencer.resolvesToTheSwiftType(typeReference, "String") ||
+            this.referencer.resolvesToAnEnumWithRawValues(typeReference)
+        ) {
             return "string";
         }
         if (this.referencer.resolvesToTheSwiftType(typeReference, "Bool")) {

--- a/generators/swift/sdk/versions.yml
+++ b/generators/swift/sdk/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.23.2
+  changelogEntry:
+    - type: fix
+      summary: |
+        Fixes a bug where query parameters with string enum types were incorrectly omitted from the request URL.
+  createdAt: "2025-11-07"
+  irVersion: 61
+
 - version: 0.23.1
   changelogEntry:
     - type: fix

--- a/seed/swift-sdk/enum/Sources/Resources/QueryParam/QueryParamClient.swift
+++ b/seed/swift-sdk/enum/Sources/Resources/QueryParam/QueryParamClient.swift
@@ -12,8 +12,8 @@ public final class QueryParamClient: Sendable {
             method: .post,
             path: "/query",
             queryParams: [
-                "operand": .unknown(operand.rawValue), 
-                "maybeOperand": maybeOperand.map { .unknown($0.rawValue) }, 
+                "operand": .string(operand.rawValue), 
+                "maybeOperand": maybeOperand.map { .string($0.rawValue) }, 
                 "operandOrColor": .unknown(operandOrColor), 
                 "maybeOperandOrColor": maybeOperandOrColor.map { .unknown($0) }
             ],
@@ -26,8 +26,8 @@ public final class QueryParamClient: Sendable {
             method: .post,
             path: "/query-list",
             queryParams: [
-                "operand": .unknown(operand.rawValue), 
-                "maybeOperand": maybeOperand.map { .unknown($0.rawValue) }, 
+                "operand": .string(operand.rawValue), 
+                "maybeOperand": maybeOperand.map { .string($0.rawValue) }, 
                 "operandOrColor": .unknown(operandOrColor), 
                 "maybeOperandOrColor": maybeOperandOrColor.map { .unknown($0) }
             ],

--- a/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Resources/NullableOptional/NullableOptionalClient_.swift
+++ b/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Resources/NullableOptional/NullableOptionalClient_.swift
@@ -140,9 +140,9 @@ public final class NullableOptionalClient_: Sendable {
             method: .get,
             path: "/api/users/filter",
             queryParams: [
-                "role": role.wrappedValue.map { .unknown($0) }, 
-                "status": status.map { .unknown($0.rawValue) }, 
-                "secondaryRole": secondaryRole?.wrappedValue.map { .unknown($0) }
+                "role": role.wrappedValue.map { .string($0) }, 
+                "status": status.map { .string($0.rawValue) }, 
+                "secondaryRole": secondaryRole?.wrappedValue.map { .string($0) }
             ],
             requestOptions: requestOptions,
             responseType: [UserResponse].self

--- a/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Resources/NullableOptional/NullableOptionalClient_.swift
+++ b/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Resources/NullableOptional/NullableOptionalClient_.swift
@@ -140,9 +140,9 @@ public final class NullableOptionalClient_: Sendable {
             method: .get,
             path: "/api/users/filter",
             queryParams: [
-                "role": role.wrappedValue.map { .unknown($0) }, 
-                "status": status.map { .unknown($0.rawValue) }, 
-                "secondaryRole": secondaryRole?.wrappedValue.map { .unknown($0) }
+                "role": role.wrappedValue.map { .string($0) }, 
+                "status": status.map { .string($0.rawValue) }, 
+                "secondaryRole": secondaryRole?.wrappedValue.map { .string($0) }
             ],
             requestOptions: requestOptions,
             responseType: [UserResponse].self

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Resources/InlineUsers/InlineUsers/InlineUsersInlineUsersClient.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Resources/InlineUsers/InlineUsers/InlineUsersInlineUsersClient.swift
@@ -14,7 +14,7 @@ public final class InlineUsersInlineUsersClient: Sendable {
             queryParams: [
                 "page": page.map { .int($0) }, 
                 "per_page": perPage.map { .int($0) }, 
-                "order": order.map { .unknown($0.rawValue) }, 
+                "order": order.map { .string($0.rawValue) }, 
                 "starting_after": startingAfter.map { .string($0) }
             ],
             requestOptions: requestOptions,
@@ -51,7 +51,7 @@ public final class InlineUsersInlineUsersClient: Sendable {
             queryParams: [
                 "page": page.map { .int($0) }, 
                 "per_page": perPage.map { .int($0) }, 
-                "order": order.map { .unknown($0.rawValue) }, 
+                "order": order.map { .string($0.rawValue) }, 
                 "starting_after": startingAfter.map { .string($0) }
             ],
             requestOptions: requestOptions,
@@ -66,7 +66,7 @@ public final class InlineUsersInlineUsersClient: Sendable {
             queryParams: [
                 "page": page.map { .double($0) }, 
                 "per_page": perPage.map { .double($0) }, 
-                "order": order.map { .unknown($0.rawValue) }, 
+                "order": order.map { .string($0.rawValue) }, 
                 "starting_after": startingAfter.map { .string($0) }
             ],
             requestOptions: requestOptions,
@@ -91,7 +91,7 @@ public final class InlineUsersInlineUsersClient: Sendable {
             queryParams: [
                 "page": page.map { .int($0) }, 
                 "limit": limit.map { .int($0) }, 
-                "order": order.map { .unknown($0.rawValue) }
+                "order": order.map { .string($0.rawValue) }
             ],
             requestOptions: requestOptions,
             responseType: ListUsersPaginationResponse.self
@@ -105,7 +105,7 @@ public final class InlineUsersInlineUsersClient: Sendable {
             queryParams: [
                 "page": page.map { .int($0) }, 
                 "limit": limit.map { .int($0) }, 
-                "order": order.map { .unknown($0.rawValue) }
+                "order": order.map { .string($0.rawValue) }
             ],
             requestOptions: requestOptions,
             responseType: ListUsersPaginationResponse.self

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Resources/Users/UsersClient.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Resources/Users/UsersClient.swift
@@ -14,7 +14,7 @@ public final class UsersClient: Sendable {
             queryParams: [
                 "page": page.map { .int($0) }, 
                 "per_page": perPage.map { .int($0) }, 
-                "order": order.map { .unknown($0.rawValue) }, 
+                "order": order.map { .string($0.rawValue) }, 
                 "starting_after": startingAfter.map { .string($0) }
             ],
             requestOptions: requestOptions,
@@ -51,7 +51,7 @@ public final class UsersClient: Sendable {
             queryParams: [
                 "page": page.map { .int($0) }, 
                 "per_page": perPage.map { .int($0) }, 
-                "order": order.map { .unknown($0.rawValue) }, 
+                "order": order.map { .string($0.rawValue) }, 
                 "starting_after": startingAfter.map { .string($0) }
             ],
             requestOptions: requestOptions,
@@ -66,7 +66,7 @@ public final class UsersClient: Sendable {
             queryParams: [
                 "page": page.map { .double($0) }, 
                 "per_page": perPage.map { .double($0) }, 
-                "order": order.map { .unknown($0.rawValue) }, 
+                "order": order.map { .string($0.rawValue) }, 
                 "starting_after": startingAfter.map { .string($0) }
             ],
             requestOptions: requestOptions,
@@ -91,7 +91,7 @@ public final class UsersClient: Sendable {
             queryParams: [
                 "page": page.map { .int($0) }, 
                 "limit": limit.map { .int($0) }, 
-                "order": order.map { .unknown($0.rawValue) }
+                "order": order.map { .string($0.rawValue) }
             ],
             requestOptions: requestOptions,
             responseType: ListUsersPaginationResponseType.self
@@ -105,7 +105,7 @@ public final class UsersClient: Sendable {
             queryParams: [
                 "page": page.map { .int($0) }, 
                 "limit": limit.map { .int($0) }, 
-                "order": order.map { .unknown($0.rawValue) }
+                "order": order.map { .string($0.rawValue) }
             ],
             requestOptions: requestOptions,
             responseType: ListUsersPaginationResponseType.self

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Resources/InlineUsers/InlineUsers/InlineUsersInlineUsersClient.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Resources/InlineUsers/InlineUsers/InlineUsersInlineUsersClient.swift
@@ -14,7 +14,7 @@ public final class InlineUsersInlineUsersClient: Sendable {
             queryParams: [
                 "page": page.map { .int($0) }, 
                 "per_page": perPage.map { .int($0) }, 
-                "order": order.map { .unknown($0.rawValue) }, 
+                "order": order.map { .string($0.rawValue) }, 
                 "starting_after": startingAfter.map { .string($0) }
             ],
             requestOptions: requestOptions,
@@ -51,7 +51,7 @@ public final class InlineUsersInlineUsersClient: Sendable {
             queryParams: [
                 "page": page.map { .int($0) }, 
                 "per_page": perPage.map { .int($0) }, 
-                "order": order.map { .unknown($0.rawValue) }, 
+                "order": order.map { .string($0.rawValue) }, 
                 "starting_after": startingAfter.map { .string($0) }
             ],
             requestOptions: requestOptions,
@@ -66,7 +66,7 @@ public final class InlineUsersInlineUsersClient: Sendable {
             queryParams: [
                 "page": page.map { .double($0) }, 
                 "per_page": perPage.map { .double($0) }, 
-                "order": order.map { .unknown($0.rawValue) }, 
+                "order": order.map { .string($0.rawValue) }, 
                 "starting_after": startingAfter.map { .string($0) }
             ],
             requestOptions: requestOptions,
@@ -91,7 +91,7 @@ public final class InlineUsersInlineUsersClient: Sendable {
             queryParams: [
                 "page": page.map { .int($0) }, 
                 "limit": limit.map { .int($0) }, 
-                "order": order.map { .unknown($0.rawValue) }
+                "order": order.map { .string($0.rawValue) }
             ],
             requestOptions: requestOptions,
             responseType: ListUsersPaginationResponse.self
@@ -105,7 +105,7 @@ public final class InlineUsersInlineUsersClient: Sendable {
             queryParams: [
                 "page": page.map { .int($0) }, 
                 "limit": limit.map { .int($0) }, 
-                "order": order.map { .unknown($0.rawValue) }
+                "order": order.map { .string($0.rawValue) }
             ],
             requestOptions: requestOptions,
             responseType: ListUsersPaginationResponse.self

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Resources/Users/UsersClient.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Resources/Users/UsersClient.swift
@@ -14,7 +14,7 @@ public final class UsersClient: Sendable {
             queryParams: [
                 "page": page.map { .int($0) }, 
                 "per_page": perPage.map { .int($0) }, 
-                "order": order.map { .unknown($0.rawValue) }, 
+                "order": order.map { .string($0.rawValue) }, 
                 "starting_after": startingAfter.map { .string($0) }
             ],
             requestOptions: requestOptions,
@@ -51,7 +51,7 @@ public final class UsersClient: Sendable {
             queryParams: [
                 "page": page.map { .int($0) }, 
                 "per_page": perPage.map { .int($0) }, 
-                "order": order.map { .unknown($0.rawValue) }, 
+                "order": order.map { .string($0.rawValue) }, 
                 "starting_after": startingAfter.map { .string($0) }
             ],
             requestOptions: requestOptions,
@@ -66,7 +66,7 @@ public final class UsersClient: Sendable {
             queryParams: [
                 "page": page.map { .double($0) }, 
                 "per_page": perPage.map { .double($0) }, 
-                "order": order.map { .unknown($0.rawValue) }, 
+                "order": order.map { .string($0.rawValue) }, 
                 "starting_after": startingAfter.map { .string($0) }
             ],
             requestOptions: requestOptions,
@@ -91,7 +91,7 @@ public final class UsersClient: Sendable {
             queryParams: [
                 "page": page.map { .int($0) }, 
                 "limit": limit.map { .int($0) }, 
-                "order": order.map { .unknown($0.rawValue) }
+                "order": order.map { .string($0.rawValue) }
             ],
             requestOptions: requestOptions,
             responseType: ListUsersPaginationResponseType.self
@@ -105,7 +105,7 @@ public final class UsersClient: Sendable {
             queryParams: [
                 "page": page.map { .int($0) }, 
                 "limit": limit.map { .int($0) }, 
-                "order": order.map { .unknown($0.rawValue) }
+                "order": order.map { .string($0.rawValue) }
             ],
             requestOptions: requestOptions,
             responseType: ListUsersPaginationResponseType.self

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Resources/InlineUsers/InlineUsers/InlineUsersInlineUsersClient.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Resources/InlineUsers/InlineUsers/InlineUsersInlineUsersClient.swift
@@ -14,7 +14,7 @@ public final class InlineUsersInlineUsersClient: Sendable {
             queryParams: [
                 "page": page.map { .int($0) }, 
                 "per_page": perPage.map { .int($0) }, 
-                "order": order.map { .unknown($0.rawValue) }, 
+                "order": order.map { .string($0.rawValue) }, 
                 "starting_after": startingAfter.map { .string($0) }
             ],
             requestOptions: requestOptions,
@@ -51,7 +51,7 @@ public final class InlineUsersInlineUsersClient: Sendable {
             queryParams: [
                 "page": page.map { .int($0) }, 
                 "per_page": perPage.map { .int($0) }, 
-                "order": order.map { .unknown($0.rawValue) }, 
+                "order": order.map { .string($0.rawValue) }, 
                 "starting_after": startingAfter.map { .string($0) }
             ],
             requestOptions: requestOptions,
@@ -66,7 +66,7 @@ public final class InlineUsersInlineUsersClient: Sendable {
             queryParams: [
                 "page": page.map { .double($0) }, 
                 "per_page": perPage.map { .double($0) }, 
-                "order": order.map { .unknown($0.rawValue) }, 
+                "order": order.map { .string($0.rawValue) }, 
                 "starting_after": startingAfter.map { .string($0) }
             ],
             requestOptions: requestOptions,
@@ -91,7 +91,7 @@ public final class InlineUsersInlineUsersClient: Sendable {
             queryParams: [
                 "page": page.map { .int($0) }, 
                 "limit": limit.map { .int($0) }, 
-                "order": order.map { .unknown($0.rawValue) }
+                "order": order.map { .string($0.rawValue) }
             ],
             requestOptions: requestOptions,
             responseType: ListUsersPaginationResponse.self
@@ -105,7 +105,7 @@ public final class InlineUsersInlineUsersClient: Sendable {
             queryParams: [
                 "page": page.map { .int($0) }, 
                 "limit": limit.map { .int($0) }, 
-                "order": order.map { .unknown($0.rawValue) }
+                "order": order.map { .string($0.rawValue) }
             ],
             requestOptions: requestOptions,
             responseType: ListUsersPaginationResponse.self

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Resources/Users/UsersClient.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Resources/Users/UsersClient.swift
@@ -14,7 +14,7 @@ public final class UsersClient: Sendable {
             queryParams: [
                 "page": page.map { .int($0) }, 
                 "per_page": perPage.map { .int($0) }, 
-                "order": order.map { .unknown($0.rawValue) }, 
+                "order": order.map { .string($0.rawValue) }, 
                 "starting_after": startingAfter.map { .string($0) }
             ],
             requestOptions: requestOptions,
@@ -51,7 +51,7 @@ public final class UsersClient: Sendable {
             queryParams: [
                 "page": page.map { .int($0) }, 
                 "per_page": perPage.map { .int($0) }, 
-                "order": order.map { .unknown($0.rawValue) }, 
+                "order": order.map { .string($0.rawValue) }, 
                 "starting_after": startingAfter.map { .string($0) }
             ],
             requestOptions: requestOptions,
@@ -66,7 +66,7 @@ public final class UsersClient: Sendable {
             queryParams: [
                 "page": page.map { .double($0) }, 
                 "per_page": perPage.map { .double($0) }, 
-                "order": order.map { .unknown($0.rawValue) }, 
+                "order": order.map { .string($0.rawValue) }, 
                 "starting_after": startingAfter.map { .string($0) }
             ],
             requestOptions: requestOptions,
@@ -91,7 +91,7 @@ public final class UsersClient: Sendable {
             queryParams: [
                 "page": page.map { .int($0) }, 
                 "limit": limit.map { .int($0) }, 
-                "order": order.map { .unknown($0.rawValue) }
+                "order": order.map { .string($0.rawValue) }
             ],
             requestOptions: requestOptions,
             responseType: ListUsersPaginationResponseType.self
@@ -105,7 +105,7 @@ public final class UsersClient: Sendable {
             queryParams: [
                 "page": page.map { .int($0) }, 
                 "limit": limit.map { .int($0) }, 
-                "order": order.map { .unknown($0.rawValue) }
+                "order": order.map { .string($0.rawValue) }
             ],
             requestOptions: requestOptions,
             responseType: ListUsersPaginationResponseType.self


### PR DESCRIPTION
## Description
Linear ticket: [FER-7621](https://linear.app/buildwithfern/issue/FER-7621/query-params-with-string-enum-types-should-be-serialized-to-string) 
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
<!-- Provide a clear and concise description of the changes made in this PR -->
Query params with string enum type are currently not recognized when building the request URL. This PR fixes the generator to encode them to string.

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Updated the `inferQueryParamCaseName` method to return "string" if the type resolves to an enum with raw values.
- Updated Seed snapshots

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated
- [x] Manual testing completed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Encodes string-enum query params as `.string(...)`, updates seed snapshots accordingly, and bumps Swift SDK version to 0.23.2.
> 
> - **Generator**:
>   - Update `inferQueryParamCaseName` in `generators/swift/sdk/src/generators/client/EndpointMethodGenerator.ts` to treat enums with raw values as `string`.
> - **Seed Snapshots (Swift SDK)**:
>   - Replace `.unknown(...)` with `.string(...)` for enum-based query params in:
>     - `seed/swift-sdk/enum/.../QueryParamClient.swift`
>     - `seed/swift-sdk/nullable-optional/.../NullableOptionalClient_.swift`
>     - Pagination clients under `seed/swift-sdk/pagination/**/UsersClient.swift` and `InlineUsersInlineUsersClient.swift`.
> - **Versioning**:
>   - Update `generators/swift/sdk/versions.yml` to version `0.23.2` with fix changelog.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db13f9c12e08f2b5644729893732aabe912e8721. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->