### PR TITLE
chore(python): Fix python changelog

### DIFF
--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
-- version: 4.35.4
+- version: 4.36.0
   changelogEntry:
     - summary: Add custom license file copying and GitHub installation token population for local generation workflows
       type: feat


### PR DESCRIPTION
## Description
This PR bumps the Python SDK generator version from 4.35.4 to 4.36.0. This version update aligns the changelog entry with the published version for the recent feature addition.

The version bump ensures that the changelog entry for custom license file copying and GitHub installation token population functionality is properly tagged with version 4.36.0.

## Changes Made
- **Version Update**: Bumped Python SDK generator from 4.35.4 to 4.36.0 in versions.yml
- **Changelog Alignment**: Aligned existing changelog entry with the new version number