### PR TITLE
fix(swift): use fully qualified type references in as is files

### DIFF
--- a/generators/swift/base/src/AsIs.ts
+++ b/generators/swift/base/src/AsIs.ts
@@ -101,7 +101,7 @@ const TestAsIsFileSpecs = {
     // Utilities
     HTTPStub: {
         relativePathToDir: "Utilities",
-        filenameWithoutExtension: "HTTPStub",
+        filenameWithoutExtension: "HTTPStub.Template",
         symbols: [{ name: "HTTPStub", shape: { type: "class" } }]
     }
 } satisfies Record<string, swift.AsIsFileSpec<string>>;

--- a/generators/swift/base/src/asIs/Sources/APIErrorResponse.swift
+++ b/generators/swift/base/src/asIs/Sources/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/generators/swift/base/src/asIs/Sources/CalendarDate.swift
+++ b/generators/swift/base/src/asIs/Sources/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/generators/swift/base/src/asIs/Sources/ClientConfig.swift
+++ b/generators/swift/base/src/asIs/Sources/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Foundation.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Foundation.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Foundation.URLSession {
+    let configuration = Foundation.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/generators/swift/base/src/asIs/Sources/ClientConfig.swift
+++ b/generators/swift/base/src/asIs/Sources/ClientConfig.swift
@@ -52,7 +52,7 @@ public final class ClientConfig: Swift.Sendable {
     let headers: [Swift.String: Swift.String]?
     let timeout: Swift.Int
     let maxRetries: Swift.Int
-    let urlSession: Foundation.URLSession
+    let urlSession: Networking.URLSession
 
     init(
         baseURL: Swift.String,
@@ -62,7 +62,7 @@ public final class ClientConfig: Swift.Sendable {
         headers: [Swift.String: Swift.String]? = nil,
         timeout: Swift.Int? = nil,
         maxRetries: Swift.Int? = nil,
-        urlSession: Foundation.URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Swift.Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Swift.Int) -> Foundation.URLSession {
-    let configuration = Foundation.URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/generators/swift/base/src/asIs/Sources/ClientError.swift
+++ b/generators/swift/base/src/asIs/Sources/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/generators/swift/base/src/asIs/Sources/Data+String.swift
+++ b/generators/swift/base/src/asIs/Sources/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/generators/swift/base/src/asIs/Sources/Decoder+AdditionalProperties.swift
+++ b/generators/swift/base/src/asIs/Sources/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/generators/swift/base/src/asIs/Sources/EncodableValue.swift
+++ b/generators/swift/base/src/asIs/Sources/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/generators/swift/base/src/asIs/Sources/Encoder+AdditionalProperties.swift
+++ b/generators/swift/base/src/asIs/Sources/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/generators/swift/base/src/asIs/Sources/FormFile.swift
+++ b/generators/swift/base/src/asIs/Sources/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/generators/swift/base/src/asIs/Sources/HTTP.swift
+++ b/generators/swift/base/src/asIs/Sources/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/generators/swift/base/src/asIs/Sources/HTTPClient.swift
+++ b/generators/swift/base/src/asIs/Sources/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Foundation.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Foundation.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Foundation.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Foundation.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Foundation.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Foundation.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/generators/swift/base/src/asIs/Sources/HTTPClient.swift
+++ b/generators/swift/base/src/asIs/Sources/HTTPClient.swift
@@ -104,12 +104,12 @@ final class HTTPClient: Swift.Sendable {
         requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> Networking.URLRequest {
+    ) async throws -> Foundation.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = Networking.URLRequest(url: url)
+        var request = Foundation.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
@@ -142,22 +142,22 @@ final class HTTPClient: Swift.Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Swift.Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -264,17 +264,17 @@ final class HTTPClient: Swift.Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: Networking.URLRequest,
+        _ request: Foundation.URLRequest,
         requestOptions: RequestOptions? = nil
     ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Foundation.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? Networking.HTTPURLResponse else {
+                guard let httpResponse = response as? Foundation.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -323,7 +323,7 @@ final class HTTPClient: Swift.Sendable {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+    private func getRetryDelay(response: Foundation.HTTPURLResponse, retryAttempt: Swift.Int)
         -> Foundation.TimeInterval
     {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {

--- a/generators/swift/base/src/asIs/Sources/HTTPClient.swift
+++ b/generators/swift/base/src/asIs/Sources/HTTPClient.swift
@@ -104,12 +104,12 @@ final class HTTPClient: Swift.Sendable {
         requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> Foundation.URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = Foundation.URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
@@ -264,17 +264,17 @@ final class HTTPClient: Swift.Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: Foundation.URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
     ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Foundation.Data, Foundation.HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? Foundation.HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -323,7 +323,7 @@ final class HTTPClient: Swift.Sendable {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: Foundation.HTTPURLResponse, retryAttempt: Swift.Int)
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
         -> Foundation.TimeInterval
     {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {

--- a/generators/swift/base/src/asIs/Sources/JSONEncoder+EncodableValue.swift
+++ b/generators/swift/base/src/asIs/Sources/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/generators/swift/base/src/asIs/Sources/JSONValue.swift
+++ b/generators/swift/base/src/asIs/Sources/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/generators/swift/base/src/asIs/Sources/KeyedDecodingContainer+Nullable.swift
+++ b/generators/swift/base/src/asIs/Sources/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/generators/swift/base/src/asIs/Sources/KeyedEncodingContainer+Nullable.swift
+++ b/generators/swift/base/src/asIs/Sources/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/generators/swift/base/src/asIs/Sources/MultipartFormData.swift
+++ b/generators/swift/base/src/asIs/Sources/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/generators/swift/base/src/asIs/Sources/MultipartFormDataConvertible.swift
+++ b/generators/swift/base/src/asIs/Sources/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/generators/swift/base/src/asIs/Sources/MultipartFormField.swift
+++ b/generators/swift/base/src/asIs/Sources/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/generators/swift/base/src/asIs/Sources/Networking.swift
+++ b/generators/swift/base/src/asIs/Sources/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/generators/swift/base/src/asIs/Sources/Nullable.swift
+++ b/generators/swift/base/src/asIs/Sources/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/generators/swift/base/src/asIs/Sources/QueryParameter.swift
+++ b/generators/swift/base/src/asIs/Sources/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/generators/swift/base/src/asIs/Sources/RequestOptions.swift
+++ b/generators/swift/base/src/asIs/Sources/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/generators/swift/base/src/asIs/Sources/Serde.swift
+++ b/generators/swift/base/src/asIs/Sources/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/generators/swift/base/src/asIs/Sources/String+URLEncoding.swift
+++ b/generators/swift/base/src/asIs/Sources/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/generators/swift/base/src/asIs/Sources/StringKey.swift
+++ b/generators/swift/base/src/asIs/Sources/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/generators/swift/base/src/asIs/Tests/HTTPStub.Template.swift
+++ b/generators/swift/base/src/asIs/Tests/HTTPStub.Template.swift
@@ -1,18 +1,19 @@
+import <%= moduleName %>
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/generators/swift/codegen/src/helpers/undiscriminated-union/undiscriminated-union.ts
+++ b/generators/swift/codegen/src/helpers/undiscriminated-union/undiscriminated-union.ts
@@ -20,7 +20,6 @@ const CASE_LABELS_BY_SWIFT_SYMBOL_NAME: Record<swift.SwiftTypeSymbolName, string
 const CASE_LABELS_BY_FOUNDATION_SYMBOL_NAME: Record<swift.FoundationTypeSymbolName, string> = {
     Data: "data",
     Date: "date",
-    URLSession: "urlSession",
     UUID: "uuid"
 };
 

--- a/generators/swift/codegen/src/symbol/as-is.ts
+++ b/generators/swift/codegen/src/symbol/as-is.ts
@@ -17,7 +17,8 @@ export type AsIsSymbolName =
     | "ClientError"
     | "FormFile"
     | "Nullable"
-    | "RequestOptions";
+    | "RequestOptions"
+    | "Networking";
 
 /**
  * Configuration specification for a static Swift file that gets included as-is in the generated SDK.
@@ -153,6 +154,11 @@ export const SourceAsIsFileSpecs = {
         relativePathToDir: "Public",
         filenameWithoutExtension: "JSONValue",
         symbols: [{ name: "JSONValue", shape: { type: "enum-with-associated-values" } }]
+    },
+    Networking: {
+        relativePathToDir: "Public",
+        filenameWithoutExtension: "Networking",
+        symbols: [{ name: "Networking", shape: { type: "enum-container" } }]
     },
     Nullable: {
         relativePathToDir: "Public",

--- a/generators/swift/codegen/src/symbol/symbol.ts
+++ b/generators/swift/codegen/src/symbol/symbol.ts
@@ -15,7 +15,7 @@ export type SwiftTypeSymbolName =
     // TODO(kafkas): Any doesn't seem to be under the Swift scope i.e. Swift.Any is not valid so we probably wanna move this.
     | "Any";
 
-export type FoundationTypeSymbolName = "Data" | "Date" | "URLSession" | "UUID";
+export type FoundationTypeSymbolName = "Data" | "Date" | "UUID";
 
 export class Symbol {
     public static readonly SWIFT_SYMBOL_NAME = "Swift";
@@ -43,7 +43,6 @@ export class Symbol {
     private static foundationTypeSymbolsByName: Record<FoundationTypeSymbolName, Symbol> = {
         Data: Symbol.foundationType("Data"),
         Date: Symbol.foundationType("Date"),
-        URLSession: Symbol.foundationType("URLSession"),
         UUID: Symbol.foundationType("UUID")
     };
     public static foundationTypeSymbols = Object.values(Symbol.foundationTypeSymbolsByName);

--- a/generators/swift/sdk/src/generators/client/RootClientGenerator.ts
+++ b/generators/swift/sdk/src/generators/client/RootClientGenerator.ts
@@ -91,7 +91,9 @@ export class RootClientGenerator {
         return swift.functionParameter({
             argumentLabel: "urlSession",
             unsafeName: "urlSession",
-            type: swift.TypeReference.optional(this.referencer.referenceFoundationType("URLSession")),
+            type: swift.TypeReference.optional(
+                swift.TypeReference.memberAccess(this.referencer.referenceAsIsType("Networking"), "URLSession")
+            ),
             defaultValue: swift.Expression.rawValue("nil"),
             docsContent:
                 "Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout."
@@ -401,7 +403,9 @@ export class RootClientGenerator {
             swift.functionParameter({
                 argumentLabel: "urlSession",
                 unsafeName: "urlSession",
-                type: swift.TypeReference.optional(this.referencer.referenceFoundationType("URLSession")),
+                type: swift.TypeReference.optional(
+                    swift.TypeReference.memberAccess(this.referencer.referenceAsIsType("Networking"), "URLSession")
+                ),
                 defaultValue: swift.Expression.nil()
             })
         ];

--- a/generators/swift/sdk/src/generators/test/TemplateDataGenerator.ts
+++ b/generators/swift/sdk/src/generators/test/TemplateDataGenerator.ts
@@ -38,6 +38,9 @@ export class TemplateDataGenerator {
         if (templateFileName === "ClientRetryTests.Template") {
             return this.generateTemplateDataForClientRetryTests();
         }
+        if (templateFileName === "HTTPStub.Template") {
+            return this.generateTemplateDataForHTTPStub();
+        }
         throw new Error(`Unknown template file "${templateFileName}"`);
     }
 
@@ -154,6 +157,13 @@ export class TemplateDataGenerator {
                     ]
                 })
             ).toStringWithIndentation(4)
+        };
+    }
+
+    private generateTemplateDataForHTTPStub() {
+        const moduleSymbol = this.context.project.nameRegistry.getRegisteredSourceModuleSymbolOrThrow();
+        return {
+            moduleName: moduleSymbol.name
         };
     }
 

--- a/generators/swift/sdk/versions.yml
+++ b/generators/swift/sdk/versions.yml
@@ -1,10 +1,18 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.23.3
+  changelogEntry:
+    - type: fix
+      summary: |
+        All static files within the SDK now use fully qualified type references.
+  createdAt: "2025-11-07"
+  irVersion: 61
+
 - version: 0.23.2
   changelogEntry:
     - type: fix
       summary: |
-        Fixes a bug where query parameters with string enum types were incorrectly omitted from the request URL.
+        Fixed a bug where query parameters with string enum types were incorrectly omitted from the request URL.
   createdAt: "2025-11-07"
   irVersion: 61
 
@@ -12,7 +20,7 @@
   changelogEntry:
     - type: fix
       summary: |
-        Fixes a bug where query parameters with empty values were not omitted from the request URL.
+        Fixed a bug where query parameters with empty values were not omitted from the request URL.
   createdAt: "2025-11-07"
   irVersion: 61
 

--- a/seed/swift-sdk/accept-header/Sources/AcceptClient.swift
+++ b/seed/swift-sdk/accept-header/Sources/AcceptClient.swift
@@ -19,7 +19,7 @@ public final class AcceptClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -47,7 +47,7 @@ public final class AcceptClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -69,7 +69,7 @@ public final class AcceptClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/accept-header/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/accept-header/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/accept-header/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/accept-header/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/accept-header/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/accept-header/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/accept-header/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/accept-header/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Foundation.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Foundation.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,12 +142,12 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
-    ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+    ) -> Foundation.URL {
+        let endpointURL: Swift.String = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
@@ -172,6 +172,15 @@ final class HTTPClient: Sendable {
             } else {
                 components.queryItems?.append(contentsOf: extraItems)
             }
+            components.queryItems = requestQueryParams.map { key, value in
+                Foundation.URLQueryItem(name: key, value: value?.toString())
+            }
+        }
+        if let additionalQueryParams = requestOptions?.additionalQueryParameters {
+            components.queryItems?.append(
+                contentsOf: additionalQueryParams.map { key, value in
+                    Foundation.URLQueryItem(name: key, value: value)
+                })
         }
         guard let url = components.url else {
             preconditionFailure(
@@ -184,9 +193,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +227,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +241,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +273,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Foundation.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Foundation.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Foundation.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +297,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +314,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +328,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Foundation.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +349,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +359,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +404,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/accept-header/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/accept-header/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/accept-header/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/accept-header/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/accept-header/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/accept-header/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/accept-header/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/accept-header/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/accept-header/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/accept-header/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/accept-header/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/accept-header/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/accept-header/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/accept-header/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/accept-header/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/accept-header/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/accept-header/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/accept-header/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/accept-header/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/accept-header/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/accept-header/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/accept-header/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/accept-header/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/accept-header/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/accept-header/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/accept-header/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/accept-header/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/accept-header/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/accept-header/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/accept-header/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Foundation.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Foundation.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Foundation.URLSession {
+    let configuration = Foundation.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/accept-header/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/accept-header/Sources/Public/ClientConfig.swift
@@ -52,7 +52,7 @@ public final class ClientConfig: Swift.Sendable {
     let headers: [Swift.String: Swift.String]?
     let timeout: Swift.Int
     let maxRetries: Swift.Int
-    let urlSession: Foundation.URLSession
+    let urlSession: Networking.URLSession
 
     init(
         baseURL: Swift.String,
@@ -62,7 +62,7 @@ public final class ClientConfig: Swift.Sendable {
         headers: [Swift.String: Swift.String]? = nil,
         timeout: Swift.Int? = nil,
         maxRetries: Swift.Int? = nil,
-        urlSession: Foundation.URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Swift.Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Swift.Int) -> Foundation.URLSession {
-    let configuration = Foundation.URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/accept-header/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/accept-header/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/accept-header/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/accept-header/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/accept-header/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/accept-header/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/accept-header/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/accept-header/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/accept-header/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/accept-header/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/accept-header/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/accept-header/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/accept-header/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/accept-header/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import Accept
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/alias-extends/Sources/AliasExtendsClient.swift
+++ b/seed/swift-sdk/alias-extends/Sources/AliasExtendsClient.swift
@@ -16,7 +16,7 @@ public final class AliasExtendsClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -38,7 +38,7 @@ public final class AliasExtendsClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/alias-extends/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/alias-extends/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/alias-extends/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/alias-extends/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/alias-extends/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/alias-extends/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/alias-extends/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/alias-extends/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/alias-extends/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/alias-extends/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/alias-extends/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/alias-extends/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/alias-extends/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/alias-extends/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/alias-extends/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/alias-extends/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/alias-extends/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/alias-extends/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/alias-extends/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/alias-extends/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/alias-extends/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/alias-extends/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/alias-extends/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/alias-extends/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/alias-extends/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/alias-extends/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/alias-extends/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/alias-extends/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/alias-extends/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/alias-extends/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/alias-extends/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/alias-extends/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/alias-extends/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/alias-extends/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/alias-extends/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/alias-extends/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/alias-extends/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/alias-extends/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/alias-extends/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/alias-extends/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/alias-extends/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/alias-extends/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/alias-extends/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/alias-extends/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/alias-extends/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/alias-extends/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/alias-extends/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/alias-extends/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/alias-extends/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/alias-extends/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/alias-extends/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/alias-extends/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import AliasExtends
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/alias/Sources/AliasClient.swift
+++ b/seed/swift-sdk/alias/Sources/AliasClient.swift
@@ -16,7 +16,7 @@ public final class AliasClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -38,7 +38,7 @@ public final class AliasClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/alias/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/alias/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/alias/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/alias/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/alias/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/alias/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/alias/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/alias/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/alias/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/alias/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/alias/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/alias/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/alias/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/alias/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/alias/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/alias/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/alias/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/alias/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/alias/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/alias/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/alias/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/alias/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/alias/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/alias/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/alias/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/alias/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/alias/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/alias/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/alias/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/alias/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/alias/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/alias/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/alias/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/alias/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/alias/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/alias/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/alias/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/alias/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/alias/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/alias/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/alias/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/alias/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/alias/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/alias/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/alias/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/alias/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/alias/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/alias/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/alias/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/alias/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/alias/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/alias/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import Alias
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/any-auth/Sources/AnyAuthClient.swift
+++ b/seed/swift-sdk/any-auth/Sources/AnyAuthClient.swift
@@ -22,7 +22,7 @@ public final class AnyAuthClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -56,7 +56,7 @@ public final class AnyAuthClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -82,7 +82,7 @@ public final class AnyAuthClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/any-auth/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/any-auth/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/any-auth/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/any-auth/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/any-auth/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/any-auth/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/any-auth/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/any-auth/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/any-auth/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/any-auth/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/any-auth/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/any-auth/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/any-auth/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/any-auth/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/any-auth/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/any-auth/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/any-auth/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/any-auth/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/any-auth/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/any-auth/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/any-auth/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/any-auth/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/any-auth/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/any-auth/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/any-auth/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/any-auth/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/any-auth/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/any-auth/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/any-auth/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/any-auth/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/any-auth/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/any-auth/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/any-auth/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/any-auth/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/any-auth/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/any-auth/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/any-auth/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/any-auth/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/any-auth/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/any-auth/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/any-auth/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/any-auth/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/any-auth/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/any-auth/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/any-auth/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/any-auth/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/any-auth/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/any-auth/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/any-auth/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/any-auth/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/any-auth/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/any-auth/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import AnyAuth
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/api-wide-base-path/Sources/ApiWideBasePathClient.swift
+++ b/seed/swift-sdk/api-wide-base-path/Sources/ApiWideBasePathClient.swift
@@ -17,7 +17,7 @@ public final class ApiWideBasePathClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -39,7 +39,7 @@ public final class ApiWideBasePathClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/api-wide-base-path/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/api-wide-base-path/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/api-wide-base-path/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/api-wide-base-path/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/api-wide-base-path/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/api-wide-base-path/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/api-wide-base-path/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/api-wide-base-path/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/api-wide-base-path/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/api-wide-base-path/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/api-wide-base-path/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/api-wide-base-path/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/api-wide-base-path/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/api-wide-base-path/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/api-wide-base-path/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/api-wide-base-path/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/api-wide-base-path/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/api-wide-base-path/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/api-wide-base-path/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/api-wide-base-path/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/api-wide-base-path/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/api-wide-base-path/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/api-wide-base-path/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/api-wide-base-path/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/api-wide-base-path/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/api-wide-base-path/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/api-wide-base-path/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/api-wide-base-path/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/api-wide-base-path/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/api-wide-base-path/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/api-wide-base-path/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/api-wide-base-path/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/api-wide-base-path/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/api-wide-base-path/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/api-wide-base-path/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/api-wide-base-path/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/api-wide-base-path/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/api-wide-base-path/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/api-wide-base-path/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/api-wide-base-path/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/api-wide-base-path/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/api-wide-base-path/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/api-wide-base-path/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/api-wide-base-path/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/api-wide-base-path/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/api-wide-base-path/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/api-wide-base-path/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/api-wide-base-path/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/api-wide-base-path/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/api-wide-base-path/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/api-wide-base-path/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/api-wide-base-path/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import ApiWideBasePath
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/audiences/Sources/AudiencesClient.swift
+++ b/seed/swift-sdk/audiences/Sources/AudiencesClient.swift
@@ -22,7 +22,7 @@ public final class AudiencesClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -44,7 +44,7 @@ public final class AudiencesClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/audiences/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/audiences/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/audiences/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/audiences/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/audiences/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/audiences/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/audiences/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/audiences/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/audiences/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/audiences/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/audiences/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/audiences/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/audiences/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/audiences/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/audiences/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/audiences/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/audiences/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/audiences/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/audiences/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/audiences/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/audiences/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/audiences/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/audiences/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/audiences/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/audiences/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/audiences/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/audiences/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/audiences/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/audiences/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/audiences/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/audiences/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/audiences/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/audiences/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/audiences/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/audiences/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/audiences/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/audiences/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/audiences/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/audiences/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/audiences/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/audiences/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/audiences/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/audiences/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/audiences/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/audiences/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/audiences/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/audiences/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/audiences/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/audiences/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/audiences/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/audiences/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/audiences/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import Audiences
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/auth-environment-variables/Sources/AuthEnvironmentVariablesClient.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/AuthEnvironmentVariablesClient.swift
@@ -19,7 +19,7 @@ public final class AuthEnvironmentVariablesClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -43,7 +43,7 @@ public final class AuthEnvironmentVariablesClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/auth-environment-variables/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/auth-environment-variables/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/auth-environment-variables/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/auth-environment-variables/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/auth-environment-variables/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/auth-environment-variables/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/auth-environment-variables/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/auth-environment-variables/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/auth-environment-variables/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/auth-environment-variables/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/auth-environment-variables/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/auth-environment-variables/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/auth-environment-variables/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/auth-environment-variables/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/auth-environment-variables/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/auth-environment-variables/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/auth-environment-variables/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/auth-environment-variables/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/auth-environment-variables/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/auth-environment-variables/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/auth-environment-variables/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/auth-environment-variables/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/auth-environment-variables/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/auth-environment-variables/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/auth-environment-variables/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/auth-environment-variables/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/auth-environment-variables/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/auth-environment-variables/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import AuthEnvironmentVariables
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/BasicAuthEnvironmentVariablesClient.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/BasicAuthEnvironmentVariablesClient.swift
@@ -22,7 +22,7 @@ public final class BasicAuthEnvironmentVariablesClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -44,7 +44,7 @@ public final class BasicAuthEnvironmentVariablesClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/basic-auth-environment-variables/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import BasicAuthEnvironmentVariables
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/basic-auth/Sources/BasicAuthClient.swift
+++ b/seed/swift-sdk/basic-auth/Sources/BasicAuthClient.swift
@@ -22,7 +22,7 @@ public final class BasicAuthClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -44,7 +44,7 @@ public final class BasicAuthClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/basic-auth/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/basic-auth/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/basic-auth/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/basic-auth/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/basic-auth/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/basic-auth/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/basic-auth/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/basic-auth/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/basic-auth/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/basic-auth/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/basic-auth/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/basic-auth/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/basic-auth/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/basic-auth/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/basic-auth/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/basic-auth/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/basic-auth/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/basic-auth/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/basic-auth/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/basic-auth/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/basic-auth/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/basic-auth/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/basic-auth/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/basic-auth/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/basic-auth/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/basic-auth/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/basic-auth/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/basic-auth/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/basic-auth/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/basic-auth/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/basic-auth/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/basic-auth/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/basic-auth/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/basic-auth/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/basic-auth/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/basic-auth/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/basic-auth/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/basic-auth/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/basic-auth/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/basic-auth/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/basic-auth/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/basic-auth/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/basic-auth/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/basic-auth/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/basic-auth/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/basic-auth/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/basic-auth/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/basic-auth/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/basic-auth/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/basic-auth/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/basic-auth/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/basic-auth/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import BasicAuth
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/BearerTokenEnvironmentVariableClient.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/BearerTokenEnvironmentVariableClient.swift
@@ -19,7 +19,7 @@ public final class BearerTokenEnvironmentVariableClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -47,7 +47,7 @@ public final class BearerTokenEnvironmentVariableClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -69,7 +69,7 @@ public final class BearerTokenEnvironmentVariableClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/bearer-token-environment-variable/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import BearerTokenEnvironmentVariable
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/bytes-download/Sources/BytesDownloadClient.swift
+++ b/seed/swift-sdk/bytes-download/Sources/BytesDownloadClient.swift
@@ -17,7 +17,7 @@ public final class BytesDownloadClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -39,7 +39,7 @@ public final class BytesDownloadClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/bytes-download/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/bytes-download/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/bytes-download/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/bytes-download/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/bytes-download/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/bytes-download/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/bytes-download/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/bytes-download/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/bytes-download/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/bytes-download/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/bytes-download/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/bytes-download/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/bytes-download/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/bytes-download/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/bytes-download/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/bytes-download/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/bytes-download/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/bytes-download/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/bytes-download/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/bytes-download/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/bytes-download/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/bytes-download/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/bytes-download/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/bytes-download/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/bytes-download/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/bytes-download/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/bytes-download/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import BytesDownload
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/bytes-upload/Sources/BytesUploadClient.swift
+++ b/seed/swift-sdk/bytes-upload/Sources/BytesUploadClient.swift
@@ -17,7 +17,7 @@ public final class BytesUploadClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -39,7 +39,7 @@ public final class BytesUploadClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/bytes-upload/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/bytes-upload/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/bytes-upload/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/bytes-upload/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/bytes-upload/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/bytes-upload/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/bytes-upload/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/bytes-upload/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/bytes-upload/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/bytes-upload/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/bytes-upload/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/bytes-upload/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/bytes-upload/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/bytes-upload/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/bytes-upload/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/bytes-upload/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/bytes-upload/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/bytes-upload/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/bytes-upload/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/bytes-upload/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/bytes-upload/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/bytes-upload/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/bytes-upload/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/bytes-upload/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/bytes-upload/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/bytes-upload/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/bytes-upload/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/bytes-upload/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/bytes-upload/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/bytes-upload/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/bytes-upload/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/bytes-upload/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/bytes-upload/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/bytes-upload/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/bytes-upload/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/bytes-upload/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/bytes-upload/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/bytes-upload/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/bytes-upload/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/bytes-upload/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/bytes-upload/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/bytes-upload/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/bytes-upload/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/bytes-upload/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/bytes-upload/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/bytes-upload/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/bytes-upload/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/bytes-upload/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/bytes-upload/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/bytes-upload/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/bytes-upload/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/bytes-upload/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import BytesUpload
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/circular-references-advanced/Sources/ApiClient.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/ApiClient.swift
@@ -18,7 +18,7 @@ public final class ApiClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -40,7 +40,7 @@ public final class ApiClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/circular-references-advanced/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/circular-references-advanced/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/circular-references-advanced/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/circular-references-advanced/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/circular-references-advanced/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/circular-references-advanced/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/circular-references-advanced/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/circular-references-advanced/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/circular-references-advanced/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/circular-references-advanced/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/circular-references-advanced/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/circular-references-advanced/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/circular-references-advanced/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/circular-references-advanced/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/circular-references-advanced/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/circular-references-advanced/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/circular-references-advanced/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/circular-references-advanced/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/circular-references-advanced/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/circular-references-advanced/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/circular-references-advanced/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/circular-references-advanced/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/circular-references-advanced/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/circular-references-advanced/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/circular-references-advanced/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/circular-references-advanced/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/circular-references-advanced/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import Api
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/circular-references/Sources/ApiClient.swift
+++ b/seed/swift-sdk/circular-references/Sources/ApiClient.swift
@@ -18,7 +18,7 @@ public final class ApiClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -40,7 +40,7 @@ public final class ApiClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/circular-references/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/circular-references/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/circular-references/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/circular-references/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/circular-references/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/circular-references/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/circular-references/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/circular-references/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/circular-references/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/circular-references/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/circular-references/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/circular-references/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/circular-references/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/circular-references/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/circular-references/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/circular-references/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/circular-references/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/circular-references/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/circular-references/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/circular-references/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/circular-references/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/circular-references/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/circular-references/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/circular-references/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/circular-references/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/circular-references/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/circular-references/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/circular-references/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/circular-references/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/circular-references/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/circular-references/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/circular-references/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/circular-references/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/circular-references/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/circular-references/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/circular-references/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/circular-references/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/circular-references/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/circular-references/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/circular-references/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/circular-references/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/circular-references/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/circular-references/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/circular-references/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/circular-references/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/circular-references/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/circular-references/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/circular-references/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/circular-references/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/circular-references/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/circular-references/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/circular-references/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import Api
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/client-side-params/no-custom-config/Sources/ClientSideParamsClient.swift
+++ b/seed/swift-sdk/client-side-params/no-custom-config/Sources/ClientSideParamsClient.swift
@@ -20,7 +20,7 @@ public final class ClientSideParamsClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -50,7 +50,7 @@ public final class ClientSideParamsClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -74,7 +74,7 @@ public final class ClientSideParamsClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/client-side-params/no-custom-config/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/client-side-params/no-custom-config/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/client-side-params/no-custom-config/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/client-side-params/no-custom-config/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/client-side-params/no-custom-config/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/client-side-params/no-custom-config/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/client-side-params/no-custom-config/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/client-side-params/no-custom-config/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/client-side-params/no-custom-config/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/client-side-params/no-custom-config/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/client-side-params/no-custom-config/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/client-side-params/no-custom-config/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/client-side-params/no-custom-config/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/client-side-params/no-custom-config/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/client-side-params/no-custom-config/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/client-side-params/no-custom-config/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/client-side-params/no-custom-config/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/client-side-params/no-custom-config/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/client-side-params/no-custom-config/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/client-side-params/no-custom-config/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/client-side-params/no-custom-config/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/client-side-params/no-custom-config/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/client-side-params/no-custom-config/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/client-side-params/no-custom-config/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/client-side-params/no-custom-config/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/client-side-params/no-custom-config/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/client-side-params/no-custom-config/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/client-side-params/no-custom-config/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/client-side-params/no-custom-config/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/client-side-params/no-custom-config/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/client-side-params/no-custom-config/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/client-side-params/no-custom-config/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/client-side-params/no-custom-config/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/client-side-params/no-custom-config/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/client-side-params/no-custom-config/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/client-side-params/no-custom-config/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/client-side-params/no-custom-config/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/client-side-params/no-custom-config/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/client-side-params/no-custom-config/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/client-side-params/no-custom-config/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/client-side-params/no-custom-config/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/client-side-params/no-custom-config/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/client-side-params/no-custom-config/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/client-side-params/no-custom-config/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/client-side-params/no-custom-config/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/client-side-params/no-custom-config/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/client-side-params/no-custom-config/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/client-side-params/no-custom-config/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/client-side-params/no-custom-config/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/client-side-params/no-custom-config/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/client-side-params/no-custom-config/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/client-side-params/no-custom-config/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import ClientSideParams
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/client-side-params/with-custom-config/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/client-side-params/with-custom-config/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/client-side-params/with-custom-config/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/client-side-params/with-custom-config/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/client-side-params/with-custom-config/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/client-side-params/with-custom-config/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/client-side-params/with-custom-config/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/client-side-params/with-custom-config/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/client-side-params/with-custom-config/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/client-side-params/with-custom-config/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/client-side-params/with-custom-config/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/client-side-params/with-custom-config/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/client-side-params/with-custom-config/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/client-side-params/with-custom-config/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/client-side-params/with-custom-config/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/client-side-params/with-custom-config/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/client-side-params/with-custom-config/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/client-side-params/with-custom-config/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/client-side-params/with-custom-config/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/client-side-params/with-custom-config/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/client-side-params/with-custom-config/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/client-side-params/with-custom-config/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/client-side-params/with-custom-config/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/client-side-params/with-custom-config/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/client-side-params/with-custom-config/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/client-side-params/with-custom-config/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/client-side-params/with-custom-config/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/client-side-params/with-custom-config/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/client-side-params/with-custom-config/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/client-side-params/with-custom-config/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/client-side-params/with-custom-config/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/client-side-params/with-custom-config/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/client-side-params/with-custom-config/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/client-side-params/with-custom-config/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/client-side-params/with-custom-config/Sources/MyCustomClient.swift
+++ b/seed/swift-sdk/client-side-params/with-custom-config/Sources/MyCustomClient.swift
@@ -20,7 +20,7 @@ public final class MyCustomClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -50,7 +50,7 @@ public final class MyCustomClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -74,7 +74,7 @@ public final class MyCustomClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/client-side-params/with-custom-config/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/client-side-params/with-custom-config/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/client-side-params/with-custom-config/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/client-side-params/with-custom-config/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/client-side-params/with-custom-config/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/client-side-params/with-custom-config/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/client-side-params/with-custom-config/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/client-side-params/with-custom-config/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/client-side-params/with-custom-config/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/client-side-params/with-custom-config/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/client-side-params/with-custom-config/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/client-side-params/with-custom-config/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/client-side-params/with-custom-config/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/client-side-params/with-custom-config/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/client-side-params/with-custom-config/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/client-side-params/with-custom-config/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/client-side-params/with-custom-config/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/client-side-params/with-custom-config/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import MyCustomModule
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/content-type/Sources/ContentTypesClient.swift
+++ b/seed/swift-sdk/content-type/Sources/ContentTypesClient.swift
@@ -17,7 +17,7 @@ public final class ContentTypesClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -39,7 +39,7 @@ public final class ContentTypesClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/content-type/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/content-type/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/content-type/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/content-type/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/content-type/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/content-type/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/content-type/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/content-type/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/content-type/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/content-type/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/content-type/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/content-type/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/content-type/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/content-type/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/content-type/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/content-type/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/content-type/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/content-type/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/content-type/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/content-type/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/content-type/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/content-type/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/content-type/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/content-type/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/content-type/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/content-type/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/content-type/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/content-type/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/content-type/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/content-type/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/content-type/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/content-type/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/content-type/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/content-type/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/content-type/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/content-type/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/content-type/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/content-type/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/content-type/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/content-type/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/content-type/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/content-type/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/content-type/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/content-type/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/content-type/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/content-type/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/content-type/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/content-type/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/content-type/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/content-type/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/content-type/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/content-type/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import ContentTypes
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/cross-package-type-names/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/cross-package-type-names/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/cross-package-type-names/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/cross-package-type-names/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/cross-package-type-names/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/cross-package-type-names/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/cross-package-type-names/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/cross-package-type-names/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/cross-package-type-names/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/cross-package-type-names/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/cross-package-type-names/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/cross-package-type-names/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/cross-package-type-names/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/cross-package-type-names/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/cross-package-type-names/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/cross-package-type-names/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/cross-package-type-names/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/cross-package-type-names/Sources/CrossPackageTypeNamesClient.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/CrossPackageTypeNamesClient.swift
@@ -22,7 +22,7 @@ public final class CrossPackageTypeNamesClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -44,7 +44,7 @@ public final class CrossPackageTypeNamesClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/cross-package-type-names/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/cross-package-type-names/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/cross-package-type-names/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/cross-package-type-names/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/cross-package-type-names/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/cross-package-type-names/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/cross-package-type-names/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/cross-package-type-names/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/cross-package-type-names/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/cross-package-type-names/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import CrossPackageTypeNames
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/custom-auth/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/custom-auth/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/custom-auth/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/custom-auth/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/custom-auth/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/custom-auth/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/custom-auth/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/custom-auth/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/custom-auth/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/custom-auth/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/custom-auth/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/custom-auth/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/custom-auth/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/custom-auth/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/custom-auth/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/custom-auth/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/custom-auth/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/custom-auth/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/custom-auth/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/custom-auth/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/custom-auth/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/custom-auth/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/custom-auth/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/custom-auth/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/custom-auth/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/custom-auth/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/custom-auth/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/custom-auth/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/custom-auth/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/custom-auth/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/custom-auth/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/custom-auth/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/custom-auth/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/custom-auth/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/custom-auth/Sources/CustomAuthClient.swift
+++ b/seed/swift-sdk/custom-auth/Sources/CustomAuthClient.swift
@@ -20,7 +20,7 @@ public final class CustomAuthClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -45,7 +45,7 @@ public final class CustomAuthClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/custom-auth/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/custom-auth/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/custom-auth/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/custom-auth/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/custom-auth/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/custom-auth/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/custom-auth/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/custom-auth/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/custom-auth/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/custom-auth/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/custom-auth/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/custom-auth/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/custom-auth/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/custom-auth/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/custom-auth/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/custom-auth/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/custom-auth/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/custom-auth/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import CustomAuth
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/empty-clients/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/empty-clients/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/empty-clients/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/empty-clients/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/empty-clients/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/empty-clients/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/empty-clients/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/empty-clients/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/empty-clients/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/empty-clients/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/empty-clients/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/empty-clients/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/empty-clients/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/empty-clients/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/empty-clients/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/empty-clients/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/empty-clients/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/empty-clients/Sources/EmptyClientsClient.swift
+++ b/seed/swift-sdk/empty-clients/Sources/EmptyClientsClient.swift
@@ -17,7 +17,7 @@ public final class EmptyClientsClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -39,7 +39,7 @@ public final class EmptyClientsClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/empty-clients/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/empty-clients/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/empty-clients/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/empty-clients/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/empty-clients/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/empty-clients/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/empty-clients/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/empty-clients/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/empty-clients/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/empty-clients/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import EmptyClients
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/enum/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/enum/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/enum/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/enum/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/enum/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/enum/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/enum/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/enum/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/enum/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/enum/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/enum/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/enum/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/enum/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/enum/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/enum/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/enum/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/enum/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/enum/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/enum/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/enum/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/enum/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/enum/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/enum/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/enum/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/enum/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/enum/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/enum/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/enum/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/enum/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/enum/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/enum/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/enum/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/enum/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/enum/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/enum/Sources/EnumClient.swift
+++ b/seed/swift-sdk/enum/Sources/EnumClient.swift
@@ -21,7 +21,7 @@ public final class EnumClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -43,7 +43,7 @@ public final class EnumClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/enum/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/enum/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/enum/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/enum/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/enum/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/enum/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/enum/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/enum/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/enum/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/enum/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/enum/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/enum/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/enum/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/enum/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/enum/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/enum/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/enum/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/enum/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import Enum
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/error-property/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/error-property/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/error-property/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/error-property/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/error-property/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/error-property/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/error-property/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/error-property/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/error-property/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/error-property/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/error-property/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/error-property/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/error-property/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/error-property/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/error-property/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/error-property/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/error-property/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/error-property/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/error-property/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/error-property/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/error-property/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/error-property/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/error-property/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/error-property/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/error-property/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/error-property/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/error-property/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/error-property/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/error-property/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/error-property/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/error-property/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/error-property/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/error-property/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/error-property/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/error-property/Sources/ErrorPropertyClient.swift
+++ b/seed/swift-sdk/error-property/Sources/ErrorPropertyClient.swift
@@ -18,7 +18,7 @@ public final class ErrorPropertyClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -40,7 +40,7 @@ public final class ErrorPropertyClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/error-property/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/error-property/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/error-property/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/error-property/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/error-property/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/error-property/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/error-property/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/error-property/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/error-property/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/error-property/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/error-property/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/error-property/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/error-property/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/error-property/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/error-property/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/error-property/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/error-property/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/error-property/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import ErrorProperty
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/errors/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/errors/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/errors/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/errors/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/errors/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/errors/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/errors/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/errors/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/errors/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/errors/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/errors/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/errors/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/errors/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/errors/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/errors/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/errors/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/errors/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/errors/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/errors/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/errors/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/errors/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/errors/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/errors/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/errors/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/errors/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/errors/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/errors/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/errors/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/errors/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/errors/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/errors/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/errors/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/errors/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/errors/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/errors/Sources/ErrorsClient.swift
+++ b/seed/swift-sdk/errors/Sources/ErrorsClient.swift
@@ -18,7 +18,7 @@ public final class ErrorsClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -40,7 +40,7 @@ public final class ErrorsClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/errors/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/errors/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/errors/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/errors/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/errors/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/errors/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/errors/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/errors/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/errors/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/errors/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/errors/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/errors/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/errors/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/errors/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/errors/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/errors/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/errors/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/errors/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import Errors
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/examples/no-custom-config/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/examples/no-custom-config/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/examples/no-custom-config/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/examples/no-custom-config/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/examples/no-custom-config/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/examples/no-custom-config/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/examples/no-custom-config/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/examples/no-custom-config/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/examples/no-custom-config/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/examples/no-custom-config/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/examples/no-custom-config/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/examples/no-custom-config/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/examples/no-custom-config/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/examples/no-custom-config/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/examples/no-custom-config/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/examples/no-custom-config/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/examples/no-custom-config/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/examples/no-custom-config/Sources/ExamplesClient.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Sources/ExamplesClient.swift
@@ -23,7 +23,7 @@ public final class ExamplesClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -53,7 +53,7 @@ public final class ExamplesClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -77,7 +77,7 @@ public final class ExamplesClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/examples/no-custom-config/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/examples/no-custom-config/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/examples/no-custom-config/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/examples/no-custom-config/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/examples/no-custom-config/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/examples/no-custom-config/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/examples/no-custom-config/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/examples/no-custom-config/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/examples/no-custom-config/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import Examples
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/examples/readme-config/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/examples/readme-config/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/examples/readme-config/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/examples/readme-config/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/examples/readme-config/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/examples/readme-config/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/examples/readme-config/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/examples/readme-config/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/examples/readme-config/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/examples/readme-config/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/examples/readme-config/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/examples/readme-config/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/examples/readme-config/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/examples/readme-config/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/examples/readme-config/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/examples/readme-config/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/examples/readme-config/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/examples/readme-config/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/examples/readme-config/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/examples/readme-config/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/examples/readme-config/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/examples/readme-config/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/examples/readme-config/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/examples/readme-config/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/examples/readme-config/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/examples/readme-config/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/examples/readme-config/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/examples/readme-config/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/examples/readme-config/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/examples/readme-config/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/examples/readme-config/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/examples/readme-config/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/examples/readme-config/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/examples/readme-config/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/examples/readme-config/Sources/ExamplesClient.swift
+++ b/seed/swift-sdk/examples/readme-config/Sources/ExamplesClient.swift
@@ -23,7 +23,7 @@ public final class ExamplesClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -53,7 +53,7 @@ public final class ExamplesClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -77,7 +77,7 @@ public final class ExamplesClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/examples/readme-config/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/examples/readme-config/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/examples/readme-config/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/examples/readme-config/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/examples/readme-config/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/examples/readme-config/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/examples/readme-config/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/examples/readme-config/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/examples/readme-config/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/examples/readme-config/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/examples/readme-config/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/examples/readme-config/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/examples/readme-config/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/examples/readme-config/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/examples/readme-config/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/examples/readme-config/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/examples/readme-config/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/examples/readme-config/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import Examples
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/exhaustive/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/exhaustive/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/exhaustive/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/exhaustive/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/exhaustive/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/exhaustive/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/exhaustive/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/exhaustive/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/exhaustive/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/exhaustive/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/exhaustive/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/exhaustive/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/exhaustive/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/exhaustive/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/exhaustive/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/exhaustive/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/exhaustive/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/exhaustive/Sources/ExhaustiveClient.swift
+++ b/seed/swift-sdk/exhaustive/Sources/ExhaustiveClient.swift
@@ -25,7 +25,7 @@ public final class ExhaustiveClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -55,7 +55,7 @@ public final class ExhaustiveClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -79,7 +79,7 @@ public final class ExhaustiveClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/exhaustive/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/exhaustive/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/exhaustive/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/exhaustive/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/exhaustive/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/exhaustive/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/exhaustive/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/exhaustive/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/exhaustive/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/exhaustive/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import Exhaustive
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/extends/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/extends/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/extends/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/extends/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/extends/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/extends/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/extends/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/extends/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/extends/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/extends/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/extends/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/extends/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/extends/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/extends/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/extends/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/extends/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/extends/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/extends/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/extends/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/extends/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/extends/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/extends/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/extends/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/extends/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/extends/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/extends/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/extends/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/extends/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/extends/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/extends/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/extends/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/extends/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/extends/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/extends/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/extends/Sources/ExtendsClient.swift
+++ b/seed/swift-sdk/extends/Sources/ExtendsClient.swift
@@ -16,7 +16,7 @@ public final class ExtendsClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -38,7 +38,7 @@ public final class ExtendsClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/extends/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/extends/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/extends/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/extends/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/extends/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/extends/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/extends/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/extends/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/extends/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/extends/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/extends/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/extends/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/extends/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/extends/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/extends/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/extends/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/extends/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/extends/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import Extends
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/extra-properties/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/extra-properties/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/extra-properties/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/extra-properties/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/extra-properties/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/extra-properties/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/extra-properties/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/extra-properties/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/extra-properties/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/extra-properties/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/extra-properties/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/extra-properties/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/extra-properties/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/extra-properties/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/extra-properties/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/extra-properties/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/extra-properties/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/extra-properties/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/extra-properties/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/extra-properties/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/extra-properties/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/extra-properties/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/extra-properties/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/extra-properties/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/extra-properties/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/extra-properties/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/extra-properties/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/extra-properties/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/extra-properties/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/extra-properties/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/extra-properties/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/extra-properties/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/extra-properties/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/extra-properties/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/extra-properties/Sources/ExtraPropertiesClient.swift
+++ b/seed/swift-sdk/extra-properties/Sources/ExtraPropertiesClient.swift
@@ -17,7 +17,7 @@ public final class ExtraPropertiesClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -39,7 +39,7 @@ public final class ExtraPropertiesClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/extra-properties/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/extra-properties/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/extra-properties/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/extra-properties/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/extra-properties/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/extra-properties/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/extra-properties/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/extra-properties/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/extra-properties/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/extra-properties/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/extra-properties/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/extra-properties/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/extra-properties/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/extra-properties/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/extra-properties/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/extra-properties/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/extra-properties/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/extra-properties/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import ExtraProperties
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/file-download/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/file-download/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/file-download/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/file-download/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/file-download/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/file-download/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/file-download/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/file-download/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/file-download/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/file-download/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/file-download/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/file-download/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/file-download/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/file-download/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/file-download/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/file-download/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/file-download/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/file-download/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/file-download/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/file-download/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/file-download/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/file-download/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/file-download/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/file-download/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/file-download/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/file-download/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/file-download/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/file-download/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/file-download/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/file-download/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/file-download/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/file-download/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/file-download/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/file-download/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/file-download/Sources/FileDownloadClient.swift
+++ b/seed/swift-sdk/file-download/Sources/FileDownloadClient.swift
@@ -17,7 +17,7 @@ public final class FileDownloadClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -39,7 +39,7 @@ public final class FileDownloadClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/file-download/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/file-download/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/file-download/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/file-download/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/file-download/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/file-download/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/file-download/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/file-download/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/file-download/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/file-download/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/file-download/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/file-download/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/file-download/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/file-download/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/file-download/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/file-download/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/file-download/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/file-download/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import FileDownload
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/file-upload-openapi/Sources/ApiClient.swift
+++ b/seed/swift-sdk/file-upload-openapi/Sources/ApiClient.swift
@@ -17,7 +17,7 @@ public final class ApiClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -39,7 +39,7 @@ public final class ApiClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/file-upload-openapi/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/file-upload-openapi/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/file-upload-openapi/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/file-upload-openapi/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/file-upload-openapi/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/file-upload-openapi/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/file-upload-openapi/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/file-upload-openapi/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/file-upload-openapi/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/file-upload-openapi/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/file-upload-openapi/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/file-upload-openapi/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/file-upload-openapi/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/file-upload-openapi/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/file-upload-openapi/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/file-upload-openapi/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/file-upload-openapi/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/file-upload-openapi/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/file-upload-openapi/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/file-upload-openapi/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/file-upload-openapi/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/file-upload-openapi/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/file-upload-openapi/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/file-upload-openapi/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/file-upload-openapi/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/file-upload-openapi/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/file-upload-openapi/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/file-upload-openapi/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/file-upload-openapi/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/file-upload-openapi/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/file-upload-openapi/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/file-upload-openapi/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/file-upload-openapi/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/file-upload-openapi/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/file-upload-openapi/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/file-upload-openapi/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/file-upload-openapi/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/file-upload-openapi/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/file-upload-openapi/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/file-upload-openapi/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/file-upload-openapi/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/file-upload-openapi/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/file-upload-openapi/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/file-upload-openapi/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/file-upload-openapi/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/file-upload-openapi/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/file-upload-openapi/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/file-upload-openapi/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/file-upload-openapi/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/file-upload-openapi/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/file-upload-openapi/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/file-upload-openapi/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import Api
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/file-upload/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/file-upload/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/file-upload/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/file-upload/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/file-upload/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/file-upload/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/file-upload/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/file-upload/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/file-upload/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/file-upload/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/file-upload/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/file-upload/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/file-upload/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/file-upload/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/file-upload/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/file-upload/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/file-upload/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/file-upload/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/file-upload/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/file-upload/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/file-upload/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/file-upload/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/file-upload/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/file-upload/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/file-upload/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/file-upload/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/file-upload/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/file-upload/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/file-upload/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/file-upload/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/file-upload/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/file-upload/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/file-upload/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/file-upload/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/file-upload/Sources/FileUploadClient.swift
+++ b/seed/swift-sdk/file-upload/Sources/FileUploadClient.swift
@@ -17,7 +17,7 @@ public final class FileUploadClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -39,7 +39,7 @@ public final class FileUploadClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/file-upload/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/file-upload/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/file-upload/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/file-upload/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/file-upload/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/file-upload/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/file-upload/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/file-upload/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/file-upload/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/file-upload/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/file-upload/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/file-upload/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/file-upload/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/file-upload/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/file-upload/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/file-upload/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/file-upload/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/file-upload/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import FileUpload
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/folders/Sources/ApiClient.swift
+++ b/seed/swift-sdk/folders/Sources/ApiClient.swift
@@ -18,7 +18,7 @@ public final class ApiClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -40,7 +40,7 @@ public final class ApiClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/folders/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/folders/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/folders/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/folders/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/folders/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/folders/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/folders/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/folders/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/folders/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/folders/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/folders/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/folders/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/folders/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/folders/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/folders/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/folders/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/folders/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/folders/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/folders/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/folders/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/folders/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/folders/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/folders/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/folders/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/folders/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/folders/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/folders/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/folders/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/folders/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/folders/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/folders/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/folders/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/folders/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/folders/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/folders/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/folders/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/folders/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/folders/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/folders/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/folders/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/folders/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/folders/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/folders/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/folders/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/folders/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/folders/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/folders/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/folders/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/folders/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/folders/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/folders/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/folders/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import Api
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/http-head/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/http-head/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/http-head/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/http-head/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/http-head/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/http-head/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/http-head/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/http-head/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/http-head/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/http-head/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/http-head/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/http-head/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/http-head/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/http-head/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/http-head/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/http-head/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/http-head/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/http-head/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/http-head/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/http-head/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/http-head/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/http-head/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/http-head/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/http-head/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/http-head/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/http-head/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/http-head/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/http-head/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/http-head/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/http-head/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/http-head/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/http-head/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/http-head/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/http-head/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/http-head/Sources/HttpHeadClient.swift
+++ b/seed/swift-sdk/http-head/Sources/HttpHeadClient.swift
@@ -17,7 +17,7 @@ public final class HttpHeadClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -39,7 +39,7 @@ public final class HttpHeadClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/http-head/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/http-head/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/http-head/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/http-head/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/http-head/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/http-head/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/http-head/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/http-head/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/http-head/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/http-head/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/http-head/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/http-head/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/http-head/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/http-head/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/http-head/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/http-head/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/http-head/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/http-head/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import HttpHead
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/idempotency-headers/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/idempotency-headers/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/idempotency-headers/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/idempotency-headers/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/idempotency-headers/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/idempotency-headers/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/idempotency-headers/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/idempotency-headers/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/idempotency-headers/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/idempotency-headers/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/idempotency-headers/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/idempotency-headers/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/idempotency-headers/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/idempotency-headers/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/idempotency-headers/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/idempotency-headers/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/idempotency-headers/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/idempotency-headers/Sources/IdempotencyHeadersClient.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/IdempotencyHeadersClient.swift
@@ -19,7 +19,7 @@ public final class IdempotencyHeadersClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -47,7 +47,7 @@ public final class IdempotencyHeadersClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -69,7 +69,7 @@ public final class IdempotencyHeadersClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/idempotency-headers/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/idempotency-headers/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/idempotency-headers/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/idempotency-headers/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/idempotency-headers/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/idempotency-headers/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/idempotency-headers/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/idempotency-headers/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/idempotency-headers/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/idempotency-headers/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import IdempotencyHeaders
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/imdb/Sources/ApiClient.swift
+++ b/seed/swift-sdk/imdb/Sources/ApiClient.swift
@@ -19,7 +19,7 @@ public final class ApiClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -49,7 +49,7 @@ public final class ApiClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -73,7 +73,7 @@ public final class ApiClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/imdb/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/imdb/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/imdb/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/imdb/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/imdb/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/imdb/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/imdb/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/imdb/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/imdb/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/imdb/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/imdb/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/imdb/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/imdb/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/imdb/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/imdb/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/imdb/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/imdb/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/imdb/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/imdb/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/imdb/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/imdb/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/imdb/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/imdb/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/imdb/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/imdb/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/imdb/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/imdb/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/imdb/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/imdb/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/imdb/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/imdb/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/imdb/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/imdb/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/imdb/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/imdb/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/imdb/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/imdb/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/imdb/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/imdb/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/imdb/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/imdb/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/imdb/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/imdb/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/imdb/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/imdb/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/imdb/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/imdb/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/imdb/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/imdb/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/imdb/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/imdb/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/imdb/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import Api
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/inferred-auth-explicit/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/inferred-auth-explicit/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/inferred-auth-explicit/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/inferred-auth-explicit/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/inferred-auth-explicit/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/inferred-auth-explicit/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/inferred-auth-explicit/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/inferred-auth-explicit/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/inferred-auth-explicit/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/inferred-auth-explicit/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/inferred-auth-explicit/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/inferred-auth-explicit/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/inferred-auth-explicit/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/inferred-auth-explicit/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/inferred-auth-explicit/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/inferred-auth-explicit/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/inferred-auth-explicit/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/inferred-auth-explicit/Sources/InferredAuthExplicitClient.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Sources/InferredAuthExplicitClient.swift
@@ -20,7 +20,7 @@ public final class InferredAuthExplicitClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -42,7 +42,7 @@ public final class InferredAuthExplicitClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/inferred-auth-explicit/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/inferred-auth-explicit/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/inferred-auth-explicit/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/inferred-auth-explicit/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/inferred-auth-explicit/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/inferred-auth-explicit/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/inferred-auth-explicit/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/inferred-auth-explicit/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/inferred-auth-explicit/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import InferredAuthExplicit
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/InferredAuthImplicitNoExpiryClient.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/InferredAuthImplicitNoExpiryClient.swift
@@ -20,7 +20,7 @@ public final class InferredAuthImplicitNoExpiryClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -42,7 +42,7 @@ public final class InferredAuthImplicitNoExpiryClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import InferredAuthImplicitNoExpiry
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/inferred-auth-implicit/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/inferred-auth-implicit/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/inferred-auth-implicit/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/inferred-auth-implicit/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/inferred-auth-implicit/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/inferred-auth-implicit/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/inferred-auth-implicit/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/inferred-auth-implicit/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/inferred-auth-implicit/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/inferred-auth-implicit/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/inferred-auth-implicit/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/inferred-auth-implicit/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/inferred-auth-implicit/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/inferred-auth-implicit/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/inferred-auth-implicit/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/inferred-auth-implicit/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/inferred-auth-implicit/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/inferred-auth-implicit/Sources/InferredAuthImplicitClient.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Sources/InferredAuthImplicitClient.swift
@@ -20,7 +20,7 @@ public final class InferredAuthImplicitClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -42,7 +42,7 @@ public final class InferredAuthImplicitClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/inferred-auth-implicit/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/inferred-auth-implicit/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/inferred-auth-implicit/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/inferred-auth-implicit/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/inferred-auth-implicit/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/inferred-auth-implicit/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/inferred-auth-implicit/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/inferred-auth-implicit/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/inferred-auth-implicit/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import InferredAuthImplicit
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/license/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/license/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/license/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/license/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/license/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/license/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/license/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/license/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/license/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/license/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/license/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/license/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/license/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/license/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/license/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/license/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/license/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/license/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/license/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/license/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/license/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/license/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/license/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/license/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/license/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/license/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/license/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/license/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/license/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/license/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/license/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/license/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/license/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/license/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/license/Sources/LicenseClient.swift
+++ b/seed/swift-sdk/license/Sources/LicenseClient.swift
@@ -16,7 +16,7 @@ public final class LicenseClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -38,7 +38,7 @@ public final class LicenseClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/license/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/license/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/license/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/license/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/license/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/license/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/license/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/license/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/license/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/license/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/license/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/license/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/license/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/license/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/license/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/license/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/license/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/license/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import License
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/literals-unions/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/literals-unions/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/literals-unions/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/literals-unions/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/literals-unions/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/literals-unions/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/literals-unions/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/literals-unions/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/literals-unions/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/literals-unions/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/literals-unions/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/literals-unions/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/literals-unions/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/literals-unions/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/literals-unions/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/literals-unions/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/literals-unions/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/literals-unions/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/literals-unions/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/literals-unions/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/literals-unions/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/literals-unions/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/literals-unions/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/literals-unions/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/literals-unions/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/literals-unions/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/literals-unions/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/literals-unions/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/literals-unions/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/literals-unions/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/literals-unions/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/literals-unions/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/literals-unions/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/literals-unions/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/literals-unions/Sources/LiteralsUnionsClient.swift
+++ b/seed/swift-sdk/literals-unions/Sources/LiteralsUnionsClient.swift
@@ -17,7 +17,7 @@ public final class LiteralsUnionsClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -39,7 +39,7 @@ public final class LiteralsUnionsClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/literals-unions/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/literals-unions/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/literals-unions/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/literals-unions/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/literals-unions/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/literals-unions/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/literals-unions/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/literals-unions/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/literals-unions/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/literals-unions/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/literals-unions/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/literals-unions/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/literals-unions/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/literals-unions/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/literals-unions/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/literals-unions/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/literals-unions/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/literals-unions/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import LiteralsUnions
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/mixed-case/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/mixed-case/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/mixed-case/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/mixed-case/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/mixed-case/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/mixed-case/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/mixed-case/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/mixed-case/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/mixed-case/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/mixed-case/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/mixed-case/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/mixed-case/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/mixed-case/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/mixed-case/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/mixed-case/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/mixed-case/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/mixed-case/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/mixed-case/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/mixed-case/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/mixed-case/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/mixed-case/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/mixed-case/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/mixed-case/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/mixed-case/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/mixed-case/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/mixed-case/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/mixed-case/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/mixed-case/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/mixed-case/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/mixed-case/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/mixed-case/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/mixed-case/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/mixed-case/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/mixed-case/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/mixed-case/Sources/MixedCaseClient.swift
+++ b/seed/swift-sdk/mixed-case/Sources/MixedCaseClient.swift
@@ -17,7 +17,7 @@ public final class MixedCaseClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -39,7 +39,7 @@ public final class MixedCaseClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/mixed-case/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/mixed-case/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/mixed-case/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/mixed-case/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/mixed-case/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/mixed-case/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/mixed-case/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/mixed-case/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/mixed-case/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/mixed-case/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/mixed-case/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/mixed-case/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/mixed-case/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/mixed-case/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/mixed-case/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/mixed-case/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/mixed-case/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/mixed-case/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import MixedCase
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/mixed-file-directory/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/mixed-file-directory/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/mixed-file-directory/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/mixed-file-directory/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/mixed-file-directory/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/mixed-file-directory/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/mixed-file-directory/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/mixed-file-directory/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/mixed-file-directory/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/mixed-file-directory/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/mixed-file-directory/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/mixed-file-directory/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/mixed-file-directory/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/mixed-file-directory/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/mixed-file-directory/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/mixed-file-directory/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/mixed-file-directory/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/mixed-file-directory/Sources/MixedFileDirectoryClient.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/MixedFileDirectoryClient.swift
@@ -18,7 +18,7 @@ public final class MixedFileDirectoryClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -40,7 +40,7 @@ public final class MixedFileDirectoryClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/mixed-file-directory/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/mixed-file-directory/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/mixed-file-directory/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/mixed-file-directory/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/mixed-file-directory/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/mixed-file-directory/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/mixed-file-directory/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/mixed-file-directory/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/mixed-file-directory/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/mixed-file-directory/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import MixedFileDirectory
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/multi-line-docs/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/multi-line-docs/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/multi-line-docs/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/multi-line-docs/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/multi-line-docs/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/multi-line-docs/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/multi-line-docs/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/multi-line-docs/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/multi-line-docs/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/multi-line-docs/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/multi-line-docs/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/multi-line-docs/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/multi-line-docs/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/multi-line-docs/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/multi-line-docs/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/multi-line-docs/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/multi-line-docs/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/multi-line-docs/Sources/MultiLineDocsClient.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/MultiLineDocsClient.swift
@@ -17,7 +17,7 @@ public final class MultiLineDocsClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -39,7 +39,7 @@ public final class MultiLineDocsClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/multi-line-docs/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/multi-line-docs/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/multi-line-docs/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/multi-line-docs/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/multi-line-docs/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/multi-line-docs/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/multi-line-docs/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/multi-line-docs/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/multi-line-docs/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/multi-line-docs/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import MultiLineDocs
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/MultiUrlEnvironmentNoDefaultClient.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/MultiUrlEnvironmentNoDefaultClient.swift
@@ -20,7 +20,7 @@ public final class MultiUrlEnvironmentNoDefaultClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -48,7 +48,7 @@ public final class MultiUrlEnvironmentNoDefaultClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -70,7 +70,7 @@ public final class MultiUrlEnvironmentNoDefaultClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/multi-url-environment-no-default/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import MultiUrlEnvironmentNoDefault
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/multi-url-environment/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/multi-url-environment/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/multi-url-environment/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/multi-url-environment/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/multi-url-environment/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/multi-url-environment/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/multi-url-environment/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/multi-url-environment/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/multi-url-environment/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/multi-url-environment/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/multi-url-environment/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/multi-url-environment/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/multi-url-environment/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/multi-url-environment/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/multi-url-environment/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/multi-url-environment/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/multi-url-environment/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/multi-url-environment/Sources/MultiUrlEnvironmentClient.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/MultiUrlEnvironmentClient.swift
@@ -20,7 +20,7 @@ public final class MultiUrlEnvironmentClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -48,7 +48,7 @@ public final class MultiUrlEnvironmentClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -70,7 +70,7 @@ public final class MultiUrlEnvironmentClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/multi-url-environment/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/multi-url-environment/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/multi-url-environment/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/multi-url-environment/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/multi-url-environment/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/multi-url-environment/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/multi-url-environment/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/multi-url-environment/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/multi-url-environment/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/multi-url-environment/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import MultiUrlEnvironment
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/multiple-request-bodies/Sources/ApiClient.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/ApiClient.swift
@@ -18,7 +18,7 @@ public final class ApiClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -46,7 +46,7 @@ public final class ApiClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -68,7 +68,7 @@ public final class ApiClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/multiple-request-bodies/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import Api
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/no-environment/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/no-environment/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/no-environment/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/no-environment/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/no-environment/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/no-environment/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/no-environment/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/no-environment/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/no-environment/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/no-environment/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/no-environment/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/no-environment/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/no-environment/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/no-environment/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/no-environment/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/no-environment/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/no-environment/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/no-environment/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/no-environment/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/no-environment/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/no-environment/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/no-environment/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/no-environment/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/no-environment/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/no-environment/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/no-environment/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/no-environment/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/no-environment/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/no-environment/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/no-environment/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/no-environment/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/no-environment/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/no-environment/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/no-environment/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/no-environment/Sources/NoEnvironmentClient.swift
+++ b/seed/swift-sdk/no-environment/Sources/NoEnvironmentClient.swift
@@ -19,7 +19,7 @@ public final class NoEnvironmentClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -47,7 +47,7 @@ public final class NoEnvironmentClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -69,7 +69,7 @@ public final class NoEnvironmentClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/no-environment/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/no-environment/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/no-environment/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/no-environment/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/no-environment/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/no-environment/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/no-environment/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/no-environment/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/no-environment/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/no-environment/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/no-environment/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/no-environment/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/no-environment/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/no-environment/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/no-environment/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/no-environment/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/no-environment/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/no-environment/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import NoEnvironment
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/no-retries/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/no-retries/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/no-retries/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/no-retries/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/no-retries/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/no-retries/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/no-retries/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/no-retries/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/no-retries/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/no-retries/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/no-retries/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/no-retries/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/no-retries/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/no-retries/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/no-retries/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/no-retries/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/no-retries/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/no-retries/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/no-retries/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/no-retries/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/no-retries/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/no-retries/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/no-retries/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/no-retries/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/no-retries/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/no-retries/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/no-retries/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/no-retries/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/no-retries/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/no-retries/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/no-retries/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/no-retries/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/no-retries/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/no-retries/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/no-retries/Sources/NoRetriesClient.swift
+++ b/seed/swift-sdk/no-retries/Sources/NoRetriesClient.swift
@@ -17,7 +17,7 @@ public final class NoRetriesClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -39,7 +39,7 @@ public final class NoRetriesClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/no-retries/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/no-retries/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/no-retries/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/no-retries/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/no-retries/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/no-retries/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/no-retries/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/no-retries/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/no-retries/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/no-retries/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/no-retries/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/no-retries/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/no-retries/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/no-retries/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/no-retries/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/no-retries/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/no-retries/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/no-retries/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import NoRetries
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/nullable-optional/no-custom-config/Sources/NullableOptionalClient.swift
+++ b/seed/swift-sdk/nullable-optional/no-custom-config/Sources/NullableOptionalClient.swift
@@ -17,7 +17,7 @@ public final class NullableOptionalClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -39,7 +39,7 @@ public final class NullableOptionalClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/nullable-optional/no-custom-config/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/nullable-optional/no-custom-config/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import NullableOptional
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/NullableOptionalClient.swift
+++ b/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/NullableOptionalClient.swift
@@ -17,7 +17,7 @@ public final class NullableOptionalClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -39,7 +39,7 @@ public final class NullableOptionalClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/nullable-optional/nullable-as-optional/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/nullable-optional/nullable-as-optional/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import NullableOptional
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/nullable/no-custom-config/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/nullable/no-custom-config/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/nullable/no-custom-config/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/nullable/no-custom-config/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/nullable/no-custom-config/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/nullable/no-custom-config/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/nullable/no-custom-config/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/nullable/no-custom-config/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/nullable/no-custom-config/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/nullable/no-custom-config/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/nullable/no-custom-config/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/nullable/no-custom-config/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/nullable/no-custom-config/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/nullable/no-custom-config/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/nullable/no-custom-config/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/nullable/no-custom-config/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/nullable/no-custom-config/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/nullable/no-custom-config/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/nullable/no-custom-config/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/nullable/no-custom-config/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/nullable/no-custom-config/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/nullable/no-custom-config/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/nullable/no-custom-config/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/nullable/no-custom-config/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/nullable/no-custom-config/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/nullable/no-custom-config/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/nullable/no-custom-config/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/nullable/no-custom-config/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/nullable/no-custom-config/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/nullable/no-custom-config/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/nullable/no-custom-config/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/nullable/no-custom-config/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/nullable/no-custom-config/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/nullable/no-custom-config/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/nullable/no-custom-config/Sources/NullableClient.swift
+++ b/seed/swift-sdk/nullable/no-custom-config/Sources/NullableClient.swift
@@ -17,7 +17,7 @@ public final class NullableClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -39,7 +39,7 @@ public final class NullableClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/nullable/no-custom-config/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/nullable/no-custom-config/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/nullable/no-custom-config/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/nullable/no-custom-config/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/nullable/no-custom-config/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/nullable/no-custom-config/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/nullable/no-custom-config/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/nullable/no-custom-config/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/nullable/no-custom-config/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/nullable/no-custom-config/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/nullable/no-custom-config/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/nullable/no-custom-config/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/nullable/no-custom-config/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/nullable/no-custom-config/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/nullable/no-custom-config/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/nullable/no-custom-config/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/nullable/no-custom-config/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/nullable/no-custom-config/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import Nullable
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/nullable/nullable-as-optional/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/nullable/nullable-as-optional/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/nullable/nullable-as-optional/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/nullable/nullable-as-optional/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/nullable/nullable-as-optional/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/nullable/nullable-as-optional/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/nullable/nullable-as-optional/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/nullable/nullable-as-optional/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/nullable/nullable-as-optional/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/nullable/nullable-as-optional/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/nullable/nullable-as-optional/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/nullable/nullable-as-optional/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/nullable/nullable-as-optional/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/nullable/nullable-as-optional/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/nullable/nullable-as-optional/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/nullable/nullable-as-optional/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/nullable/nullable-as-optional/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/nullable/nullable-as-optional/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/nullable/nullable-as-optional/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/nullable/nullable-as-optional/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/nullable/nullable-as-optional/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/nullable/nullable-as-optional/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/nullable/nullable-as-optional/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/nullable/nullable-as-optional/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/nullable/nullable-as-optional/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/nullable/nullable-as-optional/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/nullable/nullable-as-optional/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/nullable/nullable-as-optional/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/nullable/nullable-as-optional/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/nullable/nullable-as-optional/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/nullable/nullable-as-optional/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/nullable/nullable-as-optional/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/nullable/nullable-as-optional/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/nullable/nullable-as-optional/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/nullable/nullable-as-optional/Sources/NullableClient.swift
+++ b/seed/swift-sdk/nullable/nullable-as-optional/Sources/NullableClient.swift
@@ -17,7 +17,7 @@ public final class NullableClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -39,7 +39,7 @@ public final class NullableClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/nullable/nullable-as-optional/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/nullable/nullable-as-optional/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/nullable/nullable-as-optional/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/nullable/nullable-as-optional/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/nullable/nullable-as-optional/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/nullable/nullable-as-optional/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/nullable/nullable-as-optional/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/nullable/nullable-as-optional/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/nullable/nullable-as-optional/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/nullable/nullable-as-optional/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/nullable/nullable-as-optional/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/nullable/nullable-as-optional/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/nullable/nullable-as-optional/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/nullable/nullable-as-optional/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/nullable/nullable-as-optional/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/nullable/nullable-as-optional/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/nullable/nullable-as-optional/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/nullable/nullable-as-optional/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import Nullable
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/OauthClientCredentialsClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/OauthClientCredentialsClient.swift
@@ -20,7 +20,7 @@ public final class OauthClientCredentialsClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -42,7 +42,7 @@ public final class OauthClientCredentialsClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/oauth-client-credentials-custom/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import OauthClientCredentials
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/OauthClientCredentialsDefaultClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/OauthClientCredentialsDefaultClient.swift
@@ -20,7 +20,7 @@ public final class OauthClientCredentialsDefaultClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -42,7 +42,7 @@ public final class OauthClientCredentialsDefaultClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/oauth-client-credentials-default/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import OauthClientCredentialsDefault
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/OauthClientCredentialsEnvironmentVariablesClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/OauthClientCredentialsEnvironmentVariablesClient.swift
@@ -20,7 +20,7 @@ public final class OauthClientCredentialsEnvironmentVariablesClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -42,7 +42,7 @@ public final class OauthClientCredentialsEnvironmentVariablesClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import OauthClientCredentialsEnvironmentVariables
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/OauthClientCredentialsClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/OauthClientCredentialsClient.swift
@@ -20,7 +20,7 @@ public final class OauthClientCredentialsClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -42,7 +42,7 @@ public final class OauthClientCredentialsClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import OauthClientCredentials
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/OauthClientCredentialsWithVariablesClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/OauthClientCredentialsWithVariablesClient.swift
@@ -21,7 +21,7 @@ public final class OauthClientCredentialsWithVariablesClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -43,7 +43,7 @@ public final class OauthClientCredentialsWithVariablesClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import OauthClientCredentialsWithVariables
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/oauth-client-credentials/Sources/OauthClientCredentialsClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/OauthClientCredentialsClient.swift
@@ -20,7 +20,7 @@ public final class OauthClientCredentialsClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -42,7 +42,7 @@ public final class OauthClientCredentialsClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/oauth-client-credentials/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import OauthClientCredentials
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/object/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/object/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/object/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/object/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/object/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/object/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/object/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/object/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/object/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/object/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/object/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/object/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/object/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/object/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/object/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/object/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/object/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/object/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/object/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/object/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/object/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/object/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/object/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/object/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/object/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/object/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/object/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/object/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/object/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/object/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/object/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/object/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/object/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/object/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/object/Sources/ObjectClient.swift
+++ b/seed/swift-sdk/object/Sources/ObjectClient.swift
@@ -16,7 +16,7 @@ public final class ObjectClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -38,7 +38,7 @@ public final class ObjectClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/object/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/object/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/object/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/object/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/object/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/object/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/object/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/object/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/object/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/object/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/object/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/object/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/object/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/object/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/object/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/object/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/object/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/object/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import Object
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/objects-with-imports/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/objects-with-imports/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/objects-with-imports/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/objects-with-imports/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/objects-with-imports/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/objects-with-imports/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/objects-with-imports/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/objects-with-imports/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/objects-with-imports/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/objects-with-imports/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/objects-with-imports/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/objects-with-imports/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/objects-with-imports/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/objects-with-imports/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/objects-with-imports/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/objects-with-imports/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/objects-with-imports/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/objects-with-imports/Sources/ObjectsWithImportsClient.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/ObjectsWithImportsClient.swift
@@ -18,7 +18,7 @@ public final class ObjectsWithImportsClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -40,7 +40,7 @@ public final class ObjectsWithImportsClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/objects-with-imports/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/objects-with-imports/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/objects-with-imports/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/objects-with-imports/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/objects-with-imports/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/objects-with-imports/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/objects-with-imports/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/objects-with-imports/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/objects-with-imports/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/objects-with-imports/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import ObjectsWithImports
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/optional/Snippets/Example1.swift
+++ b/seed/swift-sdk/optional/Snippets/Example1.swift
@@ -1,0 +1,12 @@
+import Foundation
+import ObjectsWithImports
+
+private func main() async throws {
+    let client = ObjectsWithImportsClient(baseURL: "https://api.fern.com")
+
+    _ = try await client.optional.sendOptionalTypedBody(request: SendOptionalBodyRequest(
+        message: "message"
+    ))
+}
+
+try await main()

--- a/seed/swift-sdk/optional/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/optional/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/optional/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/optional/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/optional/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/optional/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/optional/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/optional/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/optional/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/optional/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/optional/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/optional/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/optional/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/optional/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/optional/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/optional/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/optional/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/optional/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/optional/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/optional/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/optional/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/optional/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/optional/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/optional/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/optional/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/optional/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/optional/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/optional/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/optional/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/optional/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/optional/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/optional/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/optional/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/optional/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/optional/Sources/ObjectsWithImportsClient.swift
+++ b/seed/swift-sdk/optional/Sources/ObjectsWithImportsClient.swift
@@ -17,7 +17,7 @@ public final class ObjectsWithImportsClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -39,7 +39,7 @@ public final class ObjectsWithImportsClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/optional/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/optional/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/optional/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/optional/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/optional/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/optional/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/optional/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/optional/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/optional/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/optional/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/optional/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/optional/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/optional/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/optional/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/optional/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/optional/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/optional/Sources/Resources/Optional/OptionalClient.swift
+++ b/seed/swift-sdk/optional/Sources/Resources/Optional/OptionalClient.swift
@@ -16,4 +16,14 @@ public final class OptionalClient: Sendable {
             responseType: String.self
         )
     }
+
+    public func sendOptionalTypedBody(request: SendOptionalBodyRequest?, requestOptions: RequestOptions? = nil) async throws -> String {
+        return try await httpClient.performRequest(
+            method: .post,
+            path: "/send-optional-typed-body",
+            body: request,
+            requestOptions: requestOptions,
+            responseType: String.self
+        )
+    }
 }

--- a/seed/swift-sdk/optional/Sources/Schemas/SendOptionalBodyRequest.swift
+++ b/seed/swift-sdk/optional/Sources/Schemas/SendOptionalBodyRequest.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+public struct SendOptionalBodyRequest: Codable, Hashable, Sendable {
+    public let message: String
+    /// Additional properties that are not explicitly defined in the schema
+    public let additionalProperties: [String: JSONValue]
+
+    public init(
+        message: String,
+        additionalProperties: [String: JSONValue] = .init()
+    ) {
+        self.message = message
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.message = try container.decode(String.self, forKey: .message)
+        self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
+    }
+
+    public func encode(to encoder: Encoder) throws -> Void {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try encoder.encodeAdditionalProperties(self.additionalProperties)
+        try container.encode(self.message, forKey: .message)
+    }
+
+    /// Keys for encoding/decoding struct properties.
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case message
+    }
+}

--- a/seed/swift-sdk/optional/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/optional/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import ObjectsWithImports
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/optional/Tests/Wire/Resources/Optional/OptionalClientWireTests.swift
+++ b/seed/swift-sdk/optional/Tests/Wire/Resources/Optional/OptionalClientWireTests.swift
@@ -27,4 +27,27 @@ import ObjectsWithImports
         )
         try #require(response == expectedResponse)
     }
+
+    @Test func sendOptionalTypedBody1() async throws -> Void {
+        let stub = HTTPStub()
+        stub.setResponse(
+            body: Data(
+                """
+                string
+                """.utf8
+            )
+        )
+        let client = ObjectsWithImportsClient(
+            baseURL: "https://api.fern.com",
+            urlSession: stub.urlSession
+        )
+        let expectedResponse = "string"
+        let response = try await client.optional.sendOptionalTypedBody(
+            request: SendOptionalBodyRequest(
+                message: "message"
+            ),
+            requestOptions: RequestOptions(additionalHeaders: stub.headers)
+        )
+        try #require(response == expectedResponse)
+    }
 }

--- a/seed/swift-sdk/optional/reference.md
+++ b/seed/swift-sdk/optional/reference.md
@@ -61,3 +61,62 @@ try await main()
 </dl>
 </details>
 
+<details><summary><code>client.optional.<a href="/Sources/Resources/Optional/OptionalClient.swift">sendOptionalTypedBody</a>(request: SendOptionalBodyRequest?, requestOptions: RequestOptions?) -> String</code></summary>
+<dl>
+<dd>
+
+#### 🔌 Usage
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+```swift
+import Foundation
+import ObjectsWithImports
+
+private func main() async throws {
+    let client = ObjectsWithImportsClient()
+
+    _ = try await client.optional.sendOptionalTypedBody(request: SendOptionalBodyRequest(
+        message: "message"
+    ))
+}
+
+try await main()
+```
+</dd>
+</dl>
+</dd>
+</dl>
+
+#### ⚙️ Parameters
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+**request:** `SendOptionalBodyRequest?` 
+    
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**requestOptions:** `RequestOptions?` — Additional options for configuring the request, such as custom headers or timeout settings.
+    
+</dd>
+</dl>
+</dd>
+</dl>
+
+
+</dd>
+</dl>
+</details>
+

--- a/seed/swift-sdk/package-yml/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/package-yml/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/package-yml/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/package-yml/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/package-yml/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/package-yml/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/package-yml/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/package-yml/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/package-yml/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/package-yml/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/package-yml/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/package-yml/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/package-yml/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/package-yml/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/package-yml/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/package-yml/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/package-yml/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/package-yml/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/package-yml/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/package-yml/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/package-yml/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/package-yml/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/package-yml/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/package-yml/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/package-yml/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/package-yml/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/package-yml/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/package-yml/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/package-yml/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/package-yml/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/package-yml/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/package-yml/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/package-yml/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/package-yml/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/package-yml/Sources/PackageYmlClient.swift
+++ b/seed/swift-sdk/package-yml/Sources/PackageYmlClient.swift
@@ -17,7 +17,7 @@ public final class PackageYmlClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -39,7 +39,7 @@ public final class PackageYmlClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/package-yml/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/package-yml/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/package-yml/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/package-yml/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/package-yml/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/package-yml/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/package-yml/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/package-yml/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/package-yml/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/package-yml/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/package-yml/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/package-yml/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/package-yml/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/package-yml/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/package-yml/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/package-yml/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/package-yml/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/package-yml/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import PackageYml
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/pagination-custom/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/pagination-custom/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/pagination-custom/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/pagination-custom/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/pagination-custom/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/pagination-custom/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/pagination-custom/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/pagination-custom/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/pagination-custom/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/pagination-custom/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/pagination-custom/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/pagination-custom/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/pagination-custom/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/pagination-custom/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/pagination-custom/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/pagination-custom/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/pagination-custom/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/pagination-custom/Sources/PaginationClient.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/PaginationClient.swift
@@ -19,7 +19,7 @@ public final class PaginationClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -49,7 +49,7 @@ public final class PaginationClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -73,7 +73,7 @@ public final class PaginationClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/pagination-custom/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/pagination-custom/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/pagination-custom/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/pagination-custom/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/pagination-custom/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/pagination-custom/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/pagination-custom/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/pagination-custom/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/pagination-custom/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/pagination-custom/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import Pagination
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/PaginationClient.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/PaginationClient.swift
@@ -21,7 +21,7 @@ public final class PaginationClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -51,7 +51,7 @@ public final class PaginationClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -75,7 +75,7 @@ public final class PaginationClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import Pagination
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/pagination/custom-pager/Sources/PaginationClient.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/PaginationClient.swift
@@ -21,7 +21,7 @@ public final class PaginationClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -51,7 +51,7 @@ public final class PaginationClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -75,7 +75,7 @@ public final class PaginationClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/pagination/custom-pager/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import Pagination
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/PaginationClient.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/PaginationClient.swift
@@ -21,7 +21,7 @@ public final class PaginationClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -51,7 +51,7 @@ public final class PaginationClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -75,7 +75,7 @@ public final class PaginationClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/pagination/no-custom-config/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import Pagination
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/path-parameters/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/path-parameters/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/path-parameters/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/path-parameters/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/path-parameters/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/path-parameters/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/path-parameters/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/path-parameters/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/path-parameters/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/path-parameters/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/path-parameters/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/path-parameters/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/path-parameters/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/path-parameters/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/path-parameters/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/path-parameters/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/path-parameters/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/path-parameters/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/path-parameters/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/path-parameters/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/path-parameters/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/path-parameters/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/path-parameters/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/path-parameters/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/path-parameters/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/path-parameters/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/path-parameters/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/path-parameters/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/path-parameters/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/path-parameters/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/path-parameters/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/path-parameters/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/path-parameters/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/path-parameters/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/path-parameters/Sources/PathParametersClient.swift
+++ b/seed/swift-sdk/path-parameters/Sources/PathParametersClient.swift
@@ -18,7 +18,7 @@ public final class PathParametersClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -40,7 +40,7 @@ public final class PathParametersClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/path-parameters/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/path-parameters/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/path-parameters/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/path-parameters/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/path-parameters/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/path-parameters/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/path-parameters/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/path-parameters/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/path-parameters/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/path-parameters/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/path-parameters/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/path-parameters/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/path-parameters/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/path-parameters/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/path-parameters/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/path-parameters/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/path-parameters/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/path-parameters/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import PathParameters
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/plain-text/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/plain-text/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/plain-text/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/plain-text/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/plain-text/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/plain-text/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/plain-text/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/plain-text/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/plain-text/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/plain-text/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/plain-text/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/plain-text/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/plain-text/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/plain-text/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/plain-text/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/plain-text/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/plain-text/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/plain-text/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/plain-text/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/plain-text/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/plain-text/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/plain-text/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/plain-text/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/plain-text/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/plain-text/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/plain-text/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/plain-text/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/plain-text/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/plain-text/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/plain-text/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/plain-text/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/plain-text/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/plain-text/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/plain-text/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/plain-text/Sources/PlainTextClient.swift
+++ b/seed/swift-sdk/plain-text/Sources/PlainTextClient.swift
@@ -17,7 +17,7 @@ public final class PlainTextClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -39,7 +39,7 @@ public final class PlainTextClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/plain-text/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/plain-text/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/plain-text/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/plain-text/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/plain-text/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/plain-text/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/plain-text/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/plain-text/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/plain-text/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/plain-text/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/plain-text/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/plain-text/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/plain-text/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/plain-text/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/plain-text/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/plain-text/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/plain-text/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/plain-text/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import PlainText
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/property-access/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/property-access/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/property-access/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/property-access/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/property-access/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/property-access/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/property-access/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/property-access/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/property-access/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/property-access/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/property-access/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/property-access/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/property-access/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/property-access/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/property-access/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/property-access/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/property-access/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/property-access/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/property-access/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/property-access/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/property-access/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/property-access/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/property-access/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/property-access/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/property-access/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/property-access/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/property-access/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/property-access/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/property-access/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/property-access/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/property-access/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/property-access/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/property-access/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/property-access/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/property-access/Sources/PropertyAccessClient.swift
+++ b/seed/swift-sdk/property-access/Sources/PropertyAccessClient.swift
@@ -16,7 +16,7 @@ public final class PropertyAccessClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -38,7 +38,7 @@ public final class PropertyAccessClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/property-access/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/property-access/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/property-access/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/property-access/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/property-access/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/property-access/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/property-access/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/property-access/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/property-access/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/property-access/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/property-access/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/property-access/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/property-access/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/property-access/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/property-access/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/property-access/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/property-access/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/property-access/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import PropertyAccess
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/public-object/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/public-object/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/public-object/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/public-object/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/public-object/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/public-object/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/public-object/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/public-object/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/public-object/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/public-object/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/public-object/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/public-object/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/public-object/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/public-object/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/public-object/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/public-object/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/public-object/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/public-object/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/public-object/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/public-object/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/public-object/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/public-object/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/public-object/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/public-object/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/public-object/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/public-object/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/public-object/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/public-object/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/public-object/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/public-object/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/public-object/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/public-object/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/public-object/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/public-object/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/public-object/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/public-object/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/public-object/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/public-object/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/public-object/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/public-object/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/public-object/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/public-object/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/public-object/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/public-object/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/public-object/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/public-object/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/public-object/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/public-object/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/public-object/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/public-object/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/public-object/Sources/PublicObjectClient.swift
+++ b/seed/swift-sdk/public-object/Sources/PublicObjectClient.swift
@@ -17,7 +17,7 @@ public final class PublicObjectClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -39,7 +39,7 @@ public final class PublicObjectClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/public-object/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/public-object/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import PublicObject
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/ApiClient.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/ApiClient.swift
@@ -16,7 +16,7 @@ public final class ApiClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -38,7 +38,7 @@ public final class ApiClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import Api
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/query-parameters-openapi/Sources/ApiClient.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Sources/ApiClient.swift
@@ -16,7 +16,7 @@ public final class ApiClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -38,7 +38,7 @@ public final class ApiClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/query-parameters-openapi/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/query-parameters-openapi/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/query-parameters-openapi/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/query-parameters-openapi/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/query-parameters-openapi/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/query-parameters-openapi/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/query-parameters-openapi/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/query-parameters-openapi/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/query-parameters-openapi/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/query-parameters-openapi/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/query-parameters-openapi/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/query-parameters-openapi/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/query-parameters-openapi/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/query-parameters-openapi/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/query-parameters-openapi/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/query-parameters-openapi/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/query-parameters-openapi/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/query-parameters-openapi/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/query-parameters-openapi/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/query-parameters-openapi/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/query-parameters-openapi/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/query-parameters-openapi/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/query-parameters-openapi/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/query-parameters-openapi/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/query-parameters-openapi/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/query-parameters-openapi/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import Api
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/query-parameters/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/query-parameters/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/query-parameters/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/query-parameters/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/query-parameters/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/query-parameters/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/query-parameters/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/query-parameters/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/query-parameters/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/query-parameters/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/query-parameters/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/query-parameters/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/query-parameters/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/query-parameters/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/query-parameters/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/query-parameters/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/query-parameters/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/query-parameters/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/query-parameters/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/query-parameters/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/query-parameters/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/query-parameters/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/query-parameters/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/query-parameters/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/query-parameters/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/query-parameters/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/query-parameters/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/query-parameters/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/query-parameters/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/query-parameters/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/query-parameters/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/query-parameters/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/query-parameters/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/query-parameters/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/query-parameters/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/query-parameters/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/query-parameters/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/query-parameters/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/query-parameters/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/query-parameters/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/query-parameters/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/query-parameters/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/query-parameters/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/query-parameters/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/query-parameters/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/query-parameters/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/query-parameters/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/query-parameters/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/query-parameters/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/query-parameters/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/query-parameters/Sources/QueryParametersClient.swift
+++ b/seed/swift-sdk/query-parameters/Sources/QueryParametersClient.swift
@@ -17,7 +17,7 @@ public final class QueryParametersClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -39,7 +39,7 @@ public final class QueryParametersClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/query-parameters/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/query-parameters/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import QueryParameters
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/request-parameters/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/request-parameters/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/request-parameters/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/request-parameters/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/request-parameters/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/request-parameters/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/request-parameters/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/request-parameters/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/request-parameters/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/request-parameters/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/request-parameters/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/request-parameters/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/request-parameters/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/request-parameters/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/request-parameters/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/request-parameters/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/request-parameters/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/request-parameters/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/request-parameters/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/request-parameters/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/request-parameters/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/request-parameters/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/request-parameters/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/request-parameters/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/request-parameters/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/request-parameters/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/request-parameters/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/request-parameters/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/request-parameters/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/request-parameters/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/request-parameters/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/request-parameters/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/request-parameters/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/request-parameters/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/request-parameters/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/request-parameters/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/request-parameters/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/request-parameters/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/request-parameters/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/request-parameters/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/request-parameters/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/request-parameters/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/request-parameters/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/request-parameters/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/request-parameters/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/request-parameters/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/request-parameters/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/request-parameters/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/request-parameters/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/request-parameters/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/request-parameters/Sources/RequestParametersClient.swift
+++ b/seed/swift-sdk/request-parameters/Sources/RequestParametersClient.swift
@@ -17,7 +17,7 @@ public final class RequestParametersClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -39,7 +39,7 @@ public final class RequestParametersClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/request-parameters/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/request-parameters/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import RequestParameters
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/required-nullable/no-custom-config/Sources/ApiClient.swift
+++ b/seed/swift-sdk/required-nullable/no-custom-config/Sources/ApiClient.swift
@@ -16,7 +16,7 @@ public final class ApiClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -38,7 +38,7 @@ public final class ApiClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/required-nullable/no-custom-config/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/required-nullable/no-custom-config/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/required-nullable/no-custom-config/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/required-nullable/no-custom-config/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/required-nullable/no-custom-config/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/required-nullable/no-custom-config/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/required-nullable/no-custom-config/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/required-nullable/no-custom-config/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/required-nullable/no-custom-config/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/required-nullable/no-custom-config/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/required-nullable/no-custom-config/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/required-nullable/no-custom-config/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/required-nullable/no-custom-config/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/required-nullable/no-custom-config/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/required-nullable/no-custom-config/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/required-nullable/no-custom-config/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/required-nullable/no-custom-config/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/required-nullable/no-custom-config/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/required-nullable/no-custom-config/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/required-nullable/no-custom-config/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/required-nullable/no-custom-config/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/required-nullable/no-custom-config/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/required-nullable/no-custom-config/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/required-nullable/no-custom-config/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/required-nullable/no-custom-config/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/required-nullable/no-custom-config/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/required-nullable/no-custom-config/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/required-nullable/no-custom-config/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/required-nullable/no-custom-config/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/required-nullable/no-custom-config/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/required-nullable/no-custom-config/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/required-nullable/no-custom-config/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/required-nullable/no-custom-config/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/required-nullable/no-custom-config/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/required-nullable/no-custom-config/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/required-nullable/no-custom-config/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/required-nullable/no-custom-config/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/required-nullable/no-custom-config/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/required-nullable/no-custom-config/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/required-nullable/no-custom-config/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/required-nullable/no-custom-config/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/required-nullable/no-custom-config/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/required-nullable/no-custom-config/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/required-nullable/no-custom-config/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/required-nullable/no-custom-config/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/required-nullable/no-custom-config/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/required-nullable/no-custom-config/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/required-nullable/no-custom-config/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/required-nullable/no-custom-config/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/required-nullable/no-custom-config/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/required-nullable/no-custom-config/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/required-nullable/no-custom-config/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import Api
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/ApiClient.swift
+++ b/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/ApiClient.swift
@@ -16,7 +16,7 @@ public final class ApiClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -38,7 +38,7 @@ public final class ApiClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/required-nullable/nullable-as-optional/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/required-nullable/nullable-as-optional/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import Api
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/reserved-keywords/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/reserved-keywords/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/reserved-keywords/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/reserved-keywords/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/reserved-keywords/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/reserved-keywords/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/reserved-keywords/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/reserved-keywords/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/reserved-keywords/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/reserved-keywords/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/reserved-keywords/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/reserved-keywords/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/reserved-keywords/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/reserved-keywords/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/reserved-keywords/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/reserved-keywords/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/reserved-keywords/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/reserved-keywords/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/reserved-keywords/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/reserved-keywords/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/reserved-keywords/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/reserved-keywords/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/reserved-keywords/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/reserved-keywords/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/reserved-keywords/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/reserved-keywords/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/reserved-keywords/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/reserved-keywords/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/reserved-keywords/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/reserved-keywords/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/reserved-keywords/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/reserved-keywords/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/reserved-keywords/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/reserved-keywords/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/reserved-keywords/Sources/NurseryApiClient.swift
+++ b/seed/swift-sdk/reserved-keywords/Sources/NurseryApiClient.swift
@@ -17,7 +17,7 @@ public final class NurseryApiClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -39,7 +39,7 @@ public final class NurseryApiClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/reserved-keywords/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/reserved-keywords/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/reserved-keywords/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/reserved-keywords/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/reserved-keywords/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/reserved-keywords/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/reserved-keywords/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/reserved-keywords/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/reserved-keywords/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/reserved-keywords/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/reserved-keywords/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/reserved-keywords/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/reserved-keywords/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/reserved-keywords/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/reserved-keywords/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/reserved-keywords/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/reserved-keywords/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/reserved-keywords/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import NurseryApi
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/response-property/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/response-property/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/response-property/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/response-property/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/response-property/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/response-property/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/response-property/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/response-property/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/response-property/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/response-property/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/response-property/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/response-property/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/response-property/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/response-property/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/response-property/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/response-property/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/response-property/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/response-property/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/response-property/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/response-property/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/response-property/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/response-property/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/response-property/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/response-property/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/response-property/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/response-property/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/response-property/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/response-property/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/response-property/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/response-property/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/response-property/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/response-property/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/response-property/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/response-property/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/response-property/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/response-property/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/response-property/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/response-property/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/response-property/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/response-property/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/response-property/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/response-property/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/response-property/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/response-property/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/response-property/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/response-property/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/response-property/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/response-property/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/response-property/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/response-property/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/response-property/Sources/ResponsePropertyClient.swift
+++ b/seed/swift-sdk/response-property/Sources/ResponsePropertyClient.swift
@@ -17,7 +17,7 @@ public final class ResponsePropertyClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -39,7 +39,7 @@ public final class ResponsePropertyClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/response-property/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/response-property/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import ResponseProperty
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/seed.yml
+++ b/seed/swift-sdk/seed.yml
@@ -29,9 +29,6 @@ defaultCustomConfig: {}
 scripts:
   - docker: swift:6.1.2
     commands:
-      # On Linux, URLSession/URLRequest require explicit FoundationNetworking import
-      # The Swift generator only outputs "import Foundation" but Linux needs both imports
-      - find . -name "*.swift" -exec sed -i '1s/^import Foundation$/import Foundation\nimport FoundationNetworking/' {} \;
       - swift build -c release --build-tests
       - swift test
 

--- a/seed/swift-sdk/server-sent-event-examples/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/server-sent-event-examples/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/server-sent-event-examples/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/server-sent-event-examples/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/server-sent-event-examples/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/server-sent-event-examples/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/server-sent-event-examples/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/server-sent-event-examples/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/server-sent-event-examples/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/server-sent-event-examples/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/server-sent-event-examples/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/server-sent-event-examples/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/server-sent-event-examples/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/server-sent-event-examples/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/server-sent-event-examples/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/server-sent-event-examples/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/server-sent-event-examples/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/server-sent-event-examples/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/server-sent-event-examples/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/server-sent-event-examples/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/server-sent-event-examples/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/server-sent-event-examples/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/server-sent-event-examples/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/server-sent-event-examples/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/server-sent-event-examples/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/server-sent-event-examples/Sources/ServerSentEventsClient.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/ServerSentEventsClient.swift
@@ -17,7 +17,7 @@ public final class ServerSentEventsClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -39,7 +39,7 @@ public final class ServerSentEventsClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/server-sent-event-examples/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import ServerSentEvents
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/server-sent-events/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/server-sent-events/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/server-sent-events/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/server-sent-events/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/server-sent-events/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/server-sent-events/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/server-sent-events/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/server-sent-events/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/server-sent-events/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/server-sent-events/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/server-sent-events/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/server-sent-events/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/server-sent-events/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/server-sent-events/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/server-sent-events/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/server-sent-events/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/server-sent-events/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/server-sent-events/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/server-sent-events/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/server-sent-events/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/server-sent-events/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/server-sent-events/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/server-sent-events/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/server-sent-events/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/server-sent-events/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/server-sent-events/Sources/ServerSentEventsClient.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/ServerSentEventsClient.swift
@@ -17,7 +17,7 @@ public final class ServerSentEventsClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -39,7 +39,7 @@ public final class ServerSentEventsClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/server-sent-events/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/server-sent-events/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import ServerSentEvents
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/simple-api/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/simple-api/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/simple-api/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/simple-api/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/simple-api/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/simple-api/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/simple-api/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/simple-api/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/simple-api/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/simple-api/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/simple-api/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/simple-api/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/simple-api/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/simple-api/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/simple-api/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/simple-api/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/simple-api/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/simple-api/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/simple-api/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/simple-api/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/simple-api/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/simple-api/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/simple-api/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/simple-api/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/simple-api/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/simple-api/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/simple-api/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/simple-api/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/simple-api/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/simple-api/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/simple-api/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/simple-api/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/simple-api/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/simple-api/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/simple-api/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/simple-api/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/simple-api/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/simple-api/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/simple-api/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/simple-api/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/simple-api/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/simple-api/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/simple-api/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/simple-api/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/simple-api/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/simple-api/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/simple-api/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/simple-api/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/simple-api/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/simple-api/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/simple-api/Sources/SimpleApiClient.swift
+++ b/seed/swift-sdk/simple-api/Sources/SimpleApiClient.swift
@@ -19,7 +19,7 @@ public final class SimpleApiClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -47,7 +47,7 @@ public final class SimpleApiClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -69,7 +69,7 @@ public final class SimpleApiClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/simple-api/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/simple-api/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import SimpleApi
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/simple-fhir/Sources/ApiClient.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/ApiClient.swift
@@ -16,7 +16,7 @@ public final class ApiClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -38,7 +38,7 @@ public final class ApiClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/simple-fhir/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/simple-fhir/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/simple-fhir/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/simple-fhir/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/simple-fhir/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/simple-fhir/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/simple-fhir/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/simple-fhir/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/simple-fhir/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/simple-fhir/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/simple-fhir/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/simple-fhir/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/simple-fhir/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/simple-fhir/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/simple-fhir/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/simple-fhir/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/simple-fhir/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/simple-fhir/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/simple-fhir/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/simple-fhir/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/simple-fhir/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/simple-fhir/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/simple-fhir/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/simple-fhir/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/simple-fhir/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/simple-fhir/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/simple-fhir/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import Api
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/SingleUrlEnvironmentDefaultClient.swift
+++ b/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/SingleUrlEnvironmentDefaultClient.swift
@@ -19,7 +19,7 @@ public final class SingleUrlEnvironmentDefaultClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -47,7 +47,7 @@ public final class SingleUrlEnvironmentDefaultClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -69,7 +69,7 @@ public final class SingleUrlEnvironmentDefaultClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/single-url-environment-default/no-custom-config/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/single-url-environment-default/no-custom-config/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import SingleUrlEnvironmentDefault
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/SingleUrlEnvironmentDefaultClient.swift
+++ b/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/SingleUrlEnvironmentDefaultClient.swift
@@ -19,7 +19,7 @@ public final class SingleUrlEnvironmentDefaultClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -47,7 +47,7 @@ public final class SingleUrlEnvironmentDefaultClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -69,7 +69,7 @@ public final class SingleUrlEnvironmentDefaultClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/single-url-environment-default/with-custom-config/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/single-url-environment-default/with-custom-config/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import SingleUrlEnvironmentDefault
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/SingleUrlEnvironmentNoDefaultClient.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/SingleUrlEnvironmentNoDefaultClient.swift
@@ -19,7 +19,7 @@ public final class SingleUrlEnvironmentNoDefaultClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -47,7 +47,7 @@ public final class SingleUrlEnvironmentNoDefaultClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -69,7 +69,7 @@ public final class SingleUrlEnvironmentNoDefaultClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/single-url-environment-no-default/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import SingleUrlEnvironmentNoDefault
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/streaming-parameter/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/streaming-parameter/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/streaming-parameter/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/streaming-parameter/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/streaming-parameter/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/streaming-parameter/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/streaming-parameter/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/streaming-parameter/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/streaming-parameter/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/streaming-parameter/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/streaming-parameter/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/streaming-parameter/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/streaming-parameter/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/streaming-parameter/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/streaming-parameter/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/streaming-parameter/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/streaming-parameter/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/streaming-parameter/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/streaming-parameter/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/streaming-parameter/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/streaming-parameter/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/streaming-parameter/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/streaming-parameter/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/streaming-parameter/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/streaming-parameter/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/streaming-parameter/Sources/StreamingClient.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/StreamingClient.swift
@@ -17,7 +17,7 @@ public final class StreamingClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -39,7 +39,7 @@ public final class StreamingClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/streaming-parameter/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/streaming-parameter/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import Streaming
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/streaming/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/streaming/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/streaming/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/streaming/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/streaming/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/streaming/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/streaming/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/streaming/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/streaming/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/streaming/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/streaming/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/streaming/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/streaming/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/streaming/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/streaming/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/streaming/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/streaming/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/streaming/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/streaming/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/streaming/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/streaming/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/streaming/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/streaming/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/streaming/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/streaming/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/streaming/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/streaming/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/streaming/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/streaming/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/streaming/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/streaming/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/streaming/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/streaming/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/streaming/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/streaming/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/streaming/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/streaming/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/streaming/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/streaming/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/streaming/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/streaming/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/streaming/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/streaming/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/streaming/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/streaming/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/streaming/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/streaming/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/streaming/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/streaming/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/streaming/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/streaming/Sources/StreamingClient.swift
+++ b/seed/swift-sdk/streaming/Sources/StreamingClient.swift
@@ -17,7 +17,7 @@ public final class StreamingClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -39,7 +39,7 @@ public final class StreamingClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/streaming/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/streaming/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import Streaming
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/trace/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/trace/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/trace/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/trace/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/trace/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/trace/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/trace/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/trace/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/trace/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/trace/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/trace/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/trace/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/trace/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/trace/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/trace/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/trace/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/trace/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/trace/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/trace/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/trace/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/trace/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/trace/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/trace/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/trace/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/trace/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/trace/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/trace/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/trace/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/trace/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/trace/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/trace/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/trace/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/trace/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/trace/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/trace/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/trace/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/trace/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/trace/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/trace/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/trace/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/trace/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/trace/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/trace/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/trace/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/trace/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/trace/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/trace/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/trace/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/trace/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/trace/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/trace/Sources/TraceClient.swift
+++ b/seed/swift-sdk/trace/Sources/TraceClient.swift
@@ -28,7 +28,7 @@ public final class TraceClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -58,7 +58,7 @@ public final class TraceClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -82,7 +82,7 @@ public final class TraceClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/trace/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/trace/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import Trace
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/UndiscriminatedUnionWithResponsePropertyClient.swift
+++ b/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/UndiscriminatedUnionWithResponsePropertyClient.swift
@@ -16,7 +16,7 @@ public final class UndiscriminatedUnionWithResponsePropertyClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -38,7 +38,7 @@ public final class UndiscriminatedUnionWithResponsePropertyClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/undiscriminated-union-with-response-property/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/undiscriminated-union-with-response-property/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import UndiscriminatedUnionWithResponseProperty
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/undiscriminated-unions/Sources/UndiscriminatedUnionsClient.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/UndiscriminatedUnionsClient.swift
@@ -17,7 +17,7 @@ public final class UndiscriminatedUnionsClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -39,7 +39,7 @@ public final class UndiscriminatedUnionsClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/undiscriminated-unions/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import UndiscriminatedUnions
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/unions/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/unions/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/unions/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/unions/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/unions/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/unions/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/unions/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/unions/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/unions/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/unions/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/unions/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/unions/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/unions/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/unions/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/unions/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/unions/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/unions/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/unions/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/unions/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/unions/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/unions/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/unions/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/unions/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/unions/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/unions/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/unions/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/unions/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/unions/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/unions/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/unions/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/unions/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/unions/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/unions/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/unions/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/unions/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/unions/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/unions/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/unions/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/unions/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/unions/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/unions/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/unions/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/unions/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/unions/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/unions/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/unions/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/unions/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/unions/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/unions/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/unions/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/unions/Sources/UnionsClient.swift
+++ b/seed/swift-sdk/unions/Sources/UnionsClient.swift
@@ -19,7 +19,7 @@ public final class UnionsClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -41,7 +41,7 @@ public final class UnionsClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/unions/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/unions/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import Unions
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/unknown/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/unknown/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/unknown/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/unknown/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/unknown/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/unknown/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/unknown/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/unknown/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/unknown/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/unknown/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/unknown/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/unknown/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/unknown/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/unknown/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/unknown/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/unknown/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/unknown/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/unknown/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/unknown/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/unknown/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/unknown/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/unknown/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/unknown/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/unknown/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/unknown/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/unknown/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/unknown/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/unknown/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/unknown/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/unknown/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/unknown/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/unknown/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/unknown/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/unknown/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/unknown/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/unknown/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/unknown/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/unknown/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/unknown/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/unknown/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/unknown/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/unknown/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/unknown/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/unknown/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/unknown/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/unknown/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/unknown/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/unknown/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/unknown/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/unknown/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/unknown/Sources/UnknownAsAnyClient.swift
+++ b/seed/swift-sdk/unknown/Sources/UnknownAsAnyClient.swift
@@ -17,7 +17,7 @@ public final class UnknownAsAnyClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -39,7 +39,7 @@ public final class UnknownAsAnyClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/unknown/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/unknown/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import UnknownAsAny
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/url-form-encoded/Sources/ApiClient.swift
+++ b/seed/swift-sdk/url-form-encoded/Sources/ApiClient.swift
@@ -16,7 +16,7 @@ public final class ApiClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -38,7 +38,7 @@ public final class ApiClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/url-form-encoded/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/url-form-encoded/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/url-form-encoded/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/url-form-encoded/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/url-form-encoded/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/url-form-encoded/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/url-form-encoded/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/url-form-encoded/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/url-form-encoded/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/url-form-encoded/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/url-form-encoded/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/url-form-encoded/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/url-form-encoded/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/url-form-encoded/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/url-form-encoded/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/url-form-encoded/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/url-form-encoded/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/url-form-encoded/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/url-form-encoded/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/url-form-encoded/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/url-form-encoded/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/url-form-encoded/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/url-form-encoded/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/url-form-encoded/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/url-form-encoded/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/url-form-encoded/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/url-form-encoded/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/url-form-encoded/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/url-form-encoded/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/url-form-encoded/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/url-form-encoded/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/url-form-encoded/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/url-form-encoded/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/url-form-encoded/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/url-form-encoded/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/url-form-encoded/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/url-form-encoded/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/url-form-encoded/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/url-form-encoded/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/url-form-encoded/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/url-form-encoded/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/url-form-encoded/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/url-form-encoded/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/url-form-encoded/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/url-form-encoded/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/url-form-encoded/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/url-form-encoded/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/url-form-encoded/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/url-form-encoded/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/url-form-encoded/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/url-form-encoded/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/url-form-encoded/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import Api
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/validation/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/validation/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/validation/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/validation/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/validation/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/validation/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/validation/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/validation/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/validation/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/validation/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/validation/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/validation/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/validation/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/validation/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/validation/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/validation/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/validation/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/validation/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/validation/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/validation/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/validation/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/validation/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/validation/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/validation/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/validation/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/validation/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/validation/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/validation/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/validation/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/validation/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/validation/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/validation/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/validation/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/validation/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/validation/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/validation/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/validation/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/validation/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/validation/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/validation/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/validation/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/validation/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/validation/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/validation/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/validation/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/validation/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/validation/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/validation/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/validation/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/validation/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/validation/Sources/ValidationClient.swift
+++ b/seed/swift-sdk/validation/Sources/ValidationClient.swift
@@ -16,7 +16,7 @@ public final class ValidationClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -38,7 +38,7 @@ public final class ValidationClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/validation/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/validation/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import Validation
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/variables/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/variables/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/variables/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/variables/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/variables/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/variables/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/variables/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/variables/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/variables/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/variables/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/variables/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/variables/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/variables/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/variables/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/variables/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/variables/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/variables/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/variables/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/variables/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/variables/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/variables/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/variables/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/variables/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/variables/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/variables/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/variables/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/variables/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/variables/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/variables/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/variables/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/variables/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/variables/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/variables/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/variables/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/variables/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/variables/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/variables/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/variables/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/variables/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/variables/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/variables/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/variables/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/variables/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/variables/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/variables/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/variables/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/variables/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/variables/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/variables/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/variables/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/variables/Sources/VariablesClient.swift
+++ b/seed/swift-sdk/variables/Sources/VariablesClient.swift
@@ -17,7 +17,7 @@ public final class VariablesClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -39,7 +39,7 @@ public final class VariablesClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/variables/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/variables/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import Variables
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/version-no-default/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/version-no-default/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/version-no-default/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/version-no-default/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/version-no-default/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/version-no-default/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/version-no-default/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/version-no-default/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/version-no-default/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/version-no-default/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/version-no-default/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/version-no-default/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/version-no-default/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/version-no-default/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/version-no-default/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/version-no-default/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/version-no-default/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/version-no-default/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/version-no-default/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/version-no-default/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/version-no-default/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/version-no-default/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/version-no-default/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/version-no-default/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/version-no-default/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/version-no-default/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/version-no-default/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/version-no-default/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/version-no-default/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/version-no-default/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/version-no-default/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/version-no-default/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/version-no-default/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/version-no-default/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/version-no-default/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/version-no-default/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/version-no-default/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/version-no-default/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/version-no-default/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/version-no-default/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/version-no-default/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/version-no-default/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/version-no-default/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/version-no-default/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/version-no-default/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/version-no-default/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/version-no-default/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/version-no-default/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/version-no-default/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/version-no-default/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/version-no-default/Sources/VersionClient.swift
+++ b/seed/swift-sdk/version-no-default/Sources/VersionClient.swift
@@ -17,7 +17,7 @@ public final class VersionClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -39,7 +39,7 @@ public final class VersionClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/version-no-default/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/version-no-default/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import Version
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/version/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/version/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/version/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/version/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/version/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/version/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/version/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/version/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/version/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/version/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/version/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/version/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/version/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/version/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/version/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/version/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/version/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/version/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/version/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/version/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/version/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/version/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/version/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/version/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/version/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/version/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/version/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/version/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/version/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/version/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/version/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/version/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/version/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/version/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/version/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/version/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/version/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/version/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/version/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/version/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/version/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/version/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/version/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/version/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/version/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/version/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/version/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/version/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/version/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/version/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/version/Sources/VersionClient.swift
+++ b/seed/swift-sdk/version/Sources/VersionClient.swift
@@ -17,7 +17,7 @@ public final class VersionClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -39,7 +39,7 @@ public final class VersionClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/version/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/version/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import Version
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/websocket-bearer-auth/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/websocket-bearer-auth/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/websocket-bearer-auth/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/websocket-bearer-auth/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/websocket-bearer-auth/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/websocket-bearer-auth/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/websocket-bearer-auth/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/websocket-bearer-auth/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/websocket-bearer-auth/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/websocket-bearer-auth/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/websocket-bearer-auth/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/websocket-bearer-auth/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/websocket-bearer-auth/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/websocket-bearer-auth/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/websocket-bearer-auth/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/websocket-bearer-auth/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/websocket-bearer-auth/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/websocket-bearer-auth/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/websocket-bearer-auth/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/websocket-bearer-auth/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/websocket-bearer-auth/Sources/WebsocketBearerAuthClient.swift
+++ b/seed/swift-sdk/websocket-bearer-auth/Sources/WebsocketBearerAuthClient.swift
@@ -19,7 +19,7 @@ public final class WebsocketBearerAuthClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -47,7 +47,7 @@ public final class WebsocketBearerAuthClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -69,7 +69,7 @@ public final class WebsocketBearerAuthClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/websocket-bearer-auth/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/websocket-bearer-auth/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import WebsocketBearerAuth
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/websocket-inferred-auth/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/websocket-inferred-auth/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/websocket-inferred-auth/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/websocket-inferred-auth/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/websocket-inferred-auth/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/websocket-inferred-auth/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/websocket-inferred-auth/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/websocket-inferred-auth/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/websocket-inferred-auth/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/websocket-inferred-auth/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/websocket-inferred-auth/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/websocket-inferred-auth/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/websocket-inferred-auth/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/websocket-inferred-auth/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/websocket-inferred-auth/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/websocket-inferred-auth/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/websocket-inferred-auth/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/websocket-inferred-auth/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/websocket-inferred-auth/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/websocket-inferred-auth/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/websocket-inferred-auth/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/websocket-inferred-auth/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/websocket-inferred-auth/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/websocket-inferred-auth/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/websocket-inferred-auth/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/websocket-inferred-auth/Sources/WebsocketAuthClient.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Sources/WebsocketAuthClient.swift
@@ -18,7 +18,7 @@ public final class WebsocketAuthClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -40,7 +40,7 @@ public final class WebsocketAuthClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/websocket-inferred-auth/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import WebsocketAuth
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",

--- a/seed/swift-sdk/websocket/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/websocket/Sources/Core/CalendarDate.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 /// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
-public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+public struct CalendarDate: Swift.Codable, Swift.Hashable, Swift.Sendable, Swift
+        .CustomStringConvertible, Swift.Comparable
+{
     /// The year component (expected range: 1-9999)
-    public let year: Int
+    public let year: Swift.Int
 
     /// The month component (valid range: 1-12)
-    public let month: Int
+    public let month: Swift.Int
 
     /// The day component (valid range: 1-31, depending on month)
-    public let day: Int
+    public let day: Swift.Int
 
     /// Failable initializer for creating a CalendarDate with validation
-    public init?(year: Int, month: Int, day: Int) {
+    public init?(year: Swift.Int, month: Swift.Int, day: Swift.Int) {
         guard Self.isValidDate(year: year, month: month, day: day) else {
             return nil
         }
@@ -22,12 +24,12 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     }
 
     /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
-    public init?(_ dateString: String) {
+    public init?(_ dateString: Swift.String) {
         let components = dateString.split(separator: "-")
         guard components.count == 3,
-            let year = Int(components[0]),
-            let month = Int(components[1]),
-            let day = Int(components[2])
+            let year = Swift.Int(components[0]),
+            let month = Swift.Int(components[1]),
+            let day = Swift.Int(components[2])
         else {
             return nil
         }
@@ -36,7 +38,7 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
 
     // MARK: - Codable
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dateString = try container.decode(String.self)
         guard let calendarDate = CalendarDate(dateString) else {
@@ -45,23 +47,23 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
         self = calendarDate
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)
     }
 
     // MARK: - CustomStringConvertible
 
-    public var description: String {
+    public var description: Swift.String {
         // Format as YYYY-MM-DD with zero-padding
         // %04d = 4-digit year with leading zeros (e.g., 2025)
         // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
-        String(format: "%04d-%02d-%02d", year, month, day)
+        Swift.String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     // MARK: - Comparable
 
-    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Swift.Bool {
         if lhs.year != rhs.year { return lhs.year < rhs.year }
         if lhs.month != rhs.month { return lhs.month < rhs.month }
         return lhs.day < rhs.day
@@ -70,9 +72,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Private Helpers
 
     /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
-    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
-        let calendar = Calendar(identifier: .gregorian)
-        let components = DateComponents(year: year, month: month, day: day)
+    private static func isValidDate(year: Swift.Int, month: Swift.Int, day: Swift.Int) -> Swift.Bool
+    {
+        let calendar = Foundation.Calendar(identifier: .gregorian)
+        let components = Foundation.DateComponents(year: year, month: month, day: day)
 
         guard let date = calendar.date(from: components) else {
             return false
@@ -89,10 +92,10 @@ public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible
     // MARK: - Error Types
 
     /// Errors that can occur when working with CalendarDate
-    public enum Error: Swift.Error, LocalizedError {
-        case invalidFormat(String)
+    public enum Error: Swift.Error, Foundation.LocalizedError {
+        case invalidFormat(Swift.String)
 
-        public var errorDescription: String? {
+        public var errorDescription: Swift.String? {
             switch self {
             case .invalidFormat(let string):
                 return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"

--- a/seed/swift-sdk/websocket/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/websocket/Sources/Core/Data+String.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 // MARK: - Data + String Extensions
-extension Data {
+extension Foundation.Data {
     /// Safely appends a UTF-8 encoded string to the data
     ///
     /// - Parameter string: The string to append
-    mutating func appendUTF8String(_ string: String) {
+    mutating func appendUTF8String(_ string: Swift.String) {
         guard let data = string.data(using: .utf8) else {
             assertionFailure("Failed to encode string to UTF-8: \(string)")
             return

--- a/seed/swift-sdk/websocket/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/websocket/Sources/Core/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum HTTP {
-    enum Method: String, CaseIterable {
+    enum Method: Swift.String, Swift.CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"
@@ -10,15 +10,15 @@ enum HTTP {
         case head = "HEAD"
     }
 
-    enum ContentType: String, CaseIterable {
+    enum ContentType: Swift.String, Swift.CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
         case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
-        case jsonEncodable(any Encodable)
-        case data(Data)
+        case jsonEncodable(any Swift.Encodable)
+        case data(Foundation.Data)
         case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/websocket/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/websocket/Sources/Core/Networking/HTTPClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-final class HTTPClient: Sendable {
+final class HTTPClient: Swift.Sendable {
     private let clientConfig: ClientConfig
     private let jsonEncoder = Serde.jsonEncoder
     private let jsonDecoder = Serde.jsonDecoder
 
-    private static let initialRetryDelay: TimeInterval = 1.0  // 1 second
-    private static let maxRetryDelay: TimeInterval = 60.0  // 60 seconds
-    private static let jitterFactor: Double = 0.2  // 20% jitter
+    private static let initialRetryDelay: Foundation.TimeInterval = 1.0  // 1 second
+    private static let maxRetryDelay: Foundation.TimeInterval = 60.0  // 60 seconds
+    private static let jitterFactor: Swift.Double = 0.2  // 20% jitter
 
     init(config: ClientConfig) {
         self.clientConfig = config
@@ -16,10 +16,10 @@ final class HTTPClient: Sendable {
     /// Performs a request with no response.
     func performRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil
     ) async throws {
@@ -31,17 +31,17 @@ final class HTTPClient: Sendable {
             queryParams: requestQueryParams,
             body: requestBody,
             requestOptions: requestOptions,
-            responseType: Data.self
+            responseType: Foundation.Data.self
         )
     }
 
     /// Performs a request with the specified response type.
-    func performRequest<T: Decodable>(
+    func performRequest<T: Swift.Decodable>(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         contentType requestContentType: HTTP.ContentType = .applicationJson,
-        headers requestHeaders: [String: String?] = [:],
-        queryParams requestQueryParams: [String: QueryParameter?] = [:],
+        headers requestHeaders: [Swift.String: Swift.String?] = [:],
+        queryParams requestQueryParams: [Swift.String: QueryParameter?] = [:],
         body requestBody: Any? = nil,
         requestOptions: RequestOptions? = nil,
         responseType: T.Type
@@ -49,9 +49,9 @@ final class HTTPClient: Sendable {
         let requestBody: HTTP.RequestBody? = requestBody.map { body in
             if let multipartData = body as? MultipartFormData {
                 return .multipartFormData(multipartData)
-            } else if let data = body as? Data {
+            } else if let data = body as? Foundation.Data {
                 return .data(data)
-            } else if let encodable = body as? any Encodable {
+            } else if let encodable = body as? any Swift.Encodable {
                 return .jsonEncodable(encodable)
             } else {
                 preconditionFailure("Unsupported body type: \(type(of: body))")
@@ -73,7 +73,7 @@ final class HTTPClient: Sendable {
             requestOptions: requestOptions
         )
 
-        if responseType == Data.self {
+        if responseType == Foundation.Data.self {
             if let data = data as? T {
                 return data
             } else {
@@ -81,8 +81,8 @@ final class HTTPClient: Sendable {
             }
         }
 
-        if responseType == String.self {
-            if let string = String(data: data, encoding: .utf8) as? T {
+        if responseType == Swift.String.self {
+            if let string = Swift.String(data: data, encoding: .utf8) as? T {
                 return string
             } else {
                 throw ClientError.invalidResponse
@@ -98,22 +98,22 @@ final class HTTPClient: Sendable {
 
     private func buildRequest(
         method: HTTP.Method,
-        path: String,
+        path: Swift.String,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
-        requestQueryParams: [String: QueryParameter?],
+        requestHeaders: [Swift.String: Swift.String?],
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestBody: HTTP.RequestBody? = nil,
         requestOptions: RequestOptions? = nil
-    ) async throws -> URLRequest {
+    ) async throws -> Networking.URLRequest {
         // Init with URL
         let url = buildRequestURL(
             path: path, requestQueryParams: requestQueryParams, requestOptions: requestOptions
         )
-        var request = URLRequest(url: url)
+        var request = Networking.URLRequest(url: url)
 
         // Set timeout
         if let timeout = requestOptions?.timeout {
-            request.timeoutInterval = TimeInterval(timeout)
+            request.timeoutInterval = Foundation.TimeInterval(timeout)
         }
 
         // Set method
@@ -142,22 +142,22 @@ final class HTTPClient: Sendable {
     }
 
     private func buildRequestURL(
-        path: String,
-        requestQueryParams: [String: QueryParameter?],
+        path: Swift.String,
+        requestQueryParams: [Swift.String: QueryParameter?],
         requestOptions: RequestOptions? = nil
     ) -> URL {
-        let endpointURL: String = "\(clientConfig.baseURL)\(path)"
-        guard var components: URLComponents = URLComponents(string: endpointURL) else {
+        let endpointURL = "\(clientConfig.baseURL)\(path)"
+        guard var components = Foundation.URLComponents(string: endpointURL) else {
             preconditionFailure(
                 "Invalid URL '\(endpointURL)' - this indicates an unexpected error in the SDK."
             )
         }
         if !requestQueryParams.isEmpty {
-            let baseItems: [URLQueryItem] = requestQueryParams.compactMap { key, value in
+            let baseItems: [Foundation.URLQueryItem] = requestQueryParams.compactMap { key, value in
                 guard let unwrapped = value else { return nil }
                 let stringValue = unwrapped.toString()
                 guard !stringValue.isEmpty else { return nil }
-                return URLQueryItem(name: key, value: stringValue)
+                return Foundation.URLQueryItem(name: key, value: stringValue)
             }
             if !baseItems.isEmpty {
                 components.queryItems = baseItems
@@ -165,7 +165,7 @@ final class HTTPClient: Sendable {
         }
         if let additionalQueryParams = requestOptions?.additionalQueryParameters {
             let extraItems = additionalQueryParams.compactMap { key, value in
-                value.isEmpty ? nil : URLQueryItem(name: key, value: value)
+                value.isEmpty ? nil : Foundation.URLQueryItem(name: key, value: value)
             }
             if components.queryItems == nil {
                 components.queryItems = extraItems
@@ -184,9 +184,9 @@ final class HTTPClient: Sendable {
     private func buildRequestHeaders(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-        requestHeaders: [String: String?],
+        requestHeaders: [Swift.String: Swift.String?],
         requestOptions: RequestOptions? = nil
-    ) async throws -> [String: String] {
+    ) async throws -> [Swift.String: Swift.String] {
         var headers = clientConfig.headers ?? [:]
 
         headers["Content-Type"] = buildContentTypeHeader(
@@ -218,7 +218,7 @@ final class HTTPClient: Sendable {
     private func buildContentTypeHeader(
         requestBody: HTTP.RequestBody?,
         requestContentType: HTTP.ContentType,
-    ) -> String {
+    ) -> Swift.String {
         var contentType = requestContentType.rawValue
         if let requestBody, case .multipartFormData(let multipartData) = requestBody {
             if contentType != HTTP.ContentType.multipartFormData.rawValue {
@@ -232,7 +232,8 @@ final class HTTPClient: Sendable {
         return contentType
     }
 
-    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> String? {
+    private func getBearerAuthToken(_ requestOptions: RequestOptions?) async throws -> Swift.String?
+    {
         if let tokenString = requestOptions?.token {
             return tokenString
         }
@@ -263,17 +264,17 @@ final class HTTPClient: Sendable {
     }
 
     private func executeRequestWithURLSession(
-        _ request: URLRequest,
+        _ request: Networking.URLRequest,
         requestOptions: RequestOptions? = nil
-    ) async throws -> (Data, String?) {
+    ) async throws -> (Foundation.Data, Swift.String?) {
         let maxRetries = requestOptions?.maxRetries ?? clientConfig.maxRetries
-        var lastResponse: (Data, HTTPURLResponse)?
+        var lastResponse: (Foundation.Data, Networking.HTTPURLResponse)?
 
         for attempt in 0...maxRetries {
             do {
                 let (data, response) = try await clientConfig.urlSession.data(for: request)
 
-                guard let httpResponse = response as? HTTPURLResponse else {
+                guard let httpResponse = response as? Networking.HTTPURLResponse else {
                     throw ClientError.invalidResponse
                 }
 
@@ -287,7 +288,8 @@ final class HTTPClient: Sendable {
 
                 if attempt < maxRetries && shouldRetry(statusCode: httpResponse.statusCode) {
                     let delay = getRetryDelay(response: httpResponse, retryAttempt: attempt)
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await _Concurrency.Task.sleep(
+                        nanoseconds: Swift.UInt64(delay * 1_000_000_000))
                     continue
                 }
 
@@ -303,10 +305,11 @@ final class HTTPClient: Sendable {
                         throw ClientError.networkError(error)
                     }
                 }
-                let delay = Self.initialRetryDelay * pow(2.0, Double(attempt))
+                let delay = Self.initialRetryDelay * pow(2.0, Swift.Double(attempt))
                 let cappedDelay = min(delay, Self.maxRetryDelay)
                 let jitteredDelay = addSymmetricJitter(to: cappedDelay)
-                try await Task.sleep(nanoseconds: UInt64(jitteredDelay * 1_000_000_000))
+                try await _Concurrency.Task.sleep(
+                    nanoseconds: Swift.UInt64(jitteredDelay * 1_000_000_000))
             }
         }
 
@@ -316,13 +319,15 @@ final class HTTPClient: Sendable {
         throw ClientError.invalidResponse
     }
 
-    private func shouldRetry(statusCode: Int) -> Bool {
+    private func shouldRetry(statusCode: Swift.Int) -> Swift.Bool {
         return statusCode == 408 || statusCode == 429 || statusCode >= 500
     }
 
-    private func getRetryDelay(response: HTTPURLResponse, retryAttempt: Int) -> TimeInterval {
+    private func getRetryDelay(response: Networking.HTTPURLResponse, retryAttempt: Swift.Int)
+        -> Foundation.TimeInterval
+    {
         if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            if let seconds = Double(retryAfter), seconds > 0 {
+            if let seconds = Swift.Double(retryAfter), seconds > 0 {
                 return min(seconds, Self.maxRetryDelay)
             }
 
@@ -335,8 +340,8 @@ final class HTTPClient: Sendable {
         }
 
         if let rateLimitReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset") {
-            if let resetTimeSeconds = Double(rateLimitReset) {
-                let resetDate = Date(timeIntervalSince1970: resetTimeSeconds)
+            if let resetTimeSeconds = Swift.Double(rateLimitReset) {
+                let resetDate = Foundation.Date(timeIntervalSince1970: resetTimeSeconds)
                 let delay = resetDate.timeIntervalSinceNow
                 if delay > 0 {
                     let cappedDelay = min(delay, Self.maxRetryDelay)
@@ -345,31 +350,32 @@ final class HTTPClient: Sendable {
             }
         }
 
-        let baseDelay = Self.initialRetryDelay * pow(2.0, Double(retryAttempt))
+        let baseDelay = Self.initialRetryDelay * pow(2.0, Swift.Double(retryAttempt))
         let cappedDelay = min(baseDelay, Self.maxRetryDelay)
         return addSymmetricJitter(to: cappedDelay)
     }
 
-    private func parseHTTPDate(_ dateString: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(abbreviation: "GMT")
+    private func parseHTTPDate(_ dateString: Swift.String) -> Foundation.Date? {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Foundation.TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter.date(from: dateString)
     }
 
-    private func addPositiveJitter(to delay: TimeInterval) -> TimeInterval {
-        let jitterMultiplier = 1.0 + Double.random(in: 0...Self.jitterFactor)
+    private func addPositiveJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
+        let jitterMultiplier = 1.0 + Swift.Double.random(in: 0...Self.jitterFactor)
         return delay * jitterMultiplier
     }
 
-    private func addSymmetricJitter(to delay: TimeInterval) -> TimeInterval {
+    private func addSymmetricJitter(to delay: Foundation.TimeInterval) -> Foundation.TimeInterval {
         let jitterMultiplier =
-            1.0 + Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
+            1.0 + Swift.Double.random(in: -Self.jitterFactor / 2...Self.jitterFactor / 2)
         return delay * jitterMultiplier
     }
 
-    private func makeErrorFromResponse(statusCode: Int, data: Data) -> ClientError {
+    private func makeErrorFromResponse(statusCode: Swift.Int, data: Foundation.Data) -> ClientError
+    {
         let errorResponse = parseErrorResponse(statusCode: statusCode, from: data)
         switch statusCode {
         case 400:
@@ -389,21 +395,24 @@ final class HTTPClient: Sendable {
         }
     }
 
-    private func parseErrorResponse(statusCode: Int, from data: Data) -> APIErrorResponse? {
+    private func parseErrorResponse(statusCode: Swift.Int, from data: Foundation.Data)
+        -> APIErrorResponse?
+    {
         // Try to parse as JSON error response first
         if let errorResponse = try? jsonDecoder.decode(APIErrorResponse.self, from: data) {
             return errorResponse
         }
 
         // Try to parse as simple JSON with message field
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let message = json["message"] as? String
+        if let json = try? Foundation.JSONSerialization.jsonObject(with: data)
+            as? [Swift.String: Any],
+            let message = json["message"] as? Swift.String
         {
             return APIErrorResponse(code: statusCode, message: message)
         }
 
         // Try to parse as plain text
-        if let errorMessage = String(data: data, encoding: .utf8), !errorMessage.isEmpty {
+        if let errorMessage = Swift.String(data: data, encoding: .utf8), !errorMessage.isEmpty {
             return APIErrorResponse(code: statusCode, message: errorMessage)
         }
 

--- a/seed/swift-sdk/websocket/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/websocket/Sources/Core/Networking/MultipartFormData.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Helper class for building multipart form data requests
 class MultipartFormData {
-    let boundary: String
-    private var bodyData: Data
+    let boundary: Swift.String
+    private var bodyData: Foundation.Data
 
     init() {
-        self.boundary = "Boundary-\(UUID().uuidString)"
-        self.bodyData = Data()
+        self.boundary = "Boundary-\(Foundation.UUID().uuidString)"
+        self.bodyData = Foundation.Data()
     }
 
     /// Append a file field to the form data
     func appendFile(
-        _ data: Data, withName name: String, fileName: String? = nil
+        _ data: Foundation.Data, withName name: Swift.String, fileName: Swift.String? = nil
     ) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
@@ -28,7 +28,7 @@ class MultipartFormData {
     }
 
     /// Append a text field to the form data
-    func appendField(_ value: String, withName name: String) {
+    func appendField(_ value: Swift.String, withName name: Swift.String) {
         bodyData.appendUTF8String("--\(boundary)\r\n")
         bodyData.appendUTF8String(
             "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
@@ -37,7 +37,7 @@ class MultipartFormData {
     }
 
     /// Returns the complete multipart form data with closing boundary
-    func data() -> Data {
+    func data() -> Foundation.Data {
         var finalData = bodyData
         finalData.appendUTF8String("--\(boundary)--\r\n")
         return finalData

--- a/seed/swift-sdk/websocket/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/websocket/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -27,7 +27,7 @@ extension MultipartFormDataConvertible {
             case .field(let encodableValue, let fieldName):
                 do {
                     let encodedData = try jsonEncoder.encode(value: encodableValue)
-                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                    if let encodedString = Swift.String(data: encodedData, encoding: .utf8) {
                         multipartData.appendField(encodedString, withName: fieldName)
                     }
                 } catch {

--- a/seed/swift-sdk/websocket/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/websocket/Sources/Core/Networking/MultipartFormField.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Represents a field in multipart form data
 enum MultipartFormField {
     /// A single file field
-    case file(_ file: FormFile, fieldName: String)
+    case file(_ file: FormFile, fieldName: Swift.String)
     /// An array of files with the same field name
-    case fileArray(_ files: [FormFile], fieldName: String)
+    case fileArray(_ files: [FormFile], fieldName: Swift.String)
     /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
-    case field(_ value: EncodableValue, fieldName: String)
+    case field(_ value: EncodableValue, fieldName: Swift.String)
 
     /// Create a text field from any Encodable value
-    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+    static func field<T: Swift.Encodable>(_ value: T, fieldName: Swift.String) -> MultipartFormField
+    {
         return .field(.init(value), fieldName: fieldName)
     }
 }

--- a/seed/swift-sdk/websocket/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/websocket/Sources/Core/Networking/QueryParameter.swift
@@ -1,38 +1,38 @@
 import Foundation
 
 enum QueryParameter {
-    case string(String)
-    case bool(Bool)
-    case int(Int)
-    case uint(UInt)
-    case uint64(UInt64)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case date(Date)
+    case string(Swift.String)
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case uint(Swift.UInt)
+    case uint64(Swift.UInt64)
+    case int64(Swift.Int64)
+    case float(Swift.Float)
+    case double(Swift.Double)
+    case date(Foundation.Date)
     case calendarDate(CalendarDate)
-    case stringArray([String])
-    case uuid(UUID)
+    case stringArray([Swift.String])
+    case uuid(Foundation.UUID)
     case unknown(Any)
 
-    func toString() -> String {
+    func toString() -> Swift.String {
         switch self {
         case .string(let value):
             return value
         case .bool(let value):
             return value ? "true" : "false"
         case .int(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint(let value):
-            return String(value)
+            return Swift.String(value)
         case .uint64(let value):
-            return String(value)
+            return Swift.String(value)
         case .int64(let value):
-            return String(value)
+            return Swift.String(value)
         case .float(let value):
-            return String(value)
+            return Swift.String(value)
         case .double(let value):
-            return String(value)
+            return Swift.String(value)
         case .date(let value):
             return value.ISO8601Format()
         case .calendarDate(let value):

--- a/seed/swift-sdk/websocket/Sources/Core/Serde/Decoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/websocket/Sources/Core/Serde/Decoder+AdditionalProperties.swift
@@ -1,22 +1,25 @@
 import Foundation
 
-extension Decoder {
-    func decodeAdditionalProperties<T: Decodable, C: CaseIterable & RawRepresentable>(
+extension Swift.Decoder {
+    func decodeAdditionalProperties<
+        T: Swift.Decodable, C: Swift.CaseIterable & Swift.RawRepresentable
+    >(
         using codingKeysType: C.Type
     ) throws
-        -> [String: T] where C.RawValue == String
+        -> [Swift.String: T] where C.RawValue == Swift.String
     {
         return try decodeAdditionalProperties(
-            knownKeys: Set(codingKeysType.allCases.map(\.rawValue)))
+            knownKeys: Swift.Set(codingKeysType.allCases.map(\.rawValue)))
     }
 
-    func decodeAdditionalProperties<T: Decodable>(knownKeys: Set<String>) throws -> [String:
-        T]
+    func decodeAdditionalProperties<T: Swift.Decodable>(knownKeys: Swift.Set<Swift.String>) throws
+        -> [Swift.String: T]
     {
         let container = try container(keyedBy: StringKey.self)
-        let unknownKeys = Set(container.allKeys).subtracting(knownKeys.map(StringKey.init(_:)))
+        let unknownKeys = Swift.Set(container.allKeys).subtracting(
+            knownKeys.map(StringKey.init(_:)))
         guard !unknownKeys.isEmpty else { return .init() }
-        let keyValuePairs: [(String, T)] = try unknownKeys.compactMap { key in
+        let keyValuePairs: [(Swift.String, T)] = try unknownKeys.compactMap { key in
             (key.stringValue, try container.decode(T.self, forKey: key))
         }
         return .init(uniqueKeysWithValues: keyValuePairs)

--- a/seed/swift-sdk/websocket/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/websocket/Sources/Core/Serde/EncodableValue.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Type-erased wrapper for encodable values
 struct EncodableValue {
-    let value: any Encodable
+    let value: any Swift.Encodable
 
-    init<T: Encodable>(_ value: T) {
+    init<T: Swift.Encodable>(_ value: T) {
         self.value = value
     }
 }

--- a/seed/swift-sdk/websocket/Sources/Core/Serde/Encoder+AdditionalProperties.swift
+++ b/seed/swift-sdk/websocket/Sources/Core/Serde/Encoder+AdditionalProperties.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-extension Encoder {
-    func encodeAdditionalProperties<T: Encodable>(_ additionalProperties: [String: T]) throws {
+extension Swift.Encoder {
+    func encodeAdditionalProperties<T: Swift.Encodable>(_ additionalProperties: [Swift.String: T])
+        throws
+    {
         guard !additionalProperties.isEmpty else { return }
         var container = self.container(keyedBy: StringKey.self)
         for (key, value) in additionalProperties {

--- a/seed/swift-sdk/websocket/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/websocket/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-extension JSONEncoder {
+extension Foundation.JSONEncoder {
     /// Helper for type-erasing Encodable values
-    private struct AnyEncodable: Encodable {
-        private let value: any Encodable
+    private struct AnyEncodable: Swift.Encodable {
+        private let value: any Swift.Encodable
 
-        init(_ value: any Encodable) {
+        init(_ value: any Swift.Encodable) {
             self.value = value
         }
 
-        func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Swift.Encoder) throws {
             try value.encode(to: encoder)
         }
     }
 
-    func encode(value: EncodableValue) throws -> Data {
+    func encode(value: EncodableValue) throws -> Foundation.Data {
         return try self.encode(AnyEncodable(value.value))
     }
 }

--- a/seed/swift-sdk/websocket/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/websocket/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedDecodingContainer {
+extension Swift.KeyedDecodingContainer {
     /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+    public func decodeNullableIfPresent<T>(
+        _ type: T.Type, forKey key: Swift.KeyedDecodingContainer<K>.Key
+    ) throws -> Nullable<T>? where T: Swift.Decodable {
         if contains(key) {
             if try decodeNil(forKey: key) {
                 return .null

--- a/seed/swift-sdk/websocket/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/websocket/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-extension KeyedEncodingContainer {
+extension Swift.KeyedEncodingContainer {
     /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
     /// Use this for `Optional<Nullable<T>>` fields
-    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+    public mutating func encodeNullableIfPresent<T>(
+        _ value: Nullable<T>?, forKey key: Swift.KeyedEncodingContainer<K>.Key
+    ) throws where T: Swift.Encodable {
         switch value {
         case nil:
             // Don't encode the key at all - field is missing

--- a/seed/swift-sdk/websocket/Sources/Core/Serde/Serde.swift
+++ b/seed/swift-sdk/websocket/Sources/Core/Serde/Serde.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 final class Serde {
-    static var jsonEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
+    static var jsonEncoder: Foundation.JSONEncoder {
+        let encoder = Foundation.JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }
 
-    static var jsonDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
+    static var jsonDecoder: Foundation.JSONDecoder {
+        let decoder = Foundation.JSONDecoder()
         // Use custom strategy for robust ISO 8601 date parsing with fractional seconds
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
 
-            let formatter = ISO8601DateFormatter()
+            let formatter = Foundation.ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
             if let date = formatter.date(from: dateString) {
@@ -27,7 +27,7 @@ final class Serde {
                 return date
             }
 
-            throw DecodingError.dataCorruptedError(
+            throw Swift.DecodingError.dataCorruptedError(
                 in: container, debugDescription: "Invalid date format: \(dateString)")
         }
         return decoder

--- a/seed/swift-sdk/websocket/Sources/Core/Serde/StringKey.swift
+++ b/seed/swift-sdk/websocket/Sources/Core/Serde/StringKey.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct StringKey: CodingKey, Hashable {
-    var stringValue: String
-    var intValue: Int? { Int(stringValue) }
+struct StringKey: Swift.CodingKey, Swift.Hashable {
+    var stringValue: Swift.String
+    var intValue: Swift.Int? { Swift.Int(stringValue) }
 
-    init(_ string: String) {
+    init(_ string: Swift.String) {
         self.stringValue = string
     }
 
-    init?(stringValue: String) {
+    init?(stringValue: Swift.String) {
         self.stringValue = stringValue
     }
 
-    init?(intValue: Int) {
-        self.stringValue = String(intValue)
+    init?(intValue: Swift.Int) {
+        self.stringValue = Swift.String(intValue)
     }
 }

--- a/seed/swift-sdk/websocket/Sources/Core/String+URLEncoding.swift
+++ b/seed/swift-sdk/websocket/Sources/Core/String+URLEncoding.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension String {
-    func urlPathEncoded() -> String {
+extension Swift.String {
+    func urlPathEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
     }
 
-    func urlQueryEncoded() -> String {
+    func urlQueryEncoded() -> Swift.String {
         return self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }

--- a/seed/swift-sdk/websocket/Sources/Public/APIErrorResponse.swift
+++ b/seed/swift-sdk/websocket/Sources/Public/APIErrorResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public struct APIErrorResponse: Codable, Sendable {
-    public let code: Int
-    public let type: String?
-    public let message: String?
+public struct APIErrorResponse: Swift.Codable, Swift.Sendable {
+    public let code: Swift.Int
+    public let type: Swift.String?
+    public let message: Swift.String?
 
-    public init(code: Int, type: String? = nil, message: String? = nil) {
+    public init(code: Swift.Int, type: Swift.String? = nil, message: Swift.String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/seed/swift-sdk/websocket/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/websocket/Sources/Public/ClientConfig.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-public final class ClientConfig: Sendable {
-    public typealias CredentialProvider = @Sendable () async throws -> String
+public final class ClientConfig: Swift.Sendable {
+    public typealias CredentialProvider = @Sendable () async throws -> Swift.String
 
     struct Defaults {
-        static let timeout: Int = 60
-        static let maxRetries: Int = 2
+        static let timeout: Swift.Int = 60
+        static let maxRetries: Swift.Int = 2
     }
 
     struct HeaderAuth {
-        let key: String
-        let header: String
+        let key: Swift.String
+        let header: Swift.String
     }
 
     struct BearerAuth {
         let token: Token
 
-        enum Token: Sendable {
-            case staticToken(String)
+        enum Token: Swift.Sendable {
+            case staticToken(Swift.String)
             case provider(CredentialProvider)
 
-            func retrieve() async throws -> String {
+            func retrieve() async throws -> Swift.String {
                 switch self {
                 case .staticToken(let token):
                     return token
@@ -32,37 +32,37 @@ public final class ClientConfig: Sendable {
     }
 
     struct BasicAuth {
-        let username: String?
-        let password: String?
+        let username: Swift.String?
+        let password: Swift.String?
 
-        var token: String? {
+        var token: Swift.String? {
             if let username, let password {
-                let credentials: String = "\(username):\(password)"
-                let data = credentials.data(using: .utf8) ?? Data()
+                let credentials: Swift.String = "\(username):\(password)"
+                let data = credentials.data(using: .utf8) ?? Foundation.Data()
                 return data.base64EncodedString()
             }
             return nil
         }
     }
 
-    let baseURL: String
+    let baseURL: Swift.String
     let headerAuth: HeaderAuth?
     let bearerAuth: BearerAuth?
     let basicAuth: BasicAuth?
-    let headers: [String: String]?
-    let timeout: Int
-    let maxRetries: Int
-    let urlSession: URLSession
+    let headers: [Swift.String: Swift.String]?
+    let timeout: Swift.Int
+    let maxRetries: Swift.Int
+    let urlSession: Networking.URLSession
 
     init(
-        baseURL: String,
+        baseURL: Swift.String,
         headerAuth: HeaderAuth? = nil,
         bearerAuth: BearerAuth? = nil,
         basicAuth: BasicAuth? = nil,
-        headers: [String: String]? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        headers: [Swift.String: Swift.String]? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        urlSession: Networking.URLSession? = nil
     ) {
         self.baseURL = baseURL
         self.headerAuth = headerAuth
@@ -75,8 +75,8 @@ public final class ClientConfig: Sendable {
     }
 }
 
-private func buildURLSession(timeoutSeconds: Int) -> URLSession {
-    let configuration = URLSessionConfiguration.default
+private func buildURLSession(timeoutSeconds: Swift.Int) -> Networking.URLSession {
+    let configuration = Networking.URLSessionConfiguration.default
     configuration.timeoutIntervalForRequest = .init(timeoutSeconds)
     return .init(configuration: configuration)
 }

--- a/seed/swift-sdk/websocket/Sources/Public/ClientError.swift
+++ b/seed/swift-sdk/websocket/Sources/Public/ClientError.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public enum ClientError: Error {
+public enum ClientError: Swift.Error {
     // Network & Client Errors
     case invalidURL
-    case encodingError(Error)
-    case decodingError(Error)
+    case encodingError(Swift.Error)
+    case decodingError(Swift.Error)
     case invalidResponse
-    case networkError(Error)
+    case networkError(Swift.Error)
 
     // Generic HTTP Errors (status code based)
     case badRequest(APIErrorResponse?)  // 400
@@ -15,9 +15,9 @@ public enum ClientError: Error {
     case notFound(APIErrorResponse?)  // 404
     case validationError(APIErrorResponse?)  // 422
     case serverError(APIErrorResponse?)  // 5xx
-    case httpError(statusCode: Int, response: APIErrorResponse?)  // other
+    case httpError(statusCode: Swift.Int, response: APIErrorResponse?)  // other
 
-    public var errorDescription: String? {
+    public var errorDescription: Swift.String? {
         switch self {
         case .invalidURL:
             return "Invalid URL"
@@ -47,8 +47,8 @@ public enum ClientError: Error {
         }
     }
 
-    private func formatErrorMessage(_ defaultMessage: String, _ response: APIErrorResponse?)
-        -> String
+    private func formatErrorMessage(_ defaultMessage: Swift.String, _ response: APIErrorResponse?)
+        -> Swift.String
     {
         guard let response = response else {
             return defaultMessage

--- a/seed/swift-sdk/websocket/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/websocket/Sources/Public/FormFile.swift
@@ -3,11 +3,11 @@ import Foundation
 /// Represents a file with its data and optional metadata for multipart uploads
 public struct FormFile {
     /// The file data
-    public let data: Data
+    public let data: Foundation.Data
     /// Optional filename
-    public let filename: String?
+    public let filename: Swift.String?
 
-    public init(data: Data, filename: String? = nil) {
+    public init(data: Foundation.Data, filename: Swift.String? = nil) {
         self.data = data
         self.filename = filename
     }
@@ -18,7 +18,7 @@ public struct FormFile {
 extension FormFile {
     /// Create a FormFile from raw Data with no metadata
     /// - Parameter data: The file data
-    public static func data(_ data: Data) -> FormFile {
+    public static func data(_ data: Foundation.Data) -> FormFile {
         return FormFile(data: data)
     }
 
@@ -26,7 +26,7 @@ extension FormFile {
     /// - Parameters:
     ///   - data: The file data
     ///   - filename: The filename
-    public static func named(_ data: Data, filename: String) -> FormFile {
+    public static func named(_ data: Foundation.Data, filename: Swift.String) -> FormFile {
         return FormFile(data: data, filename: filename)
     }
 }

--- a/seed/swift-sdk/websocket/Sources/Public/JSONValue.swift
+++ b/seed/swift-sdk/websocket/Sources/Public/JSONValue.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 /// A type that can represent any JSON value.
-public enum JSONValue: Codable, Hashable, Sendable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
+public enum JSONValue: Swift.Codable, Swift.Hashable, Swift.Sendable {
+    case string(Swift.String)
+    case number(Swift.Double)
+    case bool(Swift.Bool)
     case null
     case array([JSONValue])
-    case object([String: JSONValue])
+    case object([Swift.String: JSONValue])
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
             self = .null
-        } else if let bool = try? container.decode(Bool.self) {
+        } else if let bool = try? container.decode(Swift.Bool.self) {
             self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .number(Double(int))
-        } else if let double = try? container.decode(Double.self) {
+        } else if let int = try? container.decode(Swift.Int.self) {
+            self = .number(Swift.Double(int))
+        } else if let double = try? container.decode(Swift.Double.self) {
             self = .number(double)
-        } else if let string = try? container.decode(String.self) {
+        } else if let string = try? container.decode(Swift.String.self) {
             self = .string(string)
         } else if let array = try? container.decode([JSONValue].self) {
             self = .array(array)
-        } else if let object = try? container.decode([String: JSONValue].self) {
+        } else if let object = try? container.decode([Swift.String: JSONValue].self) {
             self = .object(object)
         } else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
+            throw Swift.DecodingError.dataCorrupted(
+                Swift.DecodingError.Context(
                     codingPath: decoder.codingPath,
                     debugDescription: "Unable to decode JSONValue"
                 )
@@ -36,7 +36,7 @@ public enum JSONValue: Codable, Hashable, Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {

--- a/seed/swift-sdk/websocket/Sources/Public/Networking.swift
+++ b/seed/swift-sdk/websocket/Sources/Public/Networking.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum Networking {
+    #if canImport(FoundationNetworking)
+        public typealias URLSession = FoundationNetworking.URLSession
+        public typealias URLSessionConfiguration = FoundationNetworking.URLSessionConfiguration
+        public typealias URLProtocol = FoundationNetworking.URLProtocol
+        public typealias URLRequest = FoundationNetworking.URLRequest
+        public typealias HTTPURLResponse = FoundationNetworking.HTTPURLResponse
+    #else
+        public typealias URLSession = Foundation.URLSession
+        public typealias URLSessionConfiguration = Foundation.URLSessionConfiguration
+        public typealias URLProtocol = Foundation.URLProtocol
+        public typealias URLRequest = Foundation.URLRequest
+        public typealias HTTPURLResponse = Foundation.HTTPURLResponse
+    #endif
+}

--- a/seed/swift-sdk/websocket/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/websocket/Sources/Public/Nullable.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
-public enum Nullable<Wrapped>: Codable, Hashable, Sendable
-where Wrapped: Codable & Hashable & Sendable {
+public enum Nullable<Wrapped>: Swift.Codable, Swift.Hashable, Swift.Sendable
+where Wrapped: Swift.Codable & Swift.Hashable & Swift.Sendable {
     case value(Wrapped)
     case null
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -17,7 +17,7 @@ where Wrapped: Codable & Hashable & Sendable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self {
@@ -39,7 +39,7 @@ where Wrapped: Codable & Hashable & Sendable {
     }
 
     /// Returns true if this contains an explicit null value
-    public var isNull: Bool {
+    public var isNull: Swift.Bool {
         switch self {
         case .value(_):
             return false

--- a/seed/swift-sdk/websocket/Sources/Public/RequestOptions.swift
+++ b/seed/swift-sdk/websocket/Sources/Public/RequestOptions.swift
@@ -5,34 +5,34 @@ import Foundation
 /// Use this struct to override or supplement client-wide configuration for a single request.
 public struct RequestOptions {
     /// The API key to use for this request, overriding the client-wide API key if provided.
-    let apiKey: String?
+    let apiKey: Swift.String?
 
     /// The token to use for this request, overriding the client-wide token if provided.
-    let token: String?
+    let token: Swift.String?
 
     /// The number of seconds to await an API call before timing out. If `nil`, uses the client or system default.
-    let timeout: Int?
+    let timeout: Swift.Int?
 
     /// The number of times to retry a failed API call. If `nil`, uses the client or system default.
-    let maxRetries: Int?
+    let maxRetries: Swift.Int?
 
     /// Additional HTTP headers to include with this request. These can override or supplement client-wide headers.
-    let additionalHeaders: [String: String]?
+    let additionalHeaders: [Swift.String: Swift.String]?
 
     /// Additional query parameters to include in the request URL. These are merged with any parameters generated from the request model.
-    let additionalQueryParameters: [String: String]?
+    let additionalQueryParameters: [Swift.String: Swift.String]?
 
     /// Additional body parameters to include in the request payload. These are merged with any parameters generated from the request model.
-    let additionalBodyParameters: [String: String]?
+    let additionalBodyParameters: [Swift.String: Swift.String]?
 
     public init(
-        apiKey: String? = nil,
-        token: String? = nil,
-        timeout: Int? = nil,
-        maxRetries: Int? = nil,
-        additionalHeaders: [String: String]? = nil,
-        additionalQueryParameters: [String: String]? = nil,
-        additionalBodyParameters: [String: String]? = nil
+        apiKey: Swift.String? = nil,
+        token: Swift.String? = nil,
+        timeout: Swift.Int? = nil,
+        maxRetries: Swift.Int? = nil,
+        additionalHeaders: [Swift.String: Swift.String]? = nil,
+        additionalQueryParameters: [Swift.String: Swift.String]? = nil,
+        additionalBodyParameters: [Swift.String: Swift.String]? = nil
     ) {
         self.apiKey = apiKey
         self.token = token

--- a/seed/swift-sdk/websocket/Sources/WebsocketClient.swift
+++ b/seed/swift-sdk/websocket/Sources/WebsocketClient.swift
@@ -18,7 +18,7 @@ public final class WebsocketClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         self.init(
             baseURL: baseURL,
@@ -40,7 +40,7 @@ public final class WebsocketClient: Sendable {
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
-        urlSession: URLSession? = nil
+        urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(
             baseURL: baseURL,

--- a/seed/swift-sdk/websocket/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/websocket/Tests/Utilities/HTTPStub.swift
@@ -1,18 +1,19 @@
+import Websocket
 import Foundation
 
 final class HTTPStub {
     private static func buildURLSession(stubId: String, operationQueue: OperationQueue)
-        -> URLSession
+        -> Networking.URLSession
     {
         let config = buildURLSessionConfiguration(stubId: stubId)
         if let uuid = UUID(uuidString: stubId) {
             StubURLProtocol.register(queue: operationQueue, id: uuid)
         }
-        return URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
+        return Networking.URLSession(configuration: config, delegate: nil, delegateQueue: operationQueue)
     }
 
-    private static func buildURLSessionConfiguration(stubId: String) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.ephemeral
+    private static func buildURLSessionConfiguration(stubId: String) -> Networking.URLSessionConfiguration {
+        let config = Networking.URLSessionConfiguration.ephemeral
         config.protocolClasses = [StubURLProtocol.self]
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
@@ -27,7 +28,7 @@ final class HTTPStub {
         return queue
     }
 
-    private let session: URLSession
+    private let session: Networking.URLSession
     private let delegateQueue: OperationQueue
     private let identifier: UUID
 
@@ -43,7 +44,7 @@ final class HTTPStub {
         #endif
     }
 
-    var urlSession: URLSession {
+    var urlSession: Networking.URLSession {
         session
     }
 
@@ -70,7 +71,7 @@ final class HTTPStub {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
 
-    func takeLastRequest() -> URLRequest? {
+    func takeLastRequest() -> Networking.URLRequest? {
         StubURLProtocol.takeLastRequest(for: identifier)
     }
 
@@ -87,18 +88,18 @@ final class HTTPStub {
     }
 }
 
-private final class StubURLProtocol: URLProtocol {
+private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
         let body: Data
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
     }
 
     struct ResponseSequence {
         var responses: [Response]
         var currentIndex: Int = 0
-        var lastRequest: URLRequest?
+        var lastRequest: Networking.URLRequest?
 
         mutating func nextResponse() -> Response? {
             guard currentIndex < responses.count else { return nil }
@@ -144,7 +145,7 @@ private final class StubURLProtocol: URLProtocol {
         lock.unlock()
     }
 
-    static func takeLastRequest(for id: UUID) -> URLRequest? {
+    static func takeLastRequest(for id: UUID) -> Networking.URLRequest? {
         lock.lock()
         defer { lock.unlock() }
 
@@ -208,7 +209,7 @@ private final class StubURLProtocol: URLProtocol {
         }
     #endif
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with request: Networking.URLRequest) -> Bool {
         #if canImport(Darwin)
             return request.value(forHTTPHeaderField: "Stub-ID") != nil
         #else
@@ -218,7 +219,7 @@ private final class StubURLProtocol: URLProtocol {
         #endif
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override class func canonicalRequest(for request: Networking.URLRequest) -> Networking.URLRequest {
         request
     }
 
@@ -273,7 +274,7 @@ private final class StubURLProtocol: URLProtocol {
                 return
             }
 
-            let httpResponse = HTTPURLResponse(
+            let httpResponse = Networking.HTTPURLResponse(
                 url: url,
                 statusCode: response.statusCode,
                 httpVersion: "HTTP/1.1",
@@ -300,7 +301,7 @@ private final class StubURLProtocol: URLProtocol {
             return
         }
 
-        let httpResponse = HTTPURLResponse(
+        let httpResponse = Networking.HTTPURLResponse(
             url: url,
             statusCode: response.statusCode,
             httpVersion: "HTTP/1.1",


### PR DESCRIPTION
## Description
Linear ticket: [FER-7487](https://linear.app/buildwithfern/issue/FER-7487/use-fully-qualified-names-in-as-is-files) 
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
<!-- Provide a clear and concise description of the changes made in this PR -->

This PR updates all unqualified references to Swift and Foundation types in “as-is” files to use fully qualified names. This prevents naming collisions between SDK-defined and built-in types, since static files bypass the graph resolution stage.

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Converted `HTTPStub` to a template file to import the SDK module
- Added a `Networking` container type to hold the networking types from `Foundation` and `FoundationNetworking` modules depending on the current platform
- Moved the `URLSession` type from `Foundation` to `Networking`
- Updated Seed snapshots

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated
- [x] Manual testing completed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace unqualified Swift/Foundation types with fully qualified names and introduce a `Networking` container for URLSession-related types across SDK and tests.
> 
> - **Core SDK**:
>   - Fully qualify stdlib types (e.g., `Swift.String`, `Foundation.Data`, `Foundation.JSONEncoder`, etc.) across source files to avoid name collisions.
>   - Add `public enum Networking` providing cross-platform typealiases (`URLSession`, `URLRequest`, `HTTPURLResponse`, etc.) via `Foundation`/`FoundationNetworking`.
>   - Update APIs to use `Networking.URLSession` (and related types) in `ClientConfig`, client initializers, `HTTPClient`, and helpers.
> - **Serde/HTTP Utilities**:
>   - Adjust `Serde`, encoder/decoder extensions, multipart, query parameter, and date utilities to use fully qualified types.
> - **Tests/Scaffolding**:
>   - Convert test `HTTPStub` usages to import SDK modules and use `Networking` types; align stubs with new typealiases.
> - **Seeds/Snapshots**:
>   - Regenerate seed SDKs to reflect qualified types and new `Networking` indirection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93b1f585fe2bf01be17ce43e438b4f6759082c33. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->