### PR TITLE
chore(internal): Test generator-cli publishing with rc version

### DIFF
--- a/packages/generator-cli/versions.yml
+++ b/packages/generator-cli/versions.yml
@@ -1,6 +1,13 @@
 # yaml-language-server: $schema=../../versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Test publish new rc release.
+      type: chore
+  createdAt: "2025-11-12"
+  version: 0.4.4-rc0
+
+- changelogEntry:
+    - summary: |
         Fix npm authentication in the publish workflow by properly configuring the npm registry with NODE_AUTH_TOKEN.
       type: fix
   createdAt: "2025-11-11"


### PR DESCRIPTION
## Description
This PR adds a new release candidate version (0.4.4-rc0) to the generator-cli changelog to test the publishing workflow with rc versions. This helps validate that our publishing infrastructure correctly handles pre-release versions before they become stable releases.

## Changes Made
- **Changelog Update**: Added 0.4.4-rc0 entry to `packages/generator-cli/versions.yml` with test release summary
- **Version Management**: Configured new rc version with proper changelog structure and metadata

## Testing
- [x] Manual testing of changelog format
- [x] Verified version numbering follows semantic versioning for rc releases