### PR TITLE
fix(java): add JSON normalization helper to wire tests for numeric comparison

### DIFF
--- a/generators/java-v2/sdk/src/sdk-wire-tests/SdkWireTestGenerator.ts
+++ b/generators/java-v2/sdk/src/sdk-wire-tests/SdkWireTestGenerator.ts
@@ -297,8 +297,7 @@ export class SdkWireTestGenerator {
                 }
             }
 
-            writer.dedent();
-            writer.writeLine("}");
+            this.testClassBuilder.closeTestClass(writer);
         });
 
         return {

--- a/generators/java-v2/sdk/src/sdk-wire-tests/validators/JsonValidator.ts
+++ b/generators/java-v2/sdk/src/sdk-wire-tests/validators/JsonValidator.ts
@@ -39,7 +39,6 @@ export class JsonValidator {
     /**
      * Generates enhanced JSON validation with support for complex types
      * Provides better validation than basic JsonNode.equals() for unions, generics, etc.
-     * Normalizes numeric values to handle 149.0 vs 149 comparisons.
      */
     public generateEnhancedJsonValidation(
         writer: Writer,
@@ -48,7 +47,6 @@ export class JsonValidator {
         actualVarName: string,
         expectedVarName: string
     ): void {
-        // Normalize both JsonNodes to handle numeric equivalence (149.0 vs 149)
         writer.writeLine(`JsonNode normalized${this.capitalize(actualVarName)} = normalizeNumbers(${actualVarName});`);
         writer.writeLine(
             `JsonNode normalized${this.capitalize(expectedVarName)} = normalizeNumbers(${expectedVarName});`

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,3 +1,10 @@
+- version: 3.14.10
+  changelogEntry:
+    - summary: Fix wire test JSON numeric comparison failures by adding normalization helper that converts whole number doubles (149.0) to longs (149) before assertion, resolving Jackson serialization vs API spec mismatches
+      type: fix
+  createdAt: "2025-11-12"
+  irVersion: 61
+
 - version: 3.14.9
   changelogEntry:
     - summary: Fix wire test compilation errors when using staged builders with collections. Builder method calls now correctly order required fields before collections like Lists, Sets, and Maps.

--- a/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsContainerWireTest.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsContainerWireTest.java
@@ -52,7 +52,10 @@ public class EndpointsContainerWireTest {
         String expectedRequestBody = "" + "[\n" + "  \"string\",\n" + "  \"string\"\n" + "]";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        JsonNode normalizedActualJson = normalizeNumbers(actualJson);
+        JsonNode normalizedExpectedJson = normalizeNumbers(expectedJson);
+        Assertions.assertEquals(
+                normalizedExpectedJson, normalizedActualJson, "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -83,8 +86,12 @@ public class EndpointsContainerWireTest {
         String expectedResponseBody = "" + "[\n" + "  \"string\",\n" + "  \"string\"\n" + "]";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
+        JsonNode normalizedActualResponseNode = normalizeNumbers(actualResponseNode);
+        JsonNode normalizedExpectedResponseNode = normalizeNumbers(expectedResponseNode);
         Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+                normalizedExpectedResponseNode,
+                normalizedActualResponseNode,
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -136,7 +143,10 @@ public class EndpointsContainerWireTest {
                 + "]";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        JsonNode normalizedActualJson = normalizeNumbers(actualJson);
+        JsonNode normalizedExpectedJson = normalizeNumbers(expectedJson);
+        Assertions.assertEquals(
+                normalizedExpectedJson, normalizedActualJson, "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -175,8 +185,12 @@ public class EndpointsContainerWireTest {
                 + "]";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
+        JsonNode normalizedActualResponseNode = normalizeNumbers(actualResponseNode);
+        JsonNode normalizedExpectedResponseNode = normalizeNumbers(expectedResponseNode);
         Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+                normalizedExpectedResponseNode,
+                normalizedActualResponseNode,
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -217,7 +231,10 @@ public class EndpointsContainerWireTest {
         String expectedRequestBody = "" + "[\n" + "  \"string\"\n" + "]";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        JsonNode normalizedActualJson = normalizeNumbers(actualJson);
+        JsonNode normalizedExpectedJson = normalizeNumbers(expectedJson);
+        Assertions.assertEquals(
+                normalizedExpectedJson, normalizedActualJson, "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -248,8 +265,12 @@ public class EndpointsContainerWireTest {
         String expectedResponseBody = "" + "[\n" + "  \"string\"\n" + "]";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
+        JsonNode normalizedActualResponseNode = normalizeNumbers(actualResponseNode);
+        JsonNode normalizedExpectedResponseNode = normalizeNumbers(expectedResponseNode);
         Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+                normalizedExpectedResponseNode,
+                normalizedActualResponseNode,
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -291,7 +312,10 @@ public class EndpointsContainerWireTest {
         String expectedRequestBody = "" + "[\n" + "  {\n" + "    \"string\": \"string\"\n" + "  }\n" + "]";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        JsonNode normalizedActualJson = normalizeNumbers(actualJson);
+        JsonNode normalizedExpectedJson = normalizeNumbers(expectedJson);
+        Assertions.assertEquals(
+                normalizedExpectedJson, normalizedActualJson, "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -322,8 +346,12 @@ public class EndpointsContainerWireTest {
         String expectedResponseBody = "" + "[\n" + "  {\n" + "    \"string\": \"string\"\n" + "  }\n" + "]";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
+        JsonNode normalizedActualResponseNode = normalizeNumbers(actualResponseNode);
+        JsonNode normalizedExpectedResponseNode = normalizeNumbers(expectedResponseNode);
         Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+                normalizedExpectedResponseNode,
+                normalizedActualResponseNode,
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -368,7 +396,10 @@ public class EndpointsContainerWireTest {
         String expectedRequestBody = "" + "{\n" + "  \"string\": \"string\"\n" + "}";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        JsonNode normalizedActualJson = normalizeNumbers(actualJson);
+        JsonNode normalizedExpectedJson = normalizeNumbers(expectedJson);
+        Assertions.assertEquals(
+                normalizedExpectedJson, normalizedActualJson, "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -399,8 +430,12 @@ public class EndpointsContainerWireTest {
         String expectedResponseBody = "" + "{\n" + "  \"string\": \"string\"\n" + "}";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
+        JsonNode normalizedActualResponseNode = normalizeNumbers(actualResponseNode);
+        JsonNode normalizedExpectedResponseNode = normalizeNumbers(expectedResponseNode);
         Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+                normalizedExpectedResponseNode,
+                normalizedActualResponseNode,
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -449,7 +484,10 @@ public class EndpointsContainerWireTest {
         String expectedRequestBody = "" + "{\n" + "  \"string\": {\n" + "    \"string\": \"string\"\n" + "  }\n" + "}";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        JsonNode normalizedActualJson = normalizeNumbers(actualJson);
+        JsonNode normalizedExpectedJson = normalizeNumbers(expectedJson);
+        Assertions.assertEquals(
+                normalizedExpectedJson, normalizedActualJson, "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -480,8 +518,12 @@ public class EndpointsContainerWireTest {
         String expectedResponseBody = "" + "{\n" + "  \"string\": {\n" + "    \"string\": \"string\"\n" + "  }\n" + "}";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
+        JsonNode normalizedActualResponseNode = normalizeNumbers(actualResponseNode);
+        JsonNode normalizedExpectedResponseNode = normalizeNumbers(expectedResponseNode);
         Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+                normalizedExpectedResponseNode,
+                normalizedActualResponseNode,
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -523,7 +565,10 @@ public class EndpointsContainerWireTest {
         String expectedRequestBody = "" + "{\n" + "  \"string\": \"string\"\n" + "}";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        JsonNode normalizedActualJson = normalizeNumbers(actualJson);
+        JsonNode normalizedExpectedJson = normalizeNumbers(expectedJson);
+        Assertions.assertEquals(
+                normalizedExpectedJson, normalizedActualJson, "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -554,8 +599,12 @@ public class EndpointsContainerWireTest {
         String expectedResponseBody = "" + "{\n" + "  \"string\": \"string\"\n" + "}";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
+        JsonNode normalizedActualResponseNode = normalizeNumbers(actualResponseNode);
+        JsonNode normalizedExpectedResponseNode = normalizeNumbers(expectedResponseNode);
         Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+                normalizedExpectedResponseNode,
+                normalizedActualResponseNode,
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -580,5 +629,32 @@ public class EndpointsContainerWireTest {
         if (actualResponseNode.isObject()) {
             Assertions.assertTrue(actualResponseNode.size() >= 0, "Object should have valid field count");
         }
+    }
+
+    /**
+     * Normalizes numeric values in a JsonNode tree for comparison.
+     * Converts whole number doubles (e.g., 149.0) to longs (e.g., 149).
+     */
+    private JsonNode normalizeNumbers(JsonNode node) {
+        if (node.isNumber()) {
+            double value = node.doubleValue();
+            if (value == Math.floor(value) && !Double.isInfinite(value)) {
+                return objectMapper.getNodeFactory().numberNode((long) value);
+            }
+            return node;
+        }
+        if (node.isObject()) {
+            com.fasterxml.jackson.databind.node.ObjectNode normalized = objectMapper.createObjectNode();
+            node.fields().forEachRemaining(entry -> {
+                normalized.set(entry.getKey(), normalizeNumbers(entry.getValue()));
+            });
+            return normalized;
+        }
+        if (node.isArray()) {
+            com.fasterxml.jackson.databind.node.ArrayNode normalized = objectMapper.createArrayNode();
+            node.forEach(element -> normalized.add(normalizeNumbers(element)));
+            return normalized;
+        }
+        return node;
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsContentTypeWireTest.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsContentTypeWireTest.java
@@ -93,7 +93,10 @@ public class EndpointsContentTypeWireTest {
                 + "}";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        JsonNode normalizedActualJson = normalizeNumbers(actualJson);
+        JsonNode normalizedExpectedJson = normalizeNumbers(expectedJson);
+        Assertions.assertEquals(
+                normalizedExpectedJson, normalizedActualJson, "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -173,7 +176,10 @@ public class EndpointsContentTypeWireTest {
                 + "}";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        JsonNode normalizedActualJson = normalizeNumbers(actualJson);
+        JsonNode normalizedExpectedJson = normalizeNumbers(expectedJson);
+        Assertions.assertEquals(
+                normalizedExpectedJson, normalizedActualJson, "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -197,5 +203,32 @@ public class EndpointsContentTypeWireTest {
         if (actualJson.isObject()) {
             Assertions.assertTrue(actualJson.size() >= 0, "Object should have valid field count");
         }
+    }
+
+    /**
+     * Normalizes numeric values in a JsonNode tree for comparison.
+     * Converts whole number doubles (e.g., 149.0) to longs (e.g., 149).
+     */
+    private JsonNode normalizeNumbers(JsonNode node) {
+        if (node.isNumber()) {
+            double value = node.doubleValue();
+            if (value == Math.floor(value) && !Double.isInfinite(value)) {
+                return objectMapper.getNodeFactory().numberNode((long) value);
+            }
+            return node;
+        }
+        if (node.isObject()) {
+            com.fasterxml.jackson.databind.node.ObjectNode normalized = objectMapper.createObjectNode();
+            node.fields().forEachRemaining(entry -> {
+                normalized.set(entry.getKey(), normalizeNumbers(entry.getValue()));
+            });
+            return normalized;
+        }
+        if (node.isArray()) {
+            com.fasterxml.jackson.databind.node.ArrayNode normalized = objectMapper.createArrayNode();
+            node.forEach(element -> normalized.add(normalizeNumbers(element)));
+            return normalized;
+        }
+        return node;
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsEnumWireTest.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsEnumWireTest.java
@@ -44,7 +44,10 @@ public class EndpointsEnumWireTest {
         String expectedRequestBody = "" + "\"SUNNY\"";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        JsonNode normalizedActualJson = normalizeNumbers(actualJson);
+        JsonNode normalizedExpectedJson = normalizeNumbers(expectedJson);
+        Assertions.assertEquals(
+                normalizedExpectedJson, normalizedActualJson, "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -75,8 +78,12 @@ public class EndpointsEnumWireTest {
         String expectedResponseBody = "" + "\"SUNNY\"";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
+        JsonNode normalizedActualResponseNode = normalizeNumbers(actualResponseNode);
+        JsonNode normalizedExpectedResponseNode = normalizeNumbers(expectedResponseNode);
         Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+                normalizedExpectedResponseNode,
+                normalizedActualResponseNode,
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -101,5 +108,32 @@ public class EndpointsEnumWireTest {
         if (actualResponseNode.isObject()) {
             Assertions.assertTrue(actualResponseNode.size() >= 0, "Object should have valid field count");
         }
+    }
+
+    /**
+     * Normalizes numeric values in a JsonNode tree for comparison.
+     * Converts whole number doubles (e.g., 149.0) to longs (e.g., 149).
+     */
+    private JsonNode normalizeNumbers(JsonNode node) {
+        if (node.isNumber()) {
+            double value = node.doubleValue();
+            if (value == Math.floor(value) && !Double.isInfinite(value)) {
+                return objectMapper.getNodeFactory().numberNode((long) value);
+            }
+            return node;
+        }
+        if (node.isObject()) {
+            com.fasterxml.jackson.databind.node.ObjectNode normalized = objectMapper.createObjectNode();
+            node.fields().forEachRemaining(entry -> {
+                normalized.set(entry.getKey(), normalizeNumbers(entry.getValue()));
+            });
+            return normalized;
+        }
+        if (node.isArray()) {
+            com.fasterxml.jackson.databind.node.ArrayNode normalized = objectMapper.createArrayNode();
+            node.forEach(element -> normalized.add(normalizeNumbers(element)));
+            return normalized;
+        }
+        return node;
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsHttpMethodsWireTest.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsHttpMethodsWireTest.java
@@ -54,8 +54,12 @@ public class EndpointsHttpMethodsWireTest {
         String expectedResponseBody = "" + "\"string\"";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
+        JsonNode normalizedActualResponseNode = normalizeNumbers(actualResponseNode);
+        JsonNode normalizedExpectedResponseNode = normalizeNumbers(expectedResponseNode);
         Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+                normalizedExpectedResponseNode,
+                normalizedActualResponseNode,
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -100,7 +104,10 @@ public class EndpointsHttpMethodsWireTest {
         String expectedRequestBody = "" + "{\n" + "  \"string\": \"string\"\n" + "}";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        JsonNode normalizedActualJson = normalizeNumbers(actualJson);
+        JsonNode normalizedExpectedJson = normalizeNumbers(expectedJson);
+        Assertions.assertEquals(
+                normalizedExpectedJson, normalizedActualJson, "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -153,8 +160,12 @@ public class EndpointsHttpMethodsWireTest {
                 + "}";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
+        JsonNode normalizedActualResponseNode = normalizeNumbers(actualResponseNode);
+        JsonNode normalizedExpectedResponseNode = normalizeNumbers(expectedResponseNode);
         Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+                normalizedExpectedResponseNode,
+                normalizedActualResponseNode,
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -200,7 +211,10 @@ public class EndpointsHttpMethodsWireTest {
         String expectedRequestBody = "" + "{\n" + "  \"string\": \"string\"\n" + "}";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        JsonNode normalizedActualJson = normalizeNumbers(actualJson);
+        JsonNode normalizedExpectedJson = normalizeNumbers(expectedJson);
+        Assertions.assertEquals(
+                normalizedExpectedJson, normalizedActualJson, "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -253,8 +267,12 @@ public class EndpointsHttpMethodsWireTest {
                 + "}";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
+        JsonNode normalizedActualResponseNode = normalizeNumbers(actualResponseNode);
+        JsonNode normalizedExpectedResponseNode = normalizeNumbers(expectedResponseNode);
         Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+                normalizedExpectedResponseNode,
+                normalizedActualResponseNode,
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -341,7 +359,10 @@ public class EndpointsHttpMethodsWireTest {
                 + "}";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        JsonNode normalizedActualJson = normalizeNumbers(actualJson);
+        JsonNode normalizedExpectedJson = normalizeNumbers(expectedJson);
+        Assertions.assertEquals(
+                normalizedExpectedJson, normalizedActualJson, "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -394,8 +415,12 @@ public class EndpointsHttpMethodsWireTest {
                 + "}";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
+        JsonNode normalizedActualResponseNode = normalizeNumbers(actualResponseNode);
+        JsonNode normalizedExpectedResponseNode = normalizeNumbers(expectedResponseNode);
         Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+                normalizedExpectedResponseNode,
+                normalizedActualResponseNode,
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -436,8 +461,12 @@ public class EndpointsHttpMethodsWireTest {
         String expectedResponseBody = "" + "true";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
+        JsonNode normalizedActualResponseNode = normalizeNumbers(actualResponseNode);
+        JsonNode normalizedExpectedResponseNode = normalizeNumbers(expectedResponseNode);
         Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+                normalizedExpectedResponseNode,
+                normalizedActualResponseNode,
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -462,5 +491,32 @@ public class EndpointsHttpMethodsWireTest {
         if (actualResponseNode.isObject()) {
             Assertions.assertTrue(actualResponseNode.size() >= 0, "Object should have valid field count");
         }
+    }
+
+    /**
+     * Normalizes numeric values in a JsonNode tree for comparison.
+     * Converts whole number doubles (e.g., 149.0) to longs (e.g., 149).
+     */
+    private JsonNode normalizeNumbers(JsonNode node) {
+        if (node.isNumber()) {
+            double value = node.doubleValue();
+            if (value == Math.floor(value) && !Double.isInfinite(value)) {
+                return objectMapper.getNodeFactory().numberNode((long) value);
+            }
+            return node;
+        }
+        if (node.isObject()) {
+            com.fasterxml.jackson.databind.node.ObjectNode normalized = objectMapper.createObjectNode();
+            node.fields().forEachRemaining(entry -> {
+                normalized.set(entry.getKey(), normalizeNumbers(entry.getValue()));
+            });
+            return normalized;
+        }
+        if (node.isArray()) {
+            com.fasterxml.jackson.databind.node.ArrayNode normalized = objectMapper.createArrayNode();
+            node.forEach(element -> normalized.add(normalizeNumbers(element)));
+            return normalized;
+        }
+        return node;
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsObjectWireTest.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsObjectWireTest.java
@@ -102,7 +102,10 @@ public class EndpointsObjectWireTest {
                 + "}";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        JsonNode normalizedActualJson = normalizeNumbers(actualJson);
+        JsonNode normalizedExpectedJson = normalizeNumbers(expectedJson);
+        Assertions.assertEquals(
+                normalizedExpectedJson, normalizedActualJson, "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -155,8 +158,12 @@ public class EndpointsObjectWireTest {
                 + "}";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
+        JsonNode normalizedActualResponseNode = normalizeNumbers(actualResponseNode);
+        JsonNode normalizedExpectedResponseNode = normalizeNumbers(expectedResponseNode);
         Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+                normalizedExpectedResponseNode,
+                normalizedActualResponseNode,
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -198,7 +205,10 @@ public class EndpointsObjectWireTest {
         String expectedRequestBody = "" + "{\n" + "  \"string\": \"string\"\n" + "}";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        JsonNode normalizedActualJson = normalizeNumbers(actualJson);
+        JsonNode normalizedExpectedJson = normalizeNumbers(expectedJson);
+        Assertions.assertEquals(
+                normalizedExpectedJson, normalizedActualJson, "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -229,8 +239,12 @@ public class EndpointsObjectWireTest {
         String expectedResponseBody = "" + "{\n" + "  \"string\": \"string\"\n" + "}";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
+        JsonNode normalizedActualResponseNode = normalizeNumbers(actualResponseNode);
+        JsonNode normalizedExpectedResponseNode = normalizeNumbers(expectedResponseNode);
         Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+                normalizedExpectedResponseNode,
+                normalizedActualResponseNode,
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -288,7 +302,10 @@ public class EndpointsObjectWireTest {
                 + "}";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        JsonNode normalizedActualJson = normalizeNumbers(actualJson);
+        JsonNode normalizedExpectedJson = normalizeNumbers(expectedJson);
+        Assertions.assertEquals(
+                normalizedExpectedJson, normalizedActualJson, "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -326,8 +343,12 @@ public class EndpointsObjectWireTest {
                 + "}";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
+        JsonNode normalizedActualResponseNode = normalizeNumbers(actualResponseNode);
+        JsonNode normalizedExpectedResponseNode = normalizeNumbers(expectedResponseNode);
         Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+                normalizedExpectedResponseNode,
+                normalizedActualResponseNode,
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -418,7 +439,10 @@ public class EndpointsObjectWireTest {
                 + "}";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        JsonNode normalizedActualJson = normalizeNumbers(actualJson);
+        JsonNode normalizedExpectedJson = normalizeNumbers(expectedJson);
+        Assertions.assertEquals(
+                normalizedExpectedJson, normalizedActualJson, "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -474,8 +498,12 @@ public class EndpointsObjectWireTest {
                 + "}";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
+        JsonNode normalizedActualResponseNode = normalizeNumbers(actualResponseNode);
+        JsonNode normalizedExpectedResponseNode = normalizeNumbers(expectedResponseNode);
         Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+                normalizedExpectedResponseNode,
+                normalizedActualResponseNode,
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -568,7 +596,10 @@ public class EndpointsObjectWireTest {
                 + "}";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        JsonNode normalizedActualJson = normalizeNumbers(actualJson);
+        JsonNode normalizedExpectedJson = normalizeNumbers(expectedJson);
+        Assertions.assertEquals(
+                normalizedExpectedJson, normalizedActualJson, "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -624,8 +655,12 @@ public class EndpointsObjectWireTest {
                 + "}";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
+        JsonNode normalizedActualResponseNode = normalizeNumbers(actualResponseNode);
+        JsonNode normalizedExpectedResponseNode = normalizeNumbers(expectedResponseNode);
         Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+                normalizedExpectedResponseNode,
+                normalizedActualResponseNode,
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -766,7 +801,10 @@ public class EndpointsObjectWireTest {
                 + "]";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        JsonNode normalizedActualJson = normalizeNumbers(actualJson);
+        JsonNode normalizedExpectedJson = normalizeNumbers(expectedJson);
+        Assertions.assertEquals(
+                normalizedExpectedJson, normalizedActualJson, "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -822,8 +860,12 @@ public class EndpointsObjectWireTest {
                 + "}";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
+        JsonNode normalizedActualResponseNode = normalizeNumbers(actualResponseNode);
+        JsonNode normalizedExpectedResponseNode = normalizeNumbers(expectedResponseNode);
         Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+                normalizedExpectedResponseNode,
+                normalizedActualResponseNode,
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -848,5 +890,32 @@ public class EndpointsObjectWireTest {
         if (actualResponseNode.isObject()) {
             Assertions.assertTrue(actualResponseNode.size() >= 0, "Object should have valid field count");
         }
+    }
+
+    /**
+     * Normalizes numeric values in a JsonNode tree for comparison.
+     * Converts whole number doubles (e.g., 149.0) to longs (e.g., 149).
+     */
+    private JsonNode normalizeNumbers(JsonNode node) {
+        if (node.isNumber()) {
+            double value = node.doubleValue();
+            if (value == Math.floor(value) && !Double.isInfinite(value)) {
+                return objectMapper.getNodeFactory().numberNode((long) value);
+            }
+            return node;
+        }
+        if (node.isObject()) {
+            com.fasterxml.jackson.databind.node.ObjectNode normalized = objectMapper.createObjectNode();
+            node.fields().forEachRemaining(entry -> {
+                normalized.set(entry.getKey(), normalizeNumbers(entry.getValue()));
+            });
+            return normalized;
+        }
+        if (node.isArray()) {
+            com.fasterxml.jackson.databind.node.ArrayNode normalized = objectMapper.createArrayNode();
+            node.forEach(element -> normalized.add(normalizeNumbers(element)));
+            return normalized;
+        }
+        return node;
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsParamsWireTest.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsParamsWireTest.java
@@ -47,8 +47,12 @@ public class EndpointsParamsWireTest {
         String expectedResponseBody = "" + "\"string\"";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
+        JsonNode normalizedActualResponseNode = normalizeNumbers(actualResponseNode);
+        JsonNode normalizedExpectedResponseNode = normalizeNumbers(expectedResponseNode);
         Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+                normalizedExpectedResponseNode,
+                normalizedActualResponseNode,
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -89,8 +93,12 @@ public class EndpointsParamsWireTest {
         String expectedResponseBody = "" + "\"string\"";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
+        JsonNode normalizedActualResponseNode = normalizeNumbers(actualResponseNode);
+        JsonNode normalizedExpectedResponseNode = normalizeNumbers(expectedResponseNode);
         Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+                normalizedExpectedResponseNode,
+                normalizedActualResponseNode,
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -175,7 +183,10 @@ public class EndpointsParamsWireTest {
         String expectedRequestBody = "" + "\"string\"";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        JsonNode normalizedActualJson = normalizeNumbers(actualJson);
+        JsonNode normalizedExpectedJson = normalizeNumbers(expectedJson);
+        Assertions.assertEquals(
+                normalizedExpectedJson, normalizedActualJson, "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -206,8 +217,12 @@ public class EndpointsParamsWireTest {
         String expectedResponseBody = "" + "\"string\"";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
+        JsonNode normalizedActualResponseNode = normalizeNumbers(actualResponseNode);
+        JsonNode normalizedExpectedResponseNode = normalizeNumbers(expectedResponseNode);
         Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+                normalizedExpectedResponseNode,
+                normalizedActualResponseNode,
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -246,7 +261,10 @@ public class EndpointsParamsWireTest {
         String expectedRequestBody = "" + "\"string\"";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        JsonNode normalizedActualJson = normalizeNumbers(actualJson);
+        JsonNode normalizedExpectedJson = normalizeNumbers(expectedJson);
+        Assertions.assertEquals(
+                normalizedExpectedJson, normalizedActualJson, "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -277,8 +295,12 @@ public class EndpointsParamsWireTest {
         String expectedResponseBody = "" + "\"string\"";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
+        JsonNode normalizedActualResponseNode = normalizeNumbers(actualResponseNode);
+        JsonNode normalizedExpectedResponseNode = normalizeNumbers(expectedResponseNode);
         Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+                normalizedExpectedResponseNode,
+                normalizedActualResponseNode,
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -303,5 +325,32 @@ public class EndpointsParamsWireTest {
         if (actualResponseNode.isObject()) {
             Assertions.assertTrue(actualResponseNode.size() >= 0, "Object should have valid field count");
         }
+    }
+
+    /**
+     * Normalizes numeric values in a JsonNode tree for comparison.
+     * Converts whole number doubles (e.g., 149.0) to longs (e.g., 149).
+     */
+    private JsonNode normalizeNumbers(JsonNode node) {
+        if (node.isNumber()) {
+            double value = node.doubleValue();
+            if (value == Math.floor(value) && !Double.isInfinite(value)) {
+                return objectMapper.getNodeFactory().numberNode((long) value);
+            }
+            return node;
+        }
+        if (node.isObject()) {
+            com.fasterxml.jackson.databind.node.ObjectNode normalized = objectMapper.createObjectNode();
+            node.fields().forEachRemaining(entry -> {
+                normalized.set(entry.getKey(), normalizeNumbers(entry.getValue()));
+            });
+            return normalized;
+        }
+        if (node.isArray()) {
+            com.fasterxml.jackson.databind.node.ArrayNode normalized = objectMapper.createArrayNode();
+            node.forEach(element -> normalized.add(normalizeNumbers(element)));
+            return normalized;
+        }
+        return node;
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsPrimitiveWireTest.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsPrimitiveWireTest.java
@@ -45,7 +45,10 @@ public class EndpointsPrimitiveWireTest {
         String expectedRequestBody = "" + "\"string\"";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        JsonNode normalizedActualJson = normalizeNumbers(actualJson);
+        JsonNode normalizedExpectedJson = normalizeNumbers(expectedJson);
+        Assertions.assertEquals(
+                normalizedExpectedJson, normalizedActualJson, "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -76,8 +79,12 @@ public class EndpointsPrimitiveWireTest {
         String expectedResponseBody = "" + "\"string\"";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
+        JsonNode normalizedActualResponseNode = normalizeNumbers(actualResponseNode);
+        JsonNode normalizedExpectedResponseNode = normalizeNumbers(expectedResponseNode);
         Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+                normalizedExpectedResponseNode,
+                normalizedActualResponseNode,
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -116,7 +123,10 @@ public class EndpointsPrimitiveWireTest {
         String expectedRequestBody = "" + "1";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        JsonNode normalizedActualJson = normalizeNumbers(actualJson);
+        JsonNode normalizedExpectedJson = normalizeNumbers(expectedJson);
+        Assertions.assertEquals(
+                normalizedExpectedJson, normalizedActualJson, "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -147,8 +157,12 @@ public class EndpointsPrimitiveWireTest {
         String expectedResponseBody = "" + "1";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
+        JsonNode normalizedActualResponseNode = normalizeNumbers(actualResponseNode);
+        JsonNode normalizedExpectedResponseNode = normalizeNumbers(expectedResponseNode);
         Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+                normalizedExpectedResponseNode,
+                normalizedActualResponseNode,
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -187,7 +201,10 @@ public class EndpointsPrimitiveWireTest {
         String expectedRequestBody = "" + "1000000";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        JsonNode normalizedActualJson = normalizeNumbers(actualJson);
+        JsonNode normalizedExpectedJson = normalizeNumbers(expectedJson);
+        Assertions.assertEquals(
+                normalizedExpectedJson, normalizedActualJson, "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -218,8 +235,12 @@ public class EndpointsPrimitiveWireTest {
         String expectedResponseBody = "" + "1000000";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
+        JsonNode normalizedActualResponseNode = normalizeNumbers(actualResponseNode);
+        JsonNode normalizedExpectedResponseNode = normalizeNumbers(expectedResponseNode);
         Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+                normalizedExpectedResponseNode,
+                normalizedActualResponseNode,
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -258,7 +279,10 @@ public class EndpointsPrimitiveWireTest {
         String expectedRequestBody = "" + "1.1";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        JsonNode normalizedActualJson = normalizeNumbers(actualJson);
+        JsonNode normalizedExpectedJson = normalizeNumbers(expectedJson);
+        Assertions.assertEquals(
+                normalizedExpectedJson, normalizedActualJson, "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -289,8 +313,12 @@ public class EndpointsPrimitiveWireTest {
         String expectedResponseBody = "" + "1.1";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
+        JsonNode normalizedActualResponseNode = normalizeNumbers(actualResponseNode);
+        JsonNode normalizedExpectedResponseNode = normalizeNumbers(expectedResponseNode);
         Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+                normalizedExpectedResponseNode,
+                normalizedActualResponseNode,
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -329,7 +357,10 @@ public class EndpointsPrimitiveWireTest {
         String expectedRequestBody = "" + "true";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        JsonNode normalizedActualJson = normalizeNumbers(actualJson);
+        JsonNode normalizedExpectedJson = normalizeNumbers(expectedJson);
+        Assertions.assertEquals(
+                normalizedExpectedJson, normalizedActualJson, "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -360,8 +391,12 @@ public class EndpointsPrimitiveWireTest {
         String expectedResponseBody = "" + "true";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
+        JsonNode normalizedActualResponseNode = normalizeNumbers(actualResponseNode);
+        JsonNode normalizedExpectedResponseNode = normalizeNumbers(expectedResponseNode);
         Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+                normalizedExpectedResponseNode,
+                normalizedActualResponseNode,
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -401,7 +436,10 @@ public class EndpointsPrimitiveWireTest {
         String expectedRequestBody = "" + "\"2024-01-15T09:30:00Z\"";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        JsonNode normalizedActualJson = normalizeNumbers(actualJson);
+        JsonNode normalizedExpectedJson = normalizeNumbers(expectedJson);
+        Assertions.assertEquals(
+                normalizedExpectedJson, normalizedActualJson, "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -432,8 +470,12 @@ public class EndpointsPrimitiveWireTest {
         String expectedResponseBody = "" + "\"2024-01-15T09:30:00Z\"";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
+        JsonNode normalizedActualResponseNode = normalizeNumbers(actualResponseNode);
+        JsonNode normalizedExpectedResponseNode = normalizeNumbers(expectedResponseNode);
         Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+                normalizedExpectedResponseNode,
+                normalizedActualResponseNode,
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -472,7 +514,10 @@ public class EndpointsPrimitiveWireTest {
         String expectedRequestBody = "" + "\"2023-01-15\"";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        JsonNode normalizedActualJson = normalizeNumbers(actualJson);
+        JsonNode normalizedExpectedJson = normalizeNumbers(expectedJson);
+        Assertions.assertEquals(
+                normalizedExpectedJson, normalizedActualJson, "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -503,8 +548,12 @@ public class EndpointsPrimitiveWireTest {
         String expectedResponseBody = "" + "\"2023-01-15\"";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
+        JsonNode normalizedActualResponseNode = normalizeNumbers(actualResponseNode);
+        JsonNode normalizedExpectedResponseNode = normalizeNumbers(expectedResponseNode);
         Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+                normalizedExpectedResponseNode,
+                normalizedActualResponseNode,
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -545,7 +594,10 @@ public class EndpointsPrimitiveWireTest {
         String expectedRequestBody = "" + "\"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32\"";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        JsonNode normalizedActualJson = normalizeNumbers(actualJson);
+        JsonNode normalizedExpectedJson = normalizeNumbers(expectedJson);
+        Assertions.assertEquals(
+                normalizedExpectedJson, normalizedActualJson, "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -576,8 +628,12 @@ public class EndpointsPrimitiveWireTest {
         String expectedResponseBody = "" + "\"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32\"";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
+        JsonNode normalizedActualResponseNode = normalizeNumbers(actualResponseNode);
+        JsonNode normalizedExpectedResponseNode = normalizeNumbers(expectedResponseNode);
         Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+                normalizedExpectedResponseNode,
+                normalizedActualResponseNode,
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -616,7 +672,10 @@ public class EndpointsPrimitiveWireTest {
         String expectedRequestBody = "" + "\"SGVsbG8gd29ybGQh\"";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        JsonNode normalizedActualJson = normalizeNumbers(actualJson);
+        JsonNode normalizedExpectedJson = normalizeNumbers(expectedJson);
+        Assertions.assertEquals(
+                normalizedExpectedJson, normalizedActualJson, "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -647,8 +706,12 @@ public class EndpointsPrimitiveWireTest {
         String expectedResponseBody = "" + "\"SGVsbG8gd29ybGQh\"";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
+        JsonNode normalizedActualResponseNode = normalizeNumbers(actualResponseNode);
+        JsonNode normalizedExpectedResponseNode = normalizeNumbers(expectedResponseNode);
         Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+                normalizedExpectedResponseNode,
+                normalizedActualResponseNode,
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -673,5 +736,32 @@ public class EndpointsPrimitiveWireTest {
         if (actualResponseNode.isObject()) {
             Assertions.assertTrue(actualResponseNode.size() >= 0, "Object should have valid field count");
         }
+    }
+
+    /**
+     * Normalizes numeric values in a JsonNode tree for comparison.
+     * Converts whole number doubles (e.g., 149.0) to longs (e.g., 149).
+     */
+    private JsonNode normalizeNumbers(JsonNode node) {
+        if (node.isNumber()) {
+            double value = node.doubleValue();
+            if (value == Math.floor(value) && !Double.isInfinite(value)) {
+                return objectMapper.getNodeFactory().numberNode((long) value);
+            }
+            return node;
+        }
+        if (node.isObject()) {
+            com.fasterxml.jackson.databind.node.ObjectNode normalized = objectMapper.createObjectNode();
+            node.fields().forEachRemaining(entry -> {
+                normalized.set(entry.getKey(), normalizeNumbers(entry.getValue()));
+            });
+            return normalized;
+        }
+        if (node.isArray()) {
+            com.fasterxml.jackson.databind.node.ArrayNode normalized = objectMapper.createArrayNode();
+            node.forEach(element -> normalized.add(normalizeNumbers(element)));
+            return normalized;
+        }
+        return node;
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsPutWireTest.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsPutWireTest.java
@@ -68,8 +68,12 @@ public class EndpointsPutWireTest {
                 + "}";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
+        JsonNode normalizedActualResponseNode = normalizeNumbers(actualResponseNode);
+        JsonNode normalizedExpectedResponseNode = normalizeNumbers(expectedResponseNode);
         Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+                normalizedExpectedResponseNode,
+                normalizedActualResponseNode,
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -94,5 +98,32 @@ public class EndpointsPutWireTest {
         if (actualResponseNode.isObject()) {
             Assertions.assertTrue(actualResponseNode.size() >= 0, "Object should have valid field count");
         }
+    }
+
+    /**
+     * Normalizes numeric values in a JsonNode tree for comparison.
+     * Converts whole number doubles (e.g., 149.0) to longs (e.g., 149).
+     */
+    private JsonNode normalizeNumbers(JsonNode node) {
+        if (node.isNumber()) {
+            double value = node.doubleValue();
+            if (value == Math.floor(value) && !Double.isInfinite(value)) {
+                return objectMapper.getNodeFactory().numberNode((long) value);
+            }
+            return node;
+        }
+        if (node.isObject()) {
+            com.fasterxml.jackson.databind.node.ObjectNode normalized = objectMapper.createObjectNode();
+            node.fields().forEachRemaining(entry -> {
+                normalized.set(entry.getKey(), normalizeNumbers(entry.getValue()));
+            });
+            return normalized;
+        }
+        if (node.isArray()) {
+            com.fasterxml.jackson.databind.node.ArrayNode normalized = objectMapper.createArrayNode();
+            node.forEach(element -> normalized.add(normalizeNumbers(element)));
+            return normalized;
+        }
+        return node;
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsUnionWireTest.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsUnionWireTest.java
@@ -51,7 +51,10 @@ public class EndpointsUnionWireTest {
                 "" + "{\n" + "  \"animal\": \"dog\",\n" + "  \"name\": \"name\",\n" + "  \"likesToWoof\": true\n" + "}";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        JsonNode normalizedActualJson = normalizeNumbers(actualJson);
+        JsonNode normalizedExpectedJson = normalizeNumbers(expectedJson);
+        Assertions.assertEquals(
+                normalizedExpectedJson, normalizedActualJson, "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -83,8 +86,12 @@ public class EndpointsUnionWireTest {
                 "" + "{\n" + "  \"animal\": \"dog\",\n" + "  \"name\": \"name\",\n" + "  \"likesToWoof\": true\n" + "}";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
+        JsonNode normalizedActualResponseNode = normalizeNumbers(actualResponseNode);
+        JsonNode normalizedExpectedResponseNode = normalizeNumbers(expectedResponseNode);
         Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+                normalizedExpectedResponseNode,
+                normalizedActualResponseNode,
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -109,5 +116,32 @@ public class EndpointsUnionWireTest {
         if (actualResponseNode.isObject()) {
             Assertions.assertTrue(actualResponseNode.size() >= 0, "Object should have valid field count");
         }
+    }
+
+    /**
+     * Normalizes numeric values in a JsonNode tree for comparison.
+     * Converts whole number doubles (e.g., 149.0) to longs (e.g., 149).
+     */
+    private JsonNode normalizeNumbers(JsonNode node) {
+        if (node.isNumber()) {
+            double value = node.doubleValue();
+            if (value == Math.floor(value) && !Double.isInfinite(value)) {
+                return objectMapper.getNodeFactory().numberNode((long) value);
+            }
+            return node;
+        }
+        if (node.isObject()) {
+            com.fasterxml.jackson.databind.node.ObjectNode normalized = objectMapper.createObjectNode();
+            node.fields().forEachRemaining(entry -> {
+                normalized.set(entry.getKey(), normalizeNumbers(entry.getValue()));
+            });
+            return normalized;
+        }
+        if (node.isArray()) {
+            com.fasterxml.jackson.databind.node.ArrayNode normalized = objectMapper.createArrayNode();
+            node.forEach(element -> normalized.add(normalizeNumbers(element)));
+            return normalized;
+        }
+        return node;
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsUrlsWireTest.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsUrlsWireTest.java
@@ -45,8 +45,12 @@ public class EndpointsUrlsWireTest {
         String expectedResponseBody = "" + "\"string\"";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
+        JsonNode normalizedActualResponseNode = normalizeNumbers(actualResponseNode);
+        JsonNode normalizedExpectedResponseNode = normalizeNumbers(expectedResponseNode);
         Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+                normalizedExpectedResponseNode,
+                normalizedActualResponseNode,
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -87,8 +91,12 @@ public class EndpointsUrlsWireTest {
         String expectedResponseBody = "" + "\"string\"";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
+        JsonNode normalizedActualResponseNode = normalizeNumbers(actualResponseNode);
+        JsonNode normalizedExpectedResponseNode = normalizeNumbers(expectedResponseNode);
         Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+                normalizedExpectedResponseNode,
+                normalizedActualResponseNode,
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -129,8 +137,12 @@ public class EndpointsUrlsWireTest {
         String expectedResponseBody = "" + "\"string\"";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
+        JsonNode normalizedActualResponseNode = normalizeNumbers(actualResponseNode);
+        JsonNode normalizedExpectedResponseNode = normalizeNumbers(expectedResponseNode);
         Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+                normalizedExpectedResponseNode,
+                normalizedActualResponseNode,
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -171,8 +183,12 @@ public class EndpointsUrlsWireTest {
         String expectedResponseBody = "" + "\"string\"";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
+        JsonNode normalizedActualResponseNode = normalizeNumbers(actualResponseNode);
+        JsonNode normalizedExpectedResponseNode = normalizeNumbers(expectedResponseNode);
         Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+                normalizedExpectedResponseNode,
+                normalizedActualResponseNode,
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -197,5 +213,32 @@ public class EndpointsUrlsWireTest {
         if (actualResponseNode.isObject()) {
             Assertions.assertTrue(actualResponseNode.size() >= 0, "Object should have valid field count");
         }
+    }
+
+    /**
+     * Normalizes numeric values in a JsonNode tree for comparison.
+     * Converts whole number doubles (e.g., 149.0) to longs (e.g., 149).
+     */
+    private JsonNode normalizeNumbers(JsonNode node) {
+        if (node.isNumber()) {
+            double value = node.doubleValue();
+            if (value == Math.floor(value) && !Double.isInfinite(value)) {
+                return objectMapper.getNodeFactory().numberNode((long) value);
+            }
+            return node;
+        }
+        if (node.isObject()) {
+            com.fasterxml.jackson.databind.node.ObjectNode normalized = objectMapper.createObjectNode();
+            node.fields().forEachRemaining(entry -> {
+                normalized.set(entry.getKey(), normalizeNumbers(entry.getValue()));
+            });
+            return normalized;
+        }
+        if (node.isArray()) {
+            com.fasterxml.jackson.databind.node.ArrayNode normalized = objectMapper.createArrayNode();
+            node.forEach(element -> normalized.add(normalizeNumbers(element)));
+            return normalized;
+        }
+        return node;
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/InlinedRequestsWireTest.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/InlinedRequestsWireTest.java
@@ -105,7 +105,10 @@ public class InlinedRequestsWireTest {
                 + "}";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        JsonNode normalizedActualJson = normalizeNumbers(actualJson);
+        JsonNode normalizedExpectedJson = normalizeNumbers(expectedJson);
+        Assertions.assertEquals(
+                normalizedExpectedJson, normalizedActualJson, "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -158,8 +161,12 @@ public class InlinedRequestsWireTest {
                 + "}";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
+        JsonNode normalizedActualResponseNode = normalizeNumbers(actualResponseNode);
+        JsonNode normalizedExpectedResponseNode = normalizeNumbers(expectedResponseNode);
         Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+                normalizedExpectedResponseNode,
+                normalizedActualResponseNode,
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -184,5 +191,32 @@ public class InlinedRequestsWireTest {
         if (actualResponseNode.isObject()) {
             Assertions.assertTrue(actualResponseNode.size() >= 0, "Object should have valid field count");
         }
+    }
+
+    /**
+     * Normalizes numeric values in a JsonNode tree for comparison.
+     * Converts whole number doubles (e.g., 149.0) to longs (e.g., 149).
+     */
+    private JsonNode normalizeNumbers(JsonNode node) {
+        if (node.isNumber()) {
+            double value = node.doubleValue();
+            if (value == Math.floor(value) && !Double.isInfinite(value)) {
+                return objectMapper.getNodeFactory().numberNode((long) value);
+            }
+            return node;
+        }
+        if (node.isObject()) {
+            com.fasterxml.jackson.databind.node.ObjectNode normalized = objectMapper.createObjectNode();
+            node.fields().forEachRemaining(entry -> {
+                normalized.set(entry.getKey(), normalizeNumbers(entry.getValue()));
+            });
+            return normalized;
+        }
+        if (node.isArray()) {
+            com.fasterxml.jackson.databind.node.ArrayNode normalized = objectMapper.createArrayNode();
+            node.forEach(element -> normalized.add(normalizeNumbers(element)));
+            return normalized;
+        }
+        return node;
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/NoAuthWireTest.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/NoAuthWireTest.java
@@ -48,7 +48,10 @@ public class NoAuthWireTest {
         String expectedRequestBody = "" + "{\n" + "  \"key\": \"value\"\n" + "}";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        JsonNode normalizedActualJson = normalizeNumbers(actualJson);
+        JsonNode normalizedExpectedJson = normalizeNumbers(expectedJson);
+        Assertions.assertEquals(
+                normalizedExpectedJson, normalizedActualJson, "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -79,8 +82,12 @@ public class NoAuthWireTest {
         String expectedResponseBody = "" + "true";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
+        JsonNode normalizedActualResponseNode = normalizeNumbers(actualResponseNode);
+        JsonNode normalizedExpectedResponseNode = normalizeNumbers(expectedResponseNode);
         Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+                normalizedExpectedResponseNode,
+                normalizedActualResponseNode,
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -105,5 +112,32 @@ public class NoAuthWireTest {
         if (actualResponseNode.isObject()) {
             Assertions.assertTrue(actualResponseNode.size() >= 0, "Object should have valid field count");
         }
+    }
+
+    /**
+     * Normalizes numeric values in a JsonNode tree for comparison.
+     * Converts whole number doubles (e.g., 149.0) to longs (e.g., 149).
+     */
+    private JsonNode normalizeNumbers(JsonNode node) {
+        if (node.isNumber()) {
+            double value = node.doubleValue();
+            if (value == Math.floor(value) && !Double.isInfinite(value)) {
+                return objectMapper.getNodeFactory().numberNode((long) value);
+            }
+            return node;
+        }
+        if (node.isObject()) {
+            com.fasterxml.jackson.databind.node.ObjectNode normalized = objectMapper.createObjectNode();
+            node.fields().forEachRemaining(entry -> {
+                normalized.set(entry.getKey(), normalizeNumbers(entry.getValue()));
+            });
+            return normalized;
+        }
+        if (node.isArray()) {
+            com.fasterxml.jackson.databind.node.ArrayNode normalized = objectMapper.createArrayNode();
+            node.forEach(element -> normalized.add(normalizeNumbers(element)));
+            return normalized;
+        }
+        return node;
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/ReqWithHeadersWireTest.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/ReqWithHeadersWireTest.java
@@ -59,7 +59,10 @@ public class ReqWithHeadersWireTest {
         String expectedRequestBody = "" + "\"string\"";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        JsonNode normalizedActualJson = normalizeNumbers(actualJson);
+        JsonNode normalizedExpectedJson = normalizeNumbers(expectedJson);
+        Assertions.assertEquals(
+                normalizedExpectedJson, normalizedActualJson, "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -83,5 +86,32 @@ public class ReqWithHeadersWireTest {
         if (actualJson.isObject()) {
             Assertions.assertTrue(actualJson.size() >= 0, "Object should have valid field count");
         }
+    }
+
+    /**
+     * Normalizes numeric values in a JsonNode tree for comparison.
+     * Converts whole number doubles (e.g., 149.0) to longs (e.g., 149).
+     */
+    private JsonNode normalizeNumbers(JsonNode node) {
+        if (node.isNumber()) {
+            double value = node.doubleValue();
+            if (value == Math.floor(value) && !Double.isInfinite(value)) {
+                return objectMapper.getNodeFactory().numberNode((long) value);
+            }
+            return node;
+        }
+        if (node.isObject()) {
+            com.fasterxml.jackson.databind.node.ObjectNode normalized = objectMapper.createObjectNode();
+            node.fields().forEachRemaining(entry -> {
+                normalized.set(entry.getKey(), normalizeNumbers(entry.getValue()));
+            });
+            return normalized;
+        }
+        if (node.isArray()) {
+            com.fasterxml.jackson.databind.node.ArrayNode normalized = objectMapper.createArrayNode();
+            node.forEach(element -> normalized.add(normalizeNumbers(element)));
+            return normalized;
+        }
+        return node;
     }
 }


### PR DESCRIPTION
## Description
Linear ticket: Refs [FER-7658: \[Java\] fix all wire tests issues](https://linear.app/buildwithfern/issue/FER-7658/java-fix-all-wire-tests-issues) 
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
<!-- Provide a clear and concise description of the changes made in this PR -->

Fixes runtime assertion failures in Java v2 wire tests caused by numeric type mismatches between Jackson serialization and API specs. Problem:
  - API specs define numbers like `"amount": 149` (integer)
  - Java generates builder calls like `.amount(149.0)` (double literal)
  - Jackson serializes as `"amount": 149.0` in request body
  - JsonNode.equals() comparison fails: IntNode(149) != DoubleNode(149.0)

Ideally should have a more elegant fix but this unblocks Bill

## Changes Made
  - Added normalizeNumbers() helper method at end of each wire test class
  - Recursively converts whole number doubles to longs for comparison
  - Called on both actual and expected JsonNodes before assertion


## Testing
<!-- Describe how you tested these changes -->
- [ ] Unit tests added/updated
- [ ] Manual testing completed
