### PR TITLE
Fix infinite recursion in example generation for circular type references

### DIFF
--- a/generators/python/src/fern_python/generators/pydantic_model/type_declaration_handler/abc/abstract_type_snippet_generator.py
+++ b/generators/python/src/fern_python/generators/pydantic_model/type_declaration_handler/abc/abstract_type_snippet_generator.py
@@ -1,8 +1,11 @@
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 
 from fern_python.codegen import AST
 from fern_python.snippet import SnippetWriter
+
+if TYPE_CHECKING:
+    from fern_python.snippet.recursion_guard import RecursionGuard
 
 
 class AbstractTypeSnippetGenerator(ABC):
@@ -13,4 +16,4 @@ class AbstractTypeSnippetGenerator(ABC):
         self.snippet_writer = snippet_writer
 
     @abstractmethod
-    def generate_snippet(self) -> Optional[AST.Expression]: ...
+    def generate_snippet(self, recursion_guard: Optional["RecursionGuard"] = None) -> Optional[AST.Expression]: ...

--- a/generators/python/src/fern_python/generators/pydantic_model/type_declaration_handler/alias_generator.py
+++ b/generators/python/src/fern_python/generators/pydantic_model/type_declaration_handler/alias_generator.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 
 from ...context.pydantic_generator_context import PydanticGeneratorContext
 from ..custom_config import PydanticModelCustomConfig
@@ -11,6 +11,9 @@ from fern_python.generators.pydantic_model.type_declaration_handler.abc.abstract
 from fern_python.snippet import SnippetWriter
 
 import fern.ir.resources as ir_types
+
+if TYPE_CHECKING:
+    from fern_python.snippet.recursion_guard import RecursionGuard
 
 
 class AbstractAliasGenerator(AbstractTypeGenerator, ABC):
@@ -52,9 +55,10 @@ class AbstractAliasSnippetGenerator(AbstractTypeSnippetGenerator):
         self.as_request = as_request
         self.example = example
 
-    def generate_snippet(self) -> Optional[AST.Expression]:
+    def generate_snippet(self, recursion_guard: Optional["RecursionGuard"] = None) -> Optional[AST.Expression]:
         return self.snippet_writer.get_snippet_for_example_type_reference(
             example_type_reference=self.example.value,
             use_typeddict_request=self.use_typeddict_request,
             as_request=self.as_request,
+            recursion_guard=recursion_guard,
         )

--- a/generators/python/src/fern_python/generators/pydantic_model/type_declaration_handler/enum_generator.py
+++ b/generators/python/src/fern_python/generators/pydantic_model/type_declaration_handler/enum_generator.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from typing import Optional, Union, TYPE_CHECKING
 
 from ...context.pydantic_generator_context import PydanticGeneratorContext
 from ..custom_config import PydanticModelCustomConfig
@@ -11,6 +11,9 @@ from fern_python.generators.pydantic_model.type_declaration_handler.abc.abstract
 from fern_python.snippet import SnippetWriter
 
 import fern.ir.resources as ir_types
+
+if TYPE_CHECKING:
+    from fern_python.snippet.recursion_guard import RecursionGuard
 
 
 # Note enums are the same for both pydantic models and typeddicts os the generator is not multiplexed
@@ -166,7 +169,7 @@ class EnumSnippetGenerator(AbstractTypeSnippetGenerator):
         self.name = name
         self.example = example.value if isinstance(example, ir_types.ExampleEnumType) else example
 
