### PR TITLE
fix(python): Add back some F401-ignored circular types

### DIFF
--- a/generators/python/fastapi/versions.yml
+++ b/generators/python/fastapi/versions.yml
@@ -1,5 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 1.11.1
+  changelogEntry:
+    - summary: Add back F401-ignored imports for circular references.
+      type: fix
+  createdAt: "2025-11-10"
+  irVersion: 61
+
 - version: 1.11.0
   changelogEntry:
     - summary: Add automatic discriminated union support using Pydantic's Field(discriminator=...) to improve serialization performance. Benchmarks show a 2x speedup by eliminating sequential variant attempts and enabling O(1) variant selection.

--- a/generators/python/pydantic/versions.yml
+++ b/generators/python/pydantic/versions.yml
@@ -1,5 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 1.9.1
+  changelogEntry:
+    - summary: Add back F401-ignored imports for circular references.
+      type: fix
+  createdAt: "2025-11-10"
+  irVersion: 61
+
 - version: 1.9.0
   changelogEntry:
     - summary: Add automatic discriminated union support using Pydantic's Field(discriminator=...) to improve serialization performance. Benchmarks show a 2x speedup by eliminating sequential variant attempts and enabling O(1) variant selection.

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 4.35.2
+  changelogEntry:
+    - summary: Add back F401-ignored imports for circular references.
+      type: fix
+  createdAt: "2025-11-10"
+  irVersion: 61
+
 - version: 4.35.1
   changelogEntry:
     - summary: Generated Python SDKs no longer show SyntaxWarnings when API docs or enum values include backslashes.

--- a/generators/python/src/fern_python/codegen/imports_manager.py
+++ b/generators/python/src/fern_python/codegen/imports_manager.py
@@ -140,7 +140,7 @@ class ImportsManager:
         if noqas:
             s += " # noqa: " + ", ".join(noqas)
         elif self._has_written_any_statements:
-            s += " # noqa: E402, I001"
+            s += " # noqa: E402, F401, I001"
 
         if import_.alternative_import is not None:
             alternative_import = self.get_import_as_string(import_.alternative_import)


### PR DESCRIPTION
Partially reverts https://github.com/fern-api/fern/pull/10071/files

Specifically, this was wrong: `Remove defunct F401s, which we actually never needed`