### PR TITLE
fix(java): implement graceful wire test generation with service name resolution

### DIFF
--- a/generators/java-v2/sdk/src/sdk-wire-tests/SdkWireTestGenerator.ts
+++ b/generators/java-v2/sdk/src/sdk-wire-tests/SdkWireTestGenerator.ts
@@ -59,6 +59,9 @@ export class SdkWireTestGenerator {
         dynamicSnippetsGenerator: DynamicSnippetsGenerator
     ): Promise<void> {
         const endpointsByService = this.groupEndpointsByService();
+        let totalEndpointsProcessed = 0;
+        let totalEndpointsGenerated = 0;
+        let totalServiceFilesGenerated = 0;
 
         for (const [serviceName, endpoints] of endpointsByService.entries()) {
             const endpointsWithExamples = endpoints.filter((endpoint) => {
@@ -79,18 +82,45 @@ export class SdkWireTestGenerator {
                 `Generating wire test for service: ${serviceName} with ${endpointsWithExamples.length} endpoints`
             );
 
-            const testClass = await this.generateTestClass(
+            const result = await this.generateTestClass(
                 serviceName,
                 endpointsWithExamples,
                 dynamicIr,
                 dynamicSnippetsGenerator
             );
-            const testFileName = `${this.toJavaClassName(serviceName)}WireTest.java`;
-            const testFilePath = this.getTestFilePath();
 
-            const file = new File(testFileName, RelativeFilePath.of(testFilePath), testClass);
+            totalEndpointsProcessed += endpointsWithExamples.length;
+            totalEndpointsGenerated += result.successCount;
 
-            this.context.project.addJavaFiles(file);
+            if (result.successCount > 0) {
+                const testFileName = `${this.toJavaClassName(serviceName)}WireTest.java`;
+                const testFilePath = this.getTestFilePath();
+
+                const file = new File(testFileName, RelativeFilePath.of(testFilePath), result.testClass);
+
+                this.context.project.addJavaFiles(file);
+                totalServiceFilesGenerated++;
+
+                this.context.logger.info(
+                    `Generated wire test for service ${serviceName}: ${result.successCount}/${endpointsWithExamples.length} endpoints successful`
+                );
+            } else {
+                this.context.logger.warn(
+                    `Skipping wire test file for service ${serviceName}: all ${endpointsWithExamples.length} endpoints failed to generate`
+                );
+            }
+        }
+
+        this.context.logger.info(
+            `Wire test generation summary: ${totalEndpointsGenerated}/${totalEndpointsProcessed} endpoints successful across ${totalServiceFilesGenerated} test files`
+        );
+
+        if (totalEndpointsProcessed > 0 && totalEndpointsGenerated === 0) {
+            throw new Error(
+                `Wire test generation failed: 0/${totalEndpointsProcessed} endpoints succeeded. ` +
+                    `This indicates a systemic issue with snippet generation or service mapping. ` +
+                    `Check logs above for specific endpoint failures.`
+            );
         }
     }
 
@@ -99,7 +129,7 @@ export class SdkWireTestGenerator {
         endpoints: HttpEndpoint[],
         dynamicIr: dynamic.DynamicIntermediateRepresentation,
         dynamicSnippetsGenerator: DynamicSnippetsGenerator
-    ): Promise<string> {
+    ): Promise<{ testClass: string; successCount: number }> {
         const className = `${this.toJavaClassName(serviceName)}WireTest`;
         const clientClassName = this.context.getRootClientClassName();
 
@@ -108,6 +138,7 @@ export class SdkWireTestGenerator {
 
         const endpointTests = new Map<string, { snippet: string; testExample: WireTestExample }>();
         const allImports = new Set<string>();
+        const skippedEndpoints: Array<{ endpointId: string; endpointName: string; reason: string }> = [];
 
         for (const endpoint of endpoints) {
             const testExamples = testDataExtractor.getTestExamples(endpoint);
@@ -115,20 +146,24 @@ export class SdkWireTestGenerator {
                 continue;
             }
 
-            this.context.logger.info(`Processing endpoint ${endpoint.id} with ${testExamples.length} test examples`);
+            this.context.logger.debug(`Processing endpoint ${endpoint.id} with ${testExamples.length} test examples`);
 
             const dynamicEndpoint = dynamicIr.endpoints[endpoint.id];
             if (dynamicEndpoint?.examples && dynamicEndpoint.examples.length > 0) {
                 const firstDynamicExample = dynamicEndpoint.examples[0];
                 if (firstDynamicExample) {
                     try {
-                        this.context.logger.info(
+                        this.context.logger.debug(
                             `Generating snippet for endpoint ${endpoint.id} (${endpoint.name.originalName}) with dynamic endpoint ${dynamicEndpoint.declaration.name.originalName}`
                         );
 
                         const expectedServiceName = serviceName.toLowerCase();
-                        const dynamicServiceName =
-                            dynamicEndpoint.declaration.fernFilepath?.allParts?.[0]?.originalName?.toLowerCase() || "";
+                        // Use the same fallback strategy as IR service resolution
+                        const dynamicServiceName = (
+                            dynamicEndpoint.declaration.fernFilepath?.allParts?.[0]?.originalName ||
+                            dynamicEndpoint.declaration.name.originalName ||
+                            "Service"
+                        ).toLowerCase();
 
                         const rawSnippet = await this.generateSnippetWithServiceCorrection(
                             endpoint,
@@ -148,6 +183,20 @@ export class SdkWireTestGenerator {
 
                         endpointImports.forEach((imp) => allImports.add(imp));
 
+                        // Check if method call extraction will fail and skip this endpoint
+                        const testMethodCall = snippetExtractor.extractMethodCall(fullSnippet);
+                        if (testMethodCall === null) {
+                            this.context.logger.debug(
+                                `Skipping endpoint ${endpoint.id} (${endpoint.name.originalName}): Could not extract method call from snippet`
+                            );
+                            skippedEndpoints.push({
+                                endpointId: endpoint.id,
+                                endpointName: endpoint.name.originalName,
+                                reason: `Could not extract method call from snippet - likely service mismatch or invalid snippet format`
+                            });
+                            continue;
+                        }
+
                         const imports = snippetExtractor.extractImports(fullSnippet);
                         imports.forEach((imp) => allImports.add(imp));
 
@@ -162,12 +211,20 @@ export class SdkWireTestGenerator {
                         const returnTypeInfo = this.testMethodBuilder.getEndpointReturnTypeWithImports(endpoint);
                         returnTypeInfo.imports.forEach((imp) => allImports.add(imp));
                     } catch (error) {
-                        this.context.logger.debug(`Failed to generate snippet for endpoint ${endpoint.id}: ${error}`);
+                        const errorMessage = error instanceof Error ? error.message : String(error);
+                        this.context.logger.debug(
+                            `Skipping endpoint ${endpoint.id} (${endpoint.name.originalName}): Failed to generate snippet - ${errorMessage}`
+                        );
+                        skippedEndpoints.push({
+                            endpointId: endpoint.id,
+                            endpointName: endpoint.name.originalName,
+                            reason: `Snippet generation failed: ${errorMessage}`
+                        });
                     }
                 }
             } else {
                 // No dynamic examples, but we have test examples from static IR
-                this.context.logger.info(
+                this.context.logger.debug(
                     `No dynamic examples for endpoint ${endpoint.id}, creating default snippet for service ${serviceName}`
                 );
 
@@ -176,6 +233,20 @@ export class SdkWireTestGenerator {
                     try {
                         const rawSnippet = this.generateDefaultSnippet(endpoint, serviceName, firstTestExample);
                         const fullSnippet = this.applyServiceNameCorrections(rawSnippet, serviceName);
+
+                        // Check if method call extraction will fail and skip this endpoint
+                        const testMethodCall = snippetExtractor.extractMethodCall(fullSnippet);
+                        if (testMethodCall === null) {
+                            this.context.logger.debug(
+                                `Skipping endpoint ${endpoint.id} (${endpoint.name.originalName}): Could not extract method call from default snippet`
+                            );
+                            skippedEndpoints.push({
+                                endpointId: endpoint.id,
+                                endpointName: endpoint.name.originalName,
+                                reason: `Could not extract method call from default snippet - likely service mismatch or invalid snippet format`
+                            });
+                            continue;
+                        }
 
                         const imports = snippetExtractor.extractImports(fullSnippet);
                         imports.forEach((imp) => allImports.add(imp));
@@ -188,14 +259,32 @@ export class SdkWireTestGenerator {
                         const returnTypeInfo = this.testMethodBuilder.getEndpointReturnTypeWithImports(endpoint);
                         returnTypeInfo.imports.forEach((imp) => allImports.add(imp));
                     } catch (error) {
+                        const errorMessage = error instanceof Error ? error.message : String(error);
                         this.context.logger.debug(
-                            `Failed to generate default snippet for endpoint ${endpoint.id}: ${error}`
+                            `Skipping endpoint ${endpoint.id} (${endpoint.name.originalName}): Failed to generate default snippet - ${errorMessage}`
                         );
+                        skippedEndpoints.push({
+                            endpointId: endpoint.id,
+                            endpointName: endpoint.name.originalName,
+                            reason: `Default snippet generation failed: ${errorMessage}`
+                        });
                     }
                 }
             }
         }
 
+        if (skippedEndpoints.length > 0) {
+            this.context.logger.warn(
+                `Skipped ${skippedEndpoints.length} endpoint(s) in service ${serviceName} due to generation failures`
+            );
+            // Individual endpoint details only in debug mode
+            this.context.logger.debug("Skipped endpoint details:");
+            skippedEndpoints.forEach(({ endpointName, reason }) => {
+                this.context.logger.debug(`  - ${endpointName}: ${reason}`);
+            });
+        }
+
+        const successCount = endpointTests.size;
         const hasAuth = this.context.ir.auth?.schemes && this.context.ir.auth.schemes.length > 0;
 
         const testClass = java.codeblock((writer) => {
@@ -212,10 +301,13 @@ export class SdkWireTestGenerator {
             writer.writeLine("}");
         });
 
-        return testClass.toString({
-            packageName: this.context.getRootPackageName(),
-            customConfig: this.context.customConfig ?? {}
-        });
+        return {
+            testClass: testClass.toString({
+                packageName: this.context.getRootPackageName(),
+                customConfig: this.context.customConfig ?? {}
+            }),
+            successCount
+        };
     }
 
     private async generateSnippetForExample(
@@ -278,14 +370,21 @@ export class SdkWireTestGenerator {
         serviceName: string
     ): Promise<string> {
         if (expectedServiceName !== dynamicServiceName) {
-            this.context.logger.warn(
-                `Service mismatch for endpoint ${endpoint.id}: expected service '${expectedServiceName}' but dynamic endpoint has service '${dynamicServiceName}'`
+            this.context.logger.debug(
+                `Service mismatch for endpoint ${endpoint.id}: expected service '${expectedServiceName}' but dynamic endpoint has service '${dynamicServiceName}'. ` +
+                    `Attempting service correction...`
             );
 
             const dynamicEndpoint = dynamicIr.endpoints[endpoint.id];
             if (!dynamicEndpoint) {
-                throw new Error(`Dynamic endpoint not found for ${endpoint.id}`);
+                throw new Error(
+                    `Dynamic endpoint not found for ${endpoint.id}. This is likely due to a service mapping issue in the dynamic IR.`
+                );
             }
+
+            // Use consistent casing for service correction
+            const serviceNamePascal = serviceName;
+            const serviceNameLower = expectedServiceName;
 
             const correctedDynamicEndpoint = {
                 ...dynamicEndpoint,
@@ -294,26 +393,26 @@ export class SdkWireTestGenerator {
                     fernFilepath: {
                         allParts: [
                             {
-                                originalName: expectedServiceName,
-                                camelCase: { unsafeName: expectedServiceName, safeName: expectedServiceName },
-                                snakeCase: { unsafeName: expectedServiceName, safeName: expectedServiceName },
+                                originalName: serviceNamePascal,
+                                camelCase: { unsafeName: serviceNameLower, safeName: serviceNameLower },
+                                snakeCase: { unsafeName: serviceNameLower, safeName: serviceNameLower },
                                 screamingSnakeCase: {
-                                    unsafeName: expectedServiceName.toUpperCase(),
-                                    safeName: expectedServiceName.toUpperCase()
+                                    unsafeName: serviceNamePascal.toUpperCase(),
+                                    safeName: serviceNamePascal.toUpperCase()
                                 },
-                                pascalCase: { unsafeName: serviceName, safeName: serviceName }
+                                pascalCase: { unsafeName: serviceNamePascal, safeName: serviceNamePascal }
                             }
                         ],
                         packagePath: [],
                         file: {
-                            originalName: expectedServiceName,
-                            camelCase: { unsafeName: expectedServiceName, safeName: expectedServiceName },
-                            snakeCase: { unsafeName: expectedServiceName, safeName: expectedServiceName },
+                            originalName: serviceNamePascal,
+                            camelCase: { unsafeName: serviceNameLower, safeName: serviceNameLower },
+                            snakeCase: { unsafeName: serviceNameLower, safeName: serviceNameLower },
                             screamingSnakeCase: {
-                                unsafeName: expectedServiceName.toUpperCase(),
-                                safeName: expectedServiceName.toUpperCase()
+                                unsafeName: serviceNamePascal.toUpperCase(),
+                                safeName: serviceNamePascal.toUpperCase()
                             },
-                            pascalCase: { unsafeName: serviceName, safeName: serviceName }
+                            pascalCase: { unsafeName: serviceNamePascal, safeName: serviceNamePascal }
                         }
                     }
                 }
@@ -323,7 +422,16 @@ export class SdkWireTestGenerator {
 
             try {
                 dynamicIr.endpoints[endpoint.id] = correctedDynamicEndpoint;
-                return await this.generateSnippetForExample(firstDynamicExample, dynamicSnippetsGenerator);
+                const snippet = await this.generateSnippetForExample(firstDynamicExample, dynamicSnippetsGenerator);
+                this.context.logger.debug(`Service correction succeeded for endpoint ${endpoint.id}`);
+                return snippet;
+            } catch (error) {
+                const errorMessage = error instanceof Error ? error.message : String(error);
+                throw new Error(
+                    `Service mismatch (expected: '${expectedServiceName}', got: '${dynamicServiceName}'). ` +
+                        `Correction attempt failed: ${errorMessage}. ` +
+                        `This typically occurs with V1 ungrouped endpoints or incorrect dynamic IR service mapping.`
+                );
             } finally {
                 if (originalDynamicEndpoint) {
                     dynamicIr.endpoints[endpoint.id] = originalDynamicEndpoint;

--- a/generators/java-v2/sdk/src/sdk-wire-tests/builders/TestMethodBuilder.ts
+++ b/generators/java-v2/sdk/src/sdk-wire-tests/builders/TestMethodBuilder.ts
@@ -36,6 +36,14 @@ export class TestMethodBuilder {
             const testMethodName = `test${this.toJavaMethodName(endpoint.name.pascalCase.safeName)}`;
             const methodCall = this.snippetExtractor.extractMethodCall(snippet);
 
+            // If we can't extract a method call, this endpoint should have been filtered out upstream
+            if (methodCall === null) {
+                throw new Error(
+                    `INTERNAL ERROR: Null method call reached TestMethodBuilder for endpoint ${endpoint.id}. ` +
+                        `This should have been caught upstream in SdkWireTestGenerator.`
+                );
+            }
+
             writer.writeLine("@Test");
             writer.writeLine(`public void ${testMethodName}() throws Exception {`);
             writer.indent();

--- a/generators/java-v2/sdk/src/sdk-wire-tests/extractors/SnippetExtractor.ts
+++ b/generators/java-v2/sdk/src/sdk-wire-tests/extractors/SnippetExtractor.ts
@@ -9,8 +9,16 @@ export class SnippetExtractor {
     /**
      * Extracts just the client method call from a full Java snippet.
      * Removes client instantiation and imports, returning only the actual method invocation.
+     * Returns null if the method call cannot be extracted.
      */
-    public extractMethodCall(fullSnippet: string): string {
+    public extractMethodCall(fullSnippet: string): string | null {
+        // First check if the snippet contains placeholder comments
+        // TODO: @tanmay - remove this once we have a way to generate valid client method calls
+        if (fullSnippet.includes("// TODO: Add client call")) {
+            this.context.logger.debug("Snippet contains placeholder comment, cannot extract method call");
+            return null;
+        }
+
         const lines = fullSnippet.split("\n");
 
         let clientInstantiationIndex = -1;
@@ -34,7 +42,7 @@ export class SnippetExtractor {
 
         if (clientCallStartIndex === -1) {
             this.context.logger.debug("Could not find client method call in snippet");
-            return "// TODO: Add client call";
+            return null;
         }
 
         const methodCallLines: string[] = [];
@@ -72,12 +80,12 @@ export class SnippetExtractor {
 
         if (!foundSemicolon || methodCallLines.length === 0) {
             this.context.logger.debug("Could not extract complete method call");
-            return "// TODO: Add client call";
+            return null;
         }
 
         const nonEmptyLines = methodCallLines.filter((line) => line && line.trim().length > 0);
         if (nonEmptyLines.length === 0) {
-            return "// TODO: Add client call";
+            return null;
         }
 
         const minIndent = Math.min(

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,10 +1,18 @@
+- version: 3.14.8
+  changelogEntry:
+    - summary: |
+        Fix critical wire test generation failures causing build crashes. Implemented service name resolution to handle IR vs Dynamic IR mismatches and added graceful error handling instead of build failures.
+      type: fix
+  createdAt: "2025-11-12"
+  irVersion: 61
+
 - version: 3.14.7
   changelogEntry:
     - summary: Fix inconsistent behavior between local and remote Java generation by ensuring license files are copied and platform headers are populated in all generation scenarios
       type: fix
   createdAt: "2025-11-11"
   irVersion: 61
-
+  
 - version: 3.14.6
   changelogEntry:
     - summary: |

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -12,7 +12,7 @@
       type: fix
   createdAt: "2025-11-11"
   irVersion: 61
-  
+
 - version: 3.14.6
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description
Linear ticket: Refs [FER-7658: \[Java\] fix all wire tests issues](https://linear.app/buildwithfern/issue/FER-7658/java-fix-all-wire-tests-issues) 
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
<!-- Provide a clear and concise description of the changes made in this PR -->
Fixed critical Java SDK wire test generation failures. The generator was crashing because of service name mismatches between:
  - IR Service Grouping: Fallback to generic "Service" name
  - Dynamic IR: Individual endpoint names `("chat", "generate", "classify")`
  - Result: Invalid snippet generation into placeholder comments then Java formatter crashes

Big fix for Cohere

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- SdkWireTestGenerator.ts - Implemented service name resolution algorithm to fix IR vs Dynamic IR mismatches (like  "Service" → "chat") and added graceful endpoint skipping instead of build crashes
-  TestMethodBuilder.ts - Added null method call validation with enhanced error messages to catch upstream filtering failures
- Added early placeholder comment detection `(// TODO: Add client call)` to prevent invalid snippets from reaching test generation
- [ ] Updated README.md generator (if applicable)

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated -- didn't really need this fix 
- [x] Manual testing completed -- ran the generation with cohere and verified again with auth0 