-    def generate_snippet(self) -> AST.Expression:
+    def generate_snippet(self, recursion_guard: Optional["RecursionGuard"] = None) -> AST.Expression:
         class_reference = self.snippet_writer.get_class_reference_for_declared_type_name(
             name=self.name,
             as_request=False,

--- a/generators/python/src/fern_python/generators/pydantic_model/type_declaration_handler/pydantic_models/pydantic_model_object_generator.py
+++ b/generators/python/src/fern_python/generators/pydantic_model/type_declaration_handler/pydantic_models/pydantic_model_object_generator.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, TYPE_CHECKING
 
 from ....context.pydantic_generator_context import PydanticGeneratorContext
 from ...custom_config import PydanticModelCustomConfig
@@ -12,6 +12,9 @@ from fern_python.codegen import AST, SourceFile
 from fern_python.snippet import SnippetWriter
 
 import fern.ir.resources as ir_types
+
+if TYPE_CHECKING:
+    from fern_python.snippet.recursion_guard import RecursionGuard
 
 
 class PydanticModelObjectGenerator(AbstractObjectGenerator):
@@ -97,7 +100,7 @@ class PydanticModelObjectSnippetGenerator(AbstractObjectSnippetGenerator):
             example=example,
         )
 
-    def generate_snippet(self) -> AST.Expression:
+    def generate_snippet(self, recursion_guard: Optional["RecursionGuard"] = None) -> AST.Expression:
         return AST.Expression(
             AST.ClassInstantiation(
                 class_=self.snippet_writer.get_class_reference_for_declared_type_name(
@@ -110,6 +113,7 @@ class PydanticModelObjectSnippetGenerator(AbstractObjectSnippetGenerator):
                     use_typeddict_request=False,
                     as_request=False,
                     in_typeddict=False,
+                    recursion_guard=recursion_guard,
                 ),
             ),
         )

--- a/generators/python/src/fern_python/generators/pydantic_model/type_declaration_handler/typeddicts/typeddict_object_generator.py
+++ b/generators/python/src/fern_python/generators/pydantic_model/type_declaration_handler/typeddicts/typeddict_object_generator.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, TYPE_CHECKING
 
 from ....context.pydantic_generator_context import PydanticGeneratorContext
 from ...custom_config import PydanticModelCustomConfig
@@ -12,6 +12,9 @@ from fern_python.generators.pydantic_model.typeddict import FernTypedDict
 from fern_python.snippet import SnippetWriter
 
 import fern.ir.resources as ir_types
+
+if TYPE_CHECKING:
+    from fern_python.snippet.recursion_guard import RecursionGuard
 
 
 class TypeddictObjectGenerator(AbstractObjectGenerator):
@@ -72,5 +75,5 @@ class TypeddictObjectSnippetGenerator(AbstractObjectSnippetGenerator):
             example=example,
         )
 
-    def generate_snippet(self) -> AST.Expression:
-        return FernTypedDict.type_to_snippet(example=self.example, snippet_writer=self.snippet_writer)
+    def generate_snippet(self, recursion_guard: Optional["RecursionGuard"] = None) -> AST.Expression:
+        return FernTypedDict.type_to_snippet(example=self.example, snippet_writer=self.snippet_writer, recursion_guard=recursion_guard)

--- a/generators/python/src/fern_python/generators/pydantic_model/type_declaration_handler/undiscriminated_union_generator.py
+++ b/generators/python/src/fern_python/generators/pydantic_model/type_declaration_handler/undiscriminated_union_generator.py
@@ -1,6 +1,6 @@
 from abc import ABC
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import List, Optional, TYPE_CHECKING
 
 from ...context.pydantic_generator_context import PydanticGeneratorContext
 from ..custom_config import PydanticModelCustomConfig
@@ -12,6 +12,9 @@ from fern_python.generators.pydantic_model.type_declaration_handler.abc.abstract
 from fern_python.snippet.snippet_writer import SnippetWriter
 
 import fern.ir.resources as ir_types
+
+if TYPE_CHECKING:
+    from fern_python.snippet.recursion_guard import RecursionGuard
 
 
 @dataclass(frozen=True)
@@ -71,9 +74,10 @@ class AbstractUndiscriminatedUnionSnippetGenerator(AbstractTypeSnippetGenerator)
         self.as_request = as_request
         self.use_typeddict_request = use_typeddict_request
 
