### PR TITLE
fix(java): handle nullable and literal container types in SDK generation

### DIFF
--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,3 +1,12 @@
+- version: 3.14.5
+  changelogEntry:
+    - summary: |
+        Fix SDK generation failures for OpenAPI specs with nullable container types. The generator now properly handles nullable containers in response parsing and pagination, treating them distinctly from optional containers. Also adds support for literal container detection with improved error diagnostics. 
+        This fixes "Unexpected container type" errors that occurred when processing APIs with nullable types or array examples in query parameters.
+      type: fix
+  createdAt: "2025-11-11"
+  irVersion: 61
+
 - version: 3.14.4
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description
Linear ticket: Closes [FER-7674: \[Java, Speechify\] Unexpected container type](https://linear.app/buildwithfern/issue/FER-7674/java-speechify-unexpected-container-type)
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
<!-- Provide a clear and concise description of the changes made in this PR -->

Speechify was getting `Unexpected container type` errors for APIs with nullable types. added some literal container detection as well. 

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
  - Add support for nullable containers in response parsing and pagination
  - Add literal container detection, while literals shouldn't appear in response parsing, this ensures they're handled gracefully rather than falling through to a generic error.
  - Refactored some collection type handling to be more type safe and readble.instead of using a string variable to build method names dynamically, each collection type now has its explicit handler
  - Add defensive null checking to prevent NPEs

## Testing
<!-- Describe how you tested these changes -->
- [ ] Unit tests added/updated
- [x] Manual testing completed - speechify can generate now