### PR TITLE
feat(cli): add security scheme "device auth grant" to IR

### DIFF
--- a/generators-yml.schema.json
+++ b/generators-yml.schema.json
@@ -247,6 +247,104 @@
       ],
       "additionalProperties": false
     },
+    "fernDefinition.auth.OAuthDeviceCodeEndpointSchema": {
+      "type": "object",
+      "properties": {
+        "endpoint": {
+          "type": "string"
+        },
+        "request-properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/fernDefinition.auth.OAuthDeviceCodeRequestPropertiesSchema"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "response-properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/fernDefinition.auth.OAuthDeviceCodeResponsePropertiesSchema"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "endpoint"
+      ],
+      "additionalProperties": false
+    },
+    "fernDefinition.auth.OAuthDeviceCodeRequestPropertiesSchema": {
+      "type": "object",
+      "properties": {
+        "client_id": {
+          "type": "string"
+        },
+        "scope": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "client_id"
+      ],
+      "additionalProperties": false
+    },
+    "fernDefinition.auth.OAuthDeviceCodeResponsePropertiesSchema": {
+      "type": "object",
+      "properties": {
+        "device_code": {
+          "type": "string"
+        },
+        "user_code": {
+          "type": "string"
+        },
+        "verification_uri": {
+          "type": "string"
+        },
+        "verification_uri_complete": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "expires_in": {
+          "type": "integer"
+        },
+        "interval": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "device_code",
+        "user_code",
+        "verification_uri",
+        "expires_in"
+      ],
+      "additionalProperties": false
+    },
     "fernDefinition.auth.OAuthRefreshTokenRequestPropertiesSchema": {
       "type": "object",
       "properties": {
@@ -327,7 +425,7 @@
       ],
       "additionalProperties": false
     },
-    "fernDefinition.auth.OAuthSchemeSchema": {
+    "fernDefinition.auth.OAuthClientCredentialsSchemeSchema": {
       "type": "object",
       "properties": {
         "docs": {
@@ -419,6 +517,116 @@
         "get-token"
       ],
       "additionalProperties": false
+    },
+    "fernDefinition.auth.OAuthDeviceAuthGrantSchemeSchema": {
+      "type": "object",
+      "properties": {
+        "docs": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "scheme": {
+          "const": "oauth"
+        },
+        "type": {
+          "const": "device-auth-grant"
+        },
+        "scopes": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/fernDefinition.auth.AuthScope"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "client-id-env": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "device-code-endpoint": {
+          "$ref": "#/definitions/fernDefinition.auth.OAuthDeviceCodeEndpointSchema"
+        },
+        "poll-token-endpoint": {
+          "$ref": "#/definitions/fernDefinition.auth.OAuthGetTokenEndpointSchema"
+        },
+        "polling-interval": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 1
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "token-prefix": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "token-header": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "refresh-token": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/fernDefinition.auth.OAuthRefreshTokenEndpointSchema"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "get-token": {
+          "$ref": "#/definitions/fernDefinition.auth.OAuthGetTokenEndpointSchema"
+        }
+      },
+      "required": [
+        "scheme",
+        "type",
+        "get-token"
+      ],
+      "additionalProperties": false
+    },
+    "fernDefinition.auth.OAuthSchemeSchema": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/fernDefinition.auth.OAuthClientCredentialsSchemeSchema"
+        },
+        {
+          "$ref": "#/definitions/fernDefinition.auth.OAuthDeviceAuthGrantSchemeSchema"
+        }
+      ]
     },
     "fernDefinition.auth.HeaderAuthSchemeSchema": {
       "type": "object",


### PR DESCRIPTION
## Description
Fixes FER-7676
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
<!-- Provide a clear and concise description of the changes made in this PR -->

Adds configuration for a new authentication schema "Device Auth Grant" in the IR which can be used by individual language SDKs to generate the correct authentication output.  

I was able to generate a custom device mode auth with the base `client-credential` generations using this config:
 
```
auth-schemes:
  OAuth:
    scheme: oauth
    type: client-credentials
    get-token:
      endpoint: POST /ext/api/as/token.oauth2
```

So to keep things simple and changes minimal, I am imagining implementing this one as:

```
auth-schemes:
  OAuth:
    scheme: oauth
    type: device-auth-grant
    get-token:
      endpoint: POST /ext/api/as/token.oauth2
```

With some more customization if any of the polling or device code endpoints are different. Just appending a suffix on the `get-token` endpoint is sufficient for most implementations. 

High level definition: 
<img width="496" height="636" alt="Screenshot 2025-11-11 at 6 12 03 PM" src="https://github.com/user-attachments/assets/7a23d06c-996d-48d1-96fe-55b402bed0bc" />


## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Updated `generators-yml.schema.json`

## Testing
<!-- Describe how you tested these changes -->
- [ ] Unit tests added/updated
- [ ] Manual testing completed