-    def generate_snippet(self) -> Optional[AST.Expression]:
+    def generate_snippet(self, recursion_guard: Optional["RecursionGuard"] = None) -> Optional[AST.Expression]:
         return self.snippet_writer.get_snippet_for_example_type_reference(
             example_type_reference=self.example.single_union_type,
             use_typeddict_request=self.use_typeddict_request,
             as_request=self.as_request,
+            recursion_guard=recursion_guard,
         )

--- a/generators/python/src/fern_python/generators/pydantic_model/typeddict.py
+++ b/generators/python/src/fern_python/generators/pydantic_model/typeddict.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from types import TracebackType
-from typing import Dict, List, Optional, Sequence, Type
+from typing import Dict, List, Optional, Sequence, Type, TYPE_CHECKING
 
 from ..context.pydantic_generator_context import PydanticGeneratorContext
 from fern_python.codegen import AST, SourceFile
@@ -15,6 +15,9 @@ from fern_python.generators.pydantic_model.model_utilities import can_be_fern_mo
 from fern_python.snippet.snippet_writer import SnippetWriter
 
 import fern.ir.resources as ir_types
+
+if TYPE_CHECKING:
+    from fern_python.snippet.recursion_guard import RecursionGuard
 
 TYPING_EXTENSIONS_MODULE = AST.Module.external(
     module_path=("typing_extensions",),
@@ -203,7 +206,7 @@ class FernTypedDict:
 
     @classmethod
     def snippet_from_properties(
-        cls, example_properties: List[SimpleObjectProperty], snippet_writer: SnippetWriter
+        cls, example_properties: List[SimpleObjectProperty], snippet_writer: SnippetWriter, recursion_guard: Optional["RecursionGuard"] = None
     ) -> AST.Expression:
         example_dict_pairs: List[ir_types.ExampleKeyValuePair] = []
         for property in example_properties:
@@ -219,7 +222,7 @@ class FernTypedDict:
                 )
             )
         return snippet_writer._get_snippet_for_map(
-            example_dict_pairs, use_typeddict_request=True, as_request=True, in_typeddict=True
+            example_dict_pairs, use_typeddict_request=True, as_request=True, in_typeddict=True, recursion_guard=recursion_guard
         )
 
     @classmethod
@@ -228,6 +231,7 @@ class FernTypedDict:
         example: ir_types.ExampleObjectType,
         snippet_writer: SnippetWriter,
         additional_properties: List[SimpleObjectProperty] = [],
