### PR TITLE
fix(typescript): fix imports for jest/vitest on `requestWithRetries.test.ts`

### DIFF
--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,11 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.28.8
+  changelogEntry:
+    - summary: Clean up imports for requestWithRetries.test.ts.
+      type: fix
+  createdAt: "2025-11-10"
+  irVersion: 61
+
 - version: 3.28.7
   changelogEntry:
     - summary: |

--- a/generators/typescript/utils/commons/src/typescript-project/convertJestImportsToVitest.ts
+++ b/generators/typescript/utils/commons/src/typescript-project/convertJestImportsToVitest.ts
@@ -30,7 +30,7 @@ export async function convertJestImportsToVitest(
         // 1. Replace jest.Mock with Mock
         sourceFile.forEachDescendant((node) => {
             if (node.getKind() === SyntaxKind.TypeReference && node.getText().startsWith("jest.Mock")) {
-                node.replaceWithText('Mock');
+                node.replaceWithText("Mock");
                 needsMock = true;
             }
         });
@@ -38,7 +38,7 @@ export async function convertJestImportsToVitest(
         // 2. Replace jest.SpyInstance with MockInstance
         sourceFile.forEachDescendant((node) => {
             if (node.getKind() === SyntaxKind.TypeReference && node.getText().startsWith("jest.SpyInstance")) {
-                node.replaceWithText('MockInstance');
+                node.replaceWithText("MockInstance");
                 needsMockInstance = true;
             }
         });
@@ -49,7 +49,7 @@ export async function convertJestImportsToVitest(
             const importsToAdd = [];
             if (vitestImport) {
                 const namedImports = vitestImport.getNamedImports();
-                const existingNames = namedImports.map(ni => ni.getName());
+                const existingNames = namedImports.map((ni) => ni.getName());
 
                 if (needsMock && !existingNames.includes("Mock")) {
                     importsToAdd.push("Mock");

--- a/generators/typescript/utils/core-utilities/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/generators/typescript/utils/core-utilities/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,9 @@
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("jest").Mock;
+    let mockFetch: jest.Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("jest").MockInstance;
+    let setTimeoutSpy: jest.SpyInstance;
 
     beforeEach(() => {
         mockFetch = jest.fn();

--- a/seed/ts-sdk/accept-header/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/accept-header/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/accept-header/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/accept-header/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/alias-extends/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/alias-extends/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/alias-extends/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/alias-extends/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/alias/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/alias/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/alias/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/alias/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/any-auth/generate-endpoint-metadata/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/any-auth/generate-endpoint-metadata/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/any-auth/generate-endpoint-metadata/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/any-auth/generate-endpoint-metadata/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/any-auth/no-custom-config/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/any-auth/no-custom-config/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/any-auth/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/any-auth/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/api-wide-base-path/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/api-wide-base-path/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/api-wide-base-path/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/api-wide-base-path/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/audiences/no-custom-config/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/audiences/no-custom-config/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/audiences/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/audiences/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/audiences/with-partner-audience/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/audiences/with-partner-audience/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/audiences/with-partner-audience/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/audiences/with-partner-audience/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/auth-environment-variables/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/auth-environment-variables/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/auth-environment-variables/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/auth-environment-variables/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/basic-auth-environment-variables/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/basic-auth-environment-variables/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/basic-auth-environment-variables/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/basic-auth-environment-variables/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/basic-auth/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/basic-auth/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/basic-auth/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/basic-auth/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/bearer-token-environment-variable/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/bearer-token-environment-variable/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/bearer-token-environment-variable/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/bearer-token-environment-variable/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/bytes-download/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/bytes-download/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/bytes-download/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/bytes-download/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/bytes-upload/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/bytes-upload/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/bytes-upload/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/bytes-upload/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/circular-references-advanced/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/circular-references-advanced/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/circular-references-advanced/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/circular-references-advanced/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/circular-references/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/circular-references/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/circular-references/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/circular-references/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/client-side-params/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/client-side-params/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/client-side-params/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/client-side-params/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/content-type/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/content-type/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/content-type/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/content-type/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/cross-package-type-names/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/cross-package-type-names/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/cross-package-type-names/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/cross-package-type-names/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/custom-auth/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/custom-auth/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/custom-auth/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/custom-auth/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/empty-clients/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/empty-clients/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/empty-clients/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/empty-clients/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/enum/forward-compatible-enums/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/enum/forward-compatible-enums/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/enum/forward-compatible-enums/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/enum/forward-compatible-enums/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/enum/no-custom-config/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/enum/no-custom-config/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/enum/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/enum/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/enum/serde/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/enum/serde/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/enum/serde/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/enum/serde/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/error-property/no-custom-config/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/error-property/no-custom-config/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/error-property/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/error-property/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/error-property/union-utils/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/error-property/union-utils/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/error-property/union-utils/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/error-property/union-utils/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/errors/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/errors/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/errors/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/errors/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/examples/examples-with-api-reference/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/examples/examples-with-api-reference/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/examples/retain-original-casing/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/examples/retain-original-casing/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,9 @@
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("jest").Mock;
+    let mockFetch: jest.Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("jest").MockInstance;
+    let setTimeoutSpy: jest.SpyInstance;
 
     beforeEach(() => {
         mockFetch = jest.fn();

--- a/seed/ts-sdk/exhaustive/bigint/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/exhaustive/bigint/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,9 @@
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("jest").Mock;
+    let mockFetch: jest.Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("jest").MockInstance;
+    let setTimeoutSpy: jest.SpyInstance;
 
     beforeEach(() => {
         mockFetch = jest.fn();

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/exhaustive/never-throw-errors/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/exhaustive/never-throw-errors/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/exhaustive/no-custom-config/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/exhaustive/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/exhaustive/node-fetch/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/exhaustive/node-fetch/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../../../src/test-packagePath/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../../../src/test-packagePath/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/exhaustive/retain-original-casing/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/exhaustive/retain-original-casing/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/exhaustive/serde-layer/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/exhaustive/serde-layer/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/exhaustive/use-jest/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,9 @@
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("jest").Mock;
+    let mockFetch: jest.Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("jest").MockInstance;
+    let setTimeoutSpy: jest.SpyInstance;
 
     beforeEach(() => {
         mockFetch = jest.fn();

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/exhaustive/with-audiences/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/exhaustive/with-audiences/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/exhaustive/with-audiences/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/exhaustive/with-audiences/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/extends/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/extends/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/extends/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/extends/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/extra-properties/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/extra-properties/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/extra-properties/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/extra-properties/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/file-download/file-download-response-headers/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/file-download/file-download-response-headers/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/file-download/file-download-response-headers/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/file-download/file-download-response-headers/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/file-download/no-custom-config/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/file-download/no-custom-config/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/file-download/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/file-download/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/file-download/stream-wrapper/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/file-download/stream-wrapper/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,9 @@
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("jest").Mock;
+    let mockFetch: jest.Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("jest").MockInstance;
+    let setTimeoutSpy: jest.SpyInstance;
 
     beforeEach(() => {
         mockFetch = jest.fn();

--- a/seed/ts-sdk/file-upload-openapi/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/file-upload-openapi/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/file-upload-openapi/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/file-upload-openapi/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/file-upload/form-data-node16/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/file-upload/form-data-node16/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/file-upload/form-data-node16/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/file-upload/form-data-node16/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/file-upload/inline/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/file-upload/inline/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/file-upload/inline/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/file-upload/inline/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/file-upload/no-custom-config/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/file-upload/no-custom-config/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/file-upload/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/file-upload/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/file-upload/serde/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/file-upload/serde/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/file-upload/serde/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/file-upload/serde/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/file-upload/use-jest/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/file-upload/use-jest/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,9 @@
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("jest").Mock;
+    let mockFetch: jest.Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("jest").MockInstance;
+    let setTimeoutSpy: jest.SpyInstance;
 
     beforeEach(() => {
         mockFetch = jest.fn();

--- a/seed/ts-sdk/file-upload/wrapper/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/file-upload/wrapper/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,9 @@
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("jest").Mock;
+    let mockFetch: jest.Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("jest").MockInstance;
+    let setTimeoutSpy: jest.SpyInstance;
 
     beforeEach(() => {
         mockFetch = jest.fn();

--- a/seed/ts-sdk/folders/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/folders/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/folders/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/folders/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/http-head/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/http-head/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/http-head/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/http-head/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/idempotency-headers/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/idempotency-headers/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/idempotency-headers/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/idempotency-headers/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/imdb/branded-string-aliases/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/imdb/branded-string-aliases/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/imdb/branded-string-aliases/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/imdb/branded-string-aliases/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/imdb/no-custom-config/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/imdb/no-custom-config/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/imdb/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/imdb/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/imdb/omit-undefined/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/imdb/omit-undefined/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/imdb/omit-undefined/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/imdb/omit-undefined/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/inferred-auth-explicit/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/inferred-auth-explicit/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/inferred-auth-explicit/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/inferred-auth-explicit/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/inferred-auth-implicit-no-expiry/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-no-expiry/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/inferred-auth-implicit-no-expiry/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-no-expiry/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/inferred-auth-implicit/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/inferred-auth-implicit/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/inferred-auth-implicit/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/inferred-auth-implicit/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/license/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/license/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/license/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/license/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/literal/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/literal/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/literal/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/literal/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/literals-unions/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/literals-unions/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/literals-unions/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/literals-unions/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/mixed-case/no-custom-config/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/mixed-case/no-custom-config/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/mixed-case/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/mixed-case/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/mixed-case/retain-original-casing/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/mixed-case/retain-original-casing/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/mixed-case/retain-original-casing/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/mixed-case/retain-original-casing/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/mixed-file-directory/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/mixed-file-directory/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/mixed-file-directory/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/mixed-file-directory/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/multi-line-docs/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/multi-line-docs/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/multi-line-docs/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/multi-line-docs/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/multi-url-environment-no-default/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/multi-url-environment-no-default/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/multi-url-environment-no-default/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/multi-url-environment-no-default/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/multi-url-environment/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/multi-url-environment/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/multi-url-environment/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/multi-url-environment/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/multiple-request-bodies/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/multiple-request-bodies/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/multiple-request-bodies/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/multiple-request-bodies/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/no-environment/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/no-environment/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/no-environment/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/no-environment/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/no-retries/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/no-retries/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/no-retries/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/no-retries/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/nullable-optional/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/nullable-optional/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/nullable-optional/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/nullable-optional/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/nullable/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/nullable/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/nullable/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/nullable/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/oauth-client-credentials-custom/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-custom/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/oauth-client-credentials-custom/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-custom/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/oauth-client-credentials-default/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-default/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/oauth-client-credentials-default/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-default/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/oauth-client-credentials-with-variables/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-with-variables/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/oauth-client-credentials-with-variables/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-with-variables/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/oauth-client-credentials/no-custom-config/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials/no-custom-config/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/oauth-client-credentials/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/oauth-client-credentials/serde/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials/serde/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/oauth-client-credentials/serde/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials/serde/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/object/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/object/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/object/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/object/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/objects-with-imports/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/objects-with-imports/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/objects-with-imports/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/objects-with-imports/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/optional/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/optional/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/optional/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/optional/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/package-yml/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/package-yml/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/package-yml/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/package-yml/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/pagination-custom/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/pagination-custom/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/pagination-custom/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/pagination-custom/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/pagination/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/pagination/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/pagination/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/pagination/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/path-parameters/inline-path-parameters-retain-original-casing/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/path-parameters/inline-path-parameters-retain-original-casing/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/path-parameters/inline-path-parameters-retain-original-casing/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/path-parameters/inline-path-parameters-retain-original-casing/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/path-parameters/inline-path-parameters-serde/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/path-parameters/inline-path-parameters-serde/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/path-parameters/inline-path-parameters-serde/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/path-parameters/inline-path-parameters-serde/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/path-parameters/inline-path-parameters/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/path-parameters/inline-path-parameters/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/path-parameters/inline-path-parameters/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/path-parameters/inline-path-parameters/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/path-parameters/no-custom-config/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/path-parameters/no-custom-config/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/path-parameters/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/path-parameters/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/path-parameters/retain-original-casing/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/path-parameters/retain-original-casing/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/path-parameters/retain-original-casing/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/path-parameters/retain-original-casing/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/plain-text/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/plain-text/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/plain-text/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/plain-text/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/property-access/generate-read-write-only-types/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/property-access/generate-read-write-only-types/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/property-access/generate-read-write-only-types/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/property-access/generate-read-write-only-types/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/property-access/no-custom-config/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/property-access/no-custom-config/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/property-access/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/property-access/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/public-object/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/public-object/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/public-object/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/public-object/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/query-parameters-openapi-as-objects/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/query-parameters-openapi-as-objects/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/query-parameters-openapi-as-objects/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/query-parameters-openapi-as-objects/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/query-parameters-openapi/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/query-parameters-openapi/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/query-parameters-openapi/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/query-parameters-openapi/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/query-parameters/no-custom-config/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/query-parameters/no-custom-config/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/query-parameters/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/query-parameters/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/query-parameters/serde/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/query-parameters/serde/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/query-parameters/serde/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/query-parameters/serde/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/request-parameters/flatten-request-parameters/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/request-parameters/flatten-request-parameters/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/request-parameters/flatten-request-parameters/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/request-parameters/flatten-request-parameters/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/request-parameters/no-custom-config/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/request-parameters/no-custom-config/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/request-parameters/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/request-parameters/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,9 @@
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("jest").Mock;
+    let mockFetch: jest.Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("jest").MockInstance;
+    let setTimeoutSpy: jest.SpyInstance;
 
     beforeEach(() => {
         mockFetch = jest.fn();

--- a/seed/ts-sdk/request-parameters/use-default-request-parameter-values/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/request-parameters/use-default-request-parameter-values/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/request-parameters/use-default-request-parameter-values/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/request-parameters/use-default-request-parameter-values/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/required-nullable/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/required-nullable/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/required-nullable/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/required-nullable/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/reserved-keywords/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/reserved-keywords/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/reserved-keywords/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/reserved-keywords/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/response-property/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/response-property/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/response-property/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/response-property/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/server-sent-event-examples/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/server-sent-event-examples/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/server-sent-event-examples/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/server-sent-event-examples/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/server-sent-events/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/server-sent-events/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/server-sent-events/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/server-sent-events/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/simple-api/allow-custom-fetcher/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/simple-api/allow-custom-fetcher/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/simple-api/allow-custom-fetcher/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/simple-api/allow-custom-fetcher/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/simple-api/allow-extra-fields/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/simple-api/allow-extra-fields/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/simple-api/allow-extra-fields/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/simple-api/allow-extra-fields/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/simple-api/bundle/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/simple-api/bundle/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/simple-api/bundle/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/simple-api/bundle/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/simple-api/custom-package-json/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/simple-api/custom-package-json/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/simple-api/custom-package-json/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/simple-api/custom-package-json/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/simple-api/jsr/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/simple-api/jsr/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/simple-api/jsr/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/simple-api/jsr/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/simple-api/legacy-exports/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/simple-api/legacy-exports/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/simple-api/legacy-exports/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/simple-api/legacy-exports/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/simple-api/no-custom-config/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/simple-api/no-custom-config/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/simple-api/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/simple-api/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/simple-api/no-linter/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/simple-api/no-linter/tests/unit/fetcher/makeRequest.test.ts
@@ -1,4 +1,5 @@
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
+import { Mock } from "vitest";
 
 describe("Test makeRequest", () => {
     const mockPostUrl = "https://httpbin.org/post";
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/simple-api/no-linter/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/simple-api/no-linter/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
+import { Mock, MockInstance } from "vitest";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/simple-api/no-scripts/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/simple-api/no-scripts/tests/unit/fetcher/makeRequest.test.ts
@@ -1,4 +1,5 @@
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
+import { Mock } from "vitest";
 
 describe("Test makeRequest", () => {
     const mockPostUrl = "https://httpbin.org/post";
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/simple-api/no-scripts/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/simple-api/no-scripts/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
+import { Mock, MockInstance } from "vitest";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();
@@ -11,7 +12,7 @@ describe("requestWithRetries", () => {
 
         Math.random = vi.fn(() => 0.5);
 
-        vi.useFakeTimers({ 
+        vi.useFakeTimers({
         	toFake: [
         		"setTimeout",
         		"clearTimeout",

--- a/seed/ts-sdk/simple-api/oidc-token/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/simple-api/oidc-token/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/simple-api/oidc-token/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/simple-api/oidc-token/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/simple-api/omit-fern-headers/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/simple-api/omit-fern-headers/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/simple-api/omit-fern-headers/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/simple-api/omit-fern-headers/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/simple-api/use-oxfmt/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/simple-api/use-oxfmt/tests/unit/fetcher/makeRequest.test.ts
@@ -1,4 +1,5 @@
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
+import type { Mock } from "vitest";
 
 describe("Test makeRequest", () => {
     const mockPostUrl = "https://httpbin.org/post";
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/simple-api/use-oxfmt/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/simple-api/use-oxfmt/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
+import type { Mock, MockInstance } from "vitest";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/simple-api/use-oxlint/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/simple-api/use-oxlint/tests/unit/fetcher/makeRequest.test.ts
@@ -1,4 +1,5 @@
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
+import { Mock } from "vitest";
 
 describe("Test makeRequest", () => {
     const mockPostUrl = "https://httpbin.org/post";
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/simple-api/use-oxlint/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/simple-api/use-oxlint/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
+import { Mock, MockInstance } from "vitest";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/simple-api/use-prettier-no-linter/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/simple-api/use-prettier-no-linter/tests/unit/fetcher/makeRequest.test.ts
@@ -1,4 +1,5 @@
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
+import { Mock } from "vitest";
 
 describe("Test makeRequest", () => {
     const mockPostUrl = "https://httpbin.org/post";
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/simple-api/use-prettier-no-linter/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/simple-api/use-prettier-no-linter/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
+import { Mock, MockInstance } from "vitest";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/simple-api/use-prettier/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/simple-api/use-prettier/tests/unit/fetcher/makeRequest.test.ts
@@ -1,4 +1,5 @@
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
+import type { Mock } from "vitest";
 
 describe("Test makeRequest", () => {
     const mockPostUrl = "https://httpbin.org/post";
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/simple-api/use-prettier/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/simple-api/use-prettier/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
+import type { Mock, MockInstance } from "vitest";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/simple-api/use-yarn/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/simple-api/use-yarn/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/simple-api/use-yarn/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/simple-api/use-yarn/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/simple-fhir/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/simple-fhir/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/simple-fhir/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/simple-fhir/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/single-url-environment-default/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/single-url-environment-default/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/single-url-environment-default/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/single-url-environment-default/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/single-url-environment-no-default/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/single-url-environment-no-default/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/single-url-environment-no-default/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/single-url-environment-no-default/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/streaming-parameter/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/streaming-parameter/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/streaming-parameter/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/streaming-parameter/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/streaming/no-custom-config/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/streaming/no-custom-config/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/streaming/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/streaming/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/streaming/serde-layer/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/streaming/serde-layer/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/streaming/serde-layer/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/streaming/serde-layer/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/streaming/wrapper/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/streaming/wrapper/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,9 @@
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("jest").Mock;
+    let mockFetch: jest.Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("jest").MockInstance;
+    let setTimeoutSpy: jest.SpyInstance;
 
     beforeEach(() => {
         mockFetch = jest.fn();

--- a/seed/ts-sdk/trace/exhaustive/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/trace/exhaustive/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/trace/exhaustive/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/trace/exhaustive/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/trace/no-custom-config/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/trace/no-custom-config/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/trace/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/trace/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/trace/serde-no-throwing/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/trace/serde-no-throwing/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/trace/serde/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/trace/serde/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/trace/serde/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/trace/serde/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/ts-express-casing/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/ts-express-casing/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/ts-express-casing/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/ts-express-casing/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/ts-inline-types/inline/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/ts-inline-types/inline/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/ts-inline-types/inline/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/ts-inline-types/inline/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/ts-inline-types/no-inline/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/ts-inline-types/no-inline/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/ts-inline-types/no-inline/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/ts-inline-types/no-inline/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/undiscriminated-union-with-response-property/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/undiscriminated-union-with-response-property/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/undiscriminated-union-with-response-property/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/undiscriminated-union-with-response-property/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/undiscriminated-unions/no-custom-config/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/undiscriminated-unions/no-custom-config/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/undiscriminated-unions/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/undiscriminated-unions/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/undiscriminated-unions/skip-response-validation/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/undiscriminated-unions/skip-response-validation/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/undiscriminated-unions/skip-response-validation/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/undiscriminated-unions/skip-response-validation/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/unions/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/unions/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/unions/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/unions/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/unknown/no-custom-config/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/unknown/no-custom-config/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/unknown/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/unknown/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/unknown/unknown-as-any/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/unknown/unknown-as-any/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/unknown/unknown-as-any/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/unknown/unknown-as-any/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/url-form-encoded/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/url-form-encoded/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/url-form-encoded/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/url-form-encoded/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/validation/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/validation/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/validation/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/validation/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/variables/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/variables/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/variables/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/variables/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/version-no-default/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/version-no-default/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/version-no-default/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/version-no-default/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/version/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/version/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/version/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/version/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/websocket-bearer-auth/websockets/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/websocket-bearer-auth/websockets/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/websocket-bearer-auth/websockets/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/websocket-bearer-auth/websockets/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/websocket-inferred-auth/websockets/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/websocket-inferred-auth/websockets/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/websocket-inferred-auth/websockets/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/websocket-inferred-auth/websockets/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/websocket/no-serde/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/websocket/no-serde/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/websocket/no-serde/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/websocket/no-serde/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/websocket/no-websocket-clients/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/websocket/no-websocket-clients/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/websocket/no-websocket-clients/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/websocket/no-websocket-clients/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/websocket/serde/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/websocket/serde/tests/unit/fetcher/makeRequest.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { makeRequest } from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
@@ -6,7 +7,7 @@ describe("Test makeRequest", () => {
     const mockHeaders = { "Content-Type": "application/json" };
     const mockBody = JSON.stringify({ key: "value" });
 
-    let mockFetch: import("vitest").Mock;
+    let mockFetch: Mock;
 
     beforeEach(() => {
         mockFetch = vi.fn();

--- a/seed/ts-sdk/websocket/serde/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/websocket/serde/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,9 +1,10 @@
+import type { Mock, MockInstance } from "vitest";
 import { requestWithRetries } from "../../../src/core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
-    let mockFetch: import("vi").Mock;
+    let mockFetch: Mock;
     let originalMathRandom: typeof Math.random;
-    let setTimeoutSpy: import("vi").MockInstance;
+    let setTimeoutSpy: MockInstance;
 
     beforeEach(() => {
         mockFetch = vi.fn();


### PR DESCRIPTION
## Description
Linear ticket: Closes FER-7642.
Cleans up imports for jest/vitest, especially concerning `requestWithRetries.test.ts`:
```
import("jest").Mock -> jest.Mock
import("jest").MockInstance -> jest.SpyInstance
import("vi").Mock -> Mock [see note]
import("vi").MockInstance -> MockInstance [see note]

[note] Imports of the relevant file will have: import { Mock, MockInstance } from "vitest"
```

## Changes Made
Small TS generator change.

## Testing
Generating seed now!