+        recursion_guard: Optional["RecursionGuard"] = None,
     ) -> AST.Expression:
         example_properties = [
             SimpleObjectProperty(
@@ -240,6 +244,7 @@ class FernTypedDict:
         return cls.snippet_from_properties(
             example_properties=example_properties,
             snippet_writer=snippet_writer,
+            recursion_guard=recursion_guard,
         )
 
     @classmethod

--- a/generators/python/src/fern_python/snippet/recursion_guard.py
+++ b/generators/python/src/fern_python/snippet/recursion_guard.py
@@ -1,0 +1,50 @@
+from typing import Optional, Set
+import fern.ir.resources as ir_types
+
+
+class RecursionGuard:
+    """
+    Guards against infinite recursion when generating examples for types with circular references.
+    Tracks visited types on the current recursion path and enforces a maximum depth limit.
+    """
+
+    def __init__(self, max_depth: int = 5):
+        self._visited: Set[str] = set()
+        self._depth: int = 0
+        self._max_depth: int = max_depth
+
+    def _get_type_key(self, type_name: ir_types.DeclaredTypeName) -> str:
+        """Generate a unique key for a type based on its package path and name."""
+        fern_filepath = ".".join(type_name.fern_filepath.package_path.parts) if type_name.fern_filepath.package_path.parts else ""
+        return f"{fern_filepath}:{type_name.name.original_name}"
+
+    def can_recurse(self, type_name: ir_types.DeclaredTypeName) -> bool:
+        """
+        Check if we can safely recurse into the given type.
+        Returns False if the type is already on the recursion stack or if max depth is exceeded.
+        """
+        if self._depth >= self._max_depth:
+            return False
+        
+        type_key = self._get_type_key(type_name)
+        return type_key not in self._visited
+
+    def enter(self, type_name: ir_types.DeclaredTypeName) -> "RecursionGuard":
+        """
+        Enter a new recursion level for the given type.
+        Returns a new RecursionGuard with the type added to the visited set.
+        """
+        new_guard = RecursionGuard(max_depth=self._max_depth)
+        new_guard._visited = self._visited.copy()
+        new_guard._visited.add(self._get_type_key(type_name))
+        new_guard._depth = self._depth + 1
+        return new_guard
+
+    def with_depth_increment(self) -> "RecursionGuard":
+        """
+        Increment depth without adding to visited set (for containers like lists/maps).
+        """
+        new_guard = RecursionGuard(max_depth=self._max_depth)
+        new_guard._visited = self._visited.copy()
+        new_guard._depth = self._depth + 1
+        return new_guard

--- a/generators/python/src/fern_python/snippet/type_declaration_snippet_generator.py
+++ b/generators/python/src/fern_python/snippet/type_declaration_snippet_generator.py
@@ -4,12 +4,16 @@ from fern_python.codegen import AST
 
 import fern.ir.resources as ir_types
 
-AliasSnippetGenerator = Callable[[ir_types.ExampleAliasType], Optional[AST.Expression]]
-EnumSnippetGenerator = Callable[[ir_types.DeclaredTypeName, ir_types.ExampleEnumType], AST.Expression]
-ObjectSnippetGenerator = Callable[[ir_types.DeclaredTypeName, ir_types.ExampleObjectType], AST.Expression]
-DiscriminatedUnionGenerator = Callable[[ir_types.DeclaredTypeName, ir_types.ExampleUnionType], AST.Expression]
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from .recursion_guard import RecursionGuard
+
+AliasSnippetGenerator = Callable[[ir_types.ExampleAliasType, Optional["RecursionGuard"]], Optional[AST.Expression]]
+EnumSnippetGenerator = Callable[[ir_types.DeclaredTypeName, ir_types.ExampleEnumType, Optional["RecursionGuard"]], AST.Expression]
+ObjectSnippetGenerator = Callable[[ir_types.DeclaredTypeName, ir_types.ExampleObjectType, Optional["RecursionGuard"]], AST.Expression]
+DiscriminatedUnionGenerator = Callable[[ir_types.DeclaredTypeName, ir_types.ExampleUnionType, Optional["RecursionGuard"]], AST.Expression]
 UndiscriminatedUnionGenerator = Callable[
-    [ir_types.DeclaredTypeName, ir_types.ExampleUndiscriminatedUnionType], Optional[AST.Expression]
+    [ir_types.DeclaredTypeName, ir_types.ExampleUndiscriminatedUnionType, Optional["RecursionGuard"]], Optional[AST.Expression]
 ]
 
 
@@ -32,11 +36,12 @@ class TypeDeclarationSnippetGenerator:
         self,
         name: ir_types.DeclaredTypeName,
         example: ir_types.ExampleTypeShape,
+        recursion_guard: Optional["RecursionGuard"] = None,
     ) -> Optional[AST.Expression]:
         return example.visit(
-            alias=lambda alias: self._generate_alias(alias),
-            enum=lambda enum: self._generate_enum(name, enum),
-            object=lambda object_: self._generate_object(name, object_),
-            union=lambda union: self._generate_discriminated_union(name, union),
-            undiscriminated_union=lambda union: self._generate_undiscriminated_union(name, union),
+            alias=lambda alias: self._generate_alias(alias, recursion_guard),
+            enum=lambda enum: self._generate_enum(name, enum, recursion_guard),
+            object=lambda object_: self._generate_object(name, object_, recursion_guard),
+            union=lambda union: self._generate_discriminated_union(name, union, recursion_guard),
+            undiscriminated_union=lambda union: self._generate_undiscriminated_union(name, union, recursion_guard),
         )

--- a/generators/typescript/model/type-generator/src/AbstractGeneratedType.ts
+++ b/generators/typescript/model/type-generator/src/AbstractGeneratedType.ts
@@ -1,6 +1,7 @@
 import { ExampleType, ExampleTypeShape, FernFilepath } from "@fern-fern/ir-sdk/api";
 import { GetReferenceOpts, getTextOfTsNode, Reference } from "@fern-typescript/commons";
 import { BaseContext, BaseGeneratedType } from "@fern-typescript/contexts";
+import { RecursionGuard } from "@fern-typescript/type-reference-example-generator";
 import { ModuleDeclarationStructure, StatementStructures, ts, WriterFunction } from "ts-morph";
 
 export declare namespace AbstractGeneratedType {
@@ -108,5 +109,5 @@ export abstract class AbstractGeneratedType<Shape, Context extends BaseContext> 
         responseTypeNode: ts.TypeNode | undefined;
     };
     public abstract generateModule(context: Context): ModuleDeclarationStructure | undefined;
-    public abstract buildExample(example: ExampleTypeShape, context: Context, opts: GetReferenceOpts): ts.Expression;
+    public abstract buildExample(example: ExampleTypeShape, context: Context, opts: GetReferenceOpts, recursionGuard?: RecursionGuard): ts.Expression;
 }

--- a/generators/typescript/model/type-generator/src/alias/GeneratedAliasTypeImpl.ts
+++ b/generators/typescript/model/type-generator/src/alias/GeneratedAliasTypeImpl.ts
@@ -73,7 +73,7 @@ export class GeneratedAliasTypeImpl<Context extends BaseContext>
         });
     }
 
-    public buildExample(example: ExampleTypeShape, context: Context, opts: GetReferenceOpts): ts.Expression {
+    public buildExample(example: ExampleTypeShape, context: Context, opts: GetReferenceOpts, recursionGuard?: RecursionGuard): ts.Expression {
         if (example.type !== "alias") {
             throw new Error("Example is not for an alias");
         }

--- a/generators/typescript/model/type-generator/src/alias/GeneratedBrandedStringAliasImpl.ts
+++ b/generators/typescript/model/type-generator/src/alias/GeneratedBrandedStringAliasImpl.ts
@@ -54,7 +54,7 @@ export class GeneratedBrandedStringAliasImpl<Context extends BaseContext>
         return this.getReferenceToSelf(context).getExpression(opts);
     }
 
-    public buildExample(example: ExampleTypeShape, context: Context, opts: GetReferenceOpts): ts.Expression {
+    public buildExample(example: ExampleTypeShape, context: Context, opts: GetReferenceOpts, recursionGuard?: RecursionGuard): ts.Expression {
         if (example.type !== "alias") {
             throw new Error("Example is not for an alias");
         }

--- a/generators/typescript/model/type-generator/src/enum/GeneratedEnumTypeImpl.ts
+++ b/generators/typescript/model/type-generator/src/enum/GeneratedEnumTypeImpl.ts
@@ -275,7 +275,7 @@ export class GeneratedEnumTypeImpl<Context extends BaseContext>
         return enumModule;
     }
 
-    public buildExample(example: ExampleTypeShape, context: Context, opts: GetReferenceOpts): ts.Expression {
+    public buildExample(example: ExampleTypeShape, context: Context, opts: GetReferenceOpts, recursionGuard?: RecursionGuard): ts.Expression {
         if (example.type !== "enum") {
             throw new Error("Example is not for an enum");
         }

--- a/generators/typescript/model/type-generator/src/object/GeneratedObjectTypeImpl.ts
+++ b/generators/typescript/model/type-generator/src/object/GeneratedObjectTypeImpl.ts
@@ -253,7 +253,7 @@ export class GeneratedObjectTypeImpl<Context extends BaseContext>
         }
     }
 
-    public buildExample(example: ExampleTypeShape, context: Context, opts: GetReferenceOpts): ts.Expression {
+    public buildExample(example: ExampleTypeShape, context: Context, opts: GetReferenceOpts, recursionGuard?: RecursionGuard): ts.Expression {
         if (example.type !== "object") {
             throw new Error("Example is not for an object");
         }

--- a/generators/typescript/model/type-generator/src/undiscriminated-union/GeneratedUndiscriminatedUnionTypeImpl.ts
+++ b/generators/typescript/model/type-generator/src/undiscriminated-union/GeneratedUndiscriminatedUnionTypeImpl.ts
@@ -175,7 +175,7 @@ export class GeneratedUndiscriminatedUnionTypeImpl<Context extends BaseContext>
         return this.getTypeReferenceNode(context, member).typeNode;
     }
 
-    public buildExample(example: ExampleTypeShape, context: Context, opts: GetReferenceOpts): ts.Expression {
+    public buildExample(example: ExampleTypeShape, context: Context, opts: GetReferenceOpts, recursionGuard?: RecursionGuard): ts.Expression {
         if (example.type !== "undiscriminatedUnion") {
             throw new Error("Example is not for an undiscriminated union");
         }

--- a/generators/typescript/model/type-generator/src/union/GeneratedUnionTypeImpl.ts
+++ b/generators/typescript/model/type-generator/src/union/GeneratedUnionTypeImpl.ts
@@ -119,7 +119,7 @@ export class GeneratedUnionTypeImpl<Context extends BaseContext>
         }
     }
 
-    public buildExample(example: ExampleTypeShape, context: Context, opts: GetReferenceOpts): ts.Expression {
+    public buildExample(example: ExampleTypeShape, context: Context, opts: GetReferenceOpts, recursionGuard?: RecursionGuard): ts.Expression {
         if (example.type !== "union") {
             throw new Error("Example is not for an union");
         }

--- a/generators/typescript/model/type-reference-example-generator/src/RecursionGuard.ts
+++ b/generators/typescript/model/type-reference-example-generator/src/RecursionGuard.ts
@@ -1,0 +1,36 @@
+import { TypeId } from "@fern-fern/ir-sdk/api";
+
+export interface RecursionGuard {
+    canRecurse(typeId: TypeId): boolean;
+    enter(typeId: TypeId): RecursionGuard;
+    withDepthIncrement(): RecursionGuard;
+}
+
+export class RecursionGuardImpl implements RecursionGuard {
+    private visited: Set<string>;
+    private depth: number;
+    private maxDepth: number;
+
+    constructor(maxDepth: number = 5, visited: Set<string> = new Set(), depth: number = 0) {
+        this.maxDepth = maxDepth;
+        this.visited = visited;
+        this.depth = depth;
+    }
+
+    public canRecurse(typeId: TypeId): boolean {
+        if (this.depth >= this.maxDepth) {
+            return false;
+        }
+        return !this.visited.has(typeId);
+    }
+
+    public enter(typeId: TypeId): RecursionGuard {
+        const newVisited = new Set(this.visited);
+        newVisited.add(typeId);
+        return new RecursionGuardImpl(this.maxDepth, newVisited, this.depth + 1);
+    }
+
+    public withDepthIncrement(): RecursionGuard {
+        return new RecursionGuardImpl(this.maxDepth, new Set(this.visited), this.depth + 1);
+    }
+}

--- a/generators/typescript/model/type-reference-example-generator/src/index.ts
+++ b/generators/typescript/model/type-reference-example-generator/src/index.ts
@@ -1,1 +1,2 @@
 export { TypeReferenceExampleGenerator } from "./TypeReferenceExampleGenerator";
+export { RecursionGuard, RecursionGuardImpl } from "./RecursionGuard";

--- a/generators/typescript/utils/contexts/src/base-context/type/BaseGeneratedType.ts
+++ b/generators/typescript/utils/contexts/src/base-context/type/BaseGeneratedType.ts
@@ -6,11 +6,12 @@ import { GeneratedFile } from "../../commons";
 import { GeneratedModule } from "../../commons/GeneratedModule";
 import { GeneratedStatements } from "../../commons/GeneratedStatements";
 import { GeneratedUnionInlineMemberNode } from "../../commons/GeneratedUnionInlineMemberNode";
+import { RecursionGuard } from "@fern-typescript/type-reference-example-generator";
 
 export interface BaseGeneratedType<Context>
     extends GeneratedFile<Context>,
         GeneratedStatements<Context>,
         GeneratedModule<Context>,
         GeneratedUnionInlineMemberNode<Context> {
-    buildExample: (example: ExampleTypeShape, context: Context, opts: GetReferenceOpts) => ts.Expression;
+    buildExample: (example: ExampleTypeShape, context: Context, opts: GetReferenceOpts, recursionGuard?: RecursionGuard) => ts.Expression;
 }


### PR DESCRIPTION
# Fix infinite recursion in example generation for circular type references

## Summary
This PR adds cycle detection to prevent infinite recursion when generating examples for types with circular references in both Python and TypeScript SDK generators.

**Problem**: When types have circular references (e.g., type A references type B, which references type A), the example generators would recurse infinitely, causing stack overflow errors as seen in [VapiAI/docs PR #795](https://github.com/VapiAI/docs/pull/795).

**Solution**: 
- Created `RecursionGuard` utility classes for both Python and TypeScript that track visited types and enforce a maximum recursion depth (default: 5)
- Threaded the recursion guard through all example generation code paths
- When a cycle is detected (type already visited on current stack) or max depth is reached, return `None`/`undefined` which gets filtered out by existing code

**Python changes**:
- New `RecursionGuard` class in `generators/python/src/fern_python/snippet/recursion_guard.py`
- Updated `SnippetWriter` and all snippet generator implementations to accept and pass through `recursion_guard` parameter
- Updated `FernTypedDict` helper methods to support recursion guard

**TypeScript changes**:
- New `RecursionGuard` interface and `RecursionGuardImpl` class in `generators/typescript/model/type-reference-example-generator/src/RecursionGuard.ts`
- Updated `GeneratedTypeReferenceExampleImpl.buildExample()` to check for cycles before recursing into named types
- Updated `BaseGeneratedType` interface and all concrete implementations to accept optional `recursionGuard` parameter

## Review & Testing Checklist for Human
**⚠️ CRITICAL - This PR has NOT been tested against the actual failing examples**

- [ ] **Test with VapiAI/docs examples**: Clone the VapiAI/docs repo, check out PR #795, and verify that SDK generation no longer causes infinite recursion with this fix
- [ ] **Verify TypeScript compilation**: Run `pnpm build` or equivalent in the TypeScript generators to ensure no compilation errors were introduced
- [ ] **Check maxDepth appropriateness**: The default maxDepth is set to 5. Verify this doesn't break legitimate deeply nested examples and is sufficient to catch cycles early
- [ ] **Validate return values**: Confirm that returning `None`/`undefined` on cycle detection is correct and doesn't break example generation for valid cases
- [ ] **Performance testing**: Test with deeply nested (but non-circular) structures to ensure the recursion guard doesn't cause performance issues

### Test Plan
1. Set up a test API definition with circular type references (e.g., `type A { b: B }`, `type B { a: A }`)
2. Generate Python and TypeScript SDKs with examples enabled
3. Verify generation completes without stack overflow
4. Verify generated examples are valid (or omitted for circular fields)
5. Test with the actual VapiAI/docs configuration that was failing

### Notes
- The recursion guard uses a copy-on-write approach for the visited set to avoid shared mutable state
- The `withDepthIncrement()` method is used for container types (lists, maps) to track depth without marking types as visited
- No unit tests were added in this PR - these should be added as follow-up work
- Session: https://app.devin.ai/sessions/e43b93483cc145b58c6b14ea1407a3f1
- Requested by: William McAdams (@musicpulpite, william.mcadams@buildwithfern.com)