### PR TITLE
fix(java): prevent HTTP headers from serializing to JSON request body

### DIFF
--- a/generators/java-v2/sdk/src/sdk-wire-tests/builders/TestClassBuilder.ts
+++ b/generators/java-v2/sdk/src/sdk-wire-tests/builders/TestClassBuilder.ts
@@ -77,6 +77,61 @@ export class TestClassBuilder {
     }
 
     /**
+     * Writes the closing brace for the test class and any helper methods
+     */
+    public closeTestClass(writer: Writer): void {
+        // Generate compact helper method for numeric equivalence comparison
+        this.generateJsonEqualsHelper(writer);
+        writer.dedent();
+        writer.writeLine("}");
+    }
+
+    /**
+     * Generates a compact helper for JSON comparison with numeric equivalence.
+     * Treats 149 and 149.0 as equal, which handles the common case where
+     * OpenAPI specs have integer examples but Java types are Double.
+     */
+    private generateJsonEqualsHelper(writer: Writer): void {
+        writer.writeLine("");
+        writer.writeLine("/**");
+        writer.writeLine(" * Compares two JsonNodes with numeric equivalence (149 == 149.0).");
+        writer.writeLine(" */");
+        writer.writeLine("private boolean jsonEquals(JsonNode a, JsonNode b) {");
+        writer.indent();
+        writer.writeLine("if (a.equals(b)) return true;");
+        writer.writeLine(
+            "if (a.isNumber() && b.isNumber()) return Math.abs(a.doubleValue() - b.doubleValue()) < 1e-10;"
+        );
+        writer.writeLine("if (a.isObject() && b.isObject()) {");
+        writer.indent();
+        writer.writeLine("if (a.size() != b.size()) return false;");
+        writer.writeLine("java.util.Iterator<java.util.Map.Entry<String, JsonNode>> iter = a.fields();");
+        writer.writeLine("while (iter.hasNext()) {");
+        writer.indent();
+        writer.writeLine("java.util.Map.Entry<String, JsonNode> entry = iter.next();");
+        writer.writeLine("if (!jsonEquals(entry.getValue(), b.get(entry.getKey()))) return false;");
+        writer.dedent();
+        writer.writeLine("}");
+        writer.writeLine("return true;");
+        writer.dedent();
+        writer.writeLine("}");
+        writer.writeLine("if (a.isArray() && b.isArray()) {");
+        writer.indent();
+        writer.writeLine("if (a.size() != b.size()) return false;");
+        writer.writeLine("for (int i = 0; i < a.size(); i++) {");
+        writer.indent();
+        writer.writeLine("if (!jsonEquals(a.get(i), b.get(i))) return false;");
+        writer.dedent();
+        writer.writeLine("}");
+        writer.writeLine("return true;");
+        writer.dedent();
+        writer.writeLine("}");
+        writer.writeLine("return false;");
+        writer.dedent();
+        writer.writeLine("}");
+    }
+
+    /**
      * Generates environment configuration for the client builder
      * Supports both single URL and multi-URL environment setups
      */

--- a/generators/java-v2/sdk/src/sdk-wire-tests/builders/TestClassBuilder.ts
+++ b/generators/java-v2/sdk/src/sdk-wire-tests/builders/TestClassBuilder.ts
@@ -76,9 +76,6 @@ export class TestClassBuilder {
         };
     }
 
-    /**
-     * Writes the closing brace for the test class and any helper methods
-     */
     public closeTestClass(writer: Writer): void {
         // Generate compact helper method for numeric equivalence comparison
         this.generateJsonEqualsHelper(writer);
@@ -88,13 +85,13 @@ export class TestClassBuilder {
 
     /**
      * Generates a compact helper for JSON comparison with numeric equivalence.
-     * Treats 149 and 149.0 as equal, which handles the common case where
-     * OpenAPI specs have integer examples but Java types are Double.
+     * Treats integers and doubles as numerically equal, which handles the common
+     * case where OpenAPI specs have integer examples but Java types are Double.
      */
     private generateJsonEqualsHelper(writer: Writer): void {
         writer.writeLine("");
         writer.writeLine("/**");
-        writer.writeLine(" * Compares two JsonNodes with numeric equivalence (149 == 149.0).");
+        writer.writeLine(" * Compares two JsonNodes with numeric equivalence.");
         writer.writeLine(" */");
         writer.writeLine("private boolean jsonEquals(JsonNode a, JsonNode b) {");
         writer.indent();

--- a/generators/java-v2/sdk/src/sdk-wire-tests/validators/JsonValidator.ts
+++ b/generators/java-v2/sdk/src/sdk-wire-tests/validators/JsonValidator.ts
@@ -39,6 +39,7 @@ export class JsonValidator {
     /**
      * Generates enhanced JSON validation with support for complex types
      * Provides better validation than basic JsonNode.equals() for unions, generics, etc.
+     * Uses numeric equivalence comparison to handle 149.0 vs 149.
      */
     public generateEnhancedJsonValidation(
         writer: Writer,
@@ -48,7 +49,7 @@ export class JsonValidator {
         expectedVarName: string
     ): void {
         writer.writeLine(
-            `Assertions.assertEquals(${expectedVarName}, ${actualVarName}, ` +
+            `Assertions.assertTrue(jsonEquals(${expectedVarName}, ${actualVarName}), ` +
                 `"${context === "request" ? "Request" : "Response"} body structure does not match expected");`
         );
 
@@ -98,7 +99,7 @@ export class JsonValidator {
     /**
      * Generates union type validation assertions
      */
-    private generateUnionTypeValidation(writer: Writer, jsonVarName: string, context: string): void {
+    private generateUnionTypeValidation(writer: Writer, jsonVarName: string, _context: string): void {
         writer.writeLine(
             `if (${jsonVarName}.has("type") || ${jsonVarName}.has("_type") || ${jsonVarName}.has("kind")) {`
         );
@@ -131,7 +132,7 @@ export class JsonValidator {
     /**
      * Generates validation for generic/collection types
      */
-    private generateGenericTypeValidation(writer: Writer, jsonVarName: string, context: string): void {
+    private generateGenericTypeValidation(writer: Writer, jsonVarName: string, _context: string): void {
         writer.writeLine("");
         writer.writeLine(`if (${jsonVarName}.isArray()) {`);
         writer.indent();

--- a/generators/java/generator-utils/src/main/java/com/fern/java/generators/object/BuilderGenerator.java
+++ b/generators/java/generator-utils/src/main/java/com/fern/java/generators/object/BuilderGenerator.java
@@ -318,7 +318,12 @@ public final class BuilderGenerator {
                     enrichedObjectProperty.enrichedObjectProperty.docs().get()));
             methodBuilder.addJavadoc(JavaDocUtils.getReturnDocs(CHAINED_RETURN_DOCS));
         }
-        if (enrichedObjectProperty.enrichedObjectProperty.wireKey().isPresent()) {
+        if (enrichedObjectProperty.enrichedObjectProperty.wireKey().isPresent()
+                && !enrichedObjectProperty
+                        .enrichedObjectProperty
+                        .wireKey()
+                        .get()
+                        .isEmpty()) {
             methodBuilder.addAnnotation(AnnotationSpec.builder(JsonSetter.class)
                     .addMember(
                             "value",
@@ -438,7 +443,12 @@ public final class BuilderGenerator {
     private MethodSpec.Builder getDefaultSetterForImpl(
             EnrichedObjectPropertyWithField enrichedObjectProperty, ClassName returnClass, boolean isOverridden) {
         MethodSpec.Builder methodBuilder = getDefaultSetter(enrichedObjectProperty, returnClass, isOverridden);
-        if (enrichedObjectProperty.enrichedObjectProperty.wireKey().isPresent()) {
+        if (enrichedObjectProperty.enrichedObjectProperty.wireKey().isPresent()
+                && !enrichedObjectProperty
+                        .enrichedObjectProperty
+                        .wireKey()
+                        .get()
+                        .isEmpty()) {
             methodBuilder.addAnnotation(AnnotationSpec.builder(JsonSetter.class)
                     .addMember(
                             "value",
@@ -973,7 +983,8 @@ public final class BuilderGenerator {
                 .addAnnotation(ClassName.get("", "java.lang.Override"))
                 .addParameter(poetTypeName, fieldSpec.name);
 
-        if (enrichedProperty.enrichedObjectProperty.wireKey().isPresent()) {
+        if (enrichedProperty.enrichedObjectProperty.wireKey().isPresent()
+                && !enrichedProperty.enrichedObjectProperty.wireKey().get().isEmpty()) {
             implSetter.addAnnotation(AnnotationSpec.builder(JsonSetter.class)
                     .addMember(
                             "value",
@@ -1033,7 +1044,8 @@ public final class BuilderGenerator {
 
         implSetter.addParameter(paramBuilder.build());
 
-        if (enrichedProperty.enrichedObjectProperty.wireKey().isPresent()) {
+        if (enrichedProperty.enrichedObjectProperty.wireKey().isPresent()
+                && !enrichedProperty.enrichedObjectProperty.wireKey().get().isEmpty()) {
             implSetter.addAnnotation(AnnotationSpec.builder(JsonSetter.class)
                     .addMember(
                             "value",

--- a/generators/java/generator-utils/src/main/java/com/fern/java/generators/object/EnrichedObjectProperty.java
+++ b/generators/java/generator-utils/src/main/java/com/fern/java/generators/object/EnrichedObjectProperty.java
@@ -135,7 +135,9 @@ public interface EnrichedObjectProperty {
         } else {
             getterBuilder.addStatement("return $L", fieldSpec().get().name);
         }
-        if (wireKey().isPresent() && !nullable() && !aliasOfNullable()) {
+        // Headers have empty wireKey to avoid JSON serialization
+        boolean hasWireKey = wireKey().isPresent() && !wireKey().get().isEmpty();
+        if (hasWireKey && !nullable() && !aliasOfNullable()) {
             getterBuilder.addAnnotation(AnnotationSpec.builder(JsonProperty.class)
                     .addMember("value", "$S", wireKey().get())
                     .build());
@@ -153,7 +155,9 @@ public interface EnrichedObjectProperty {
 
     @Value.Lazy
     default Optional<MethodSpec> getterForSerialization() {
-        if (wireKey().isEmpty() || (!nullable() && !aliasOfNullable())) {
+        // Headers have empty wireKey and should not have serialization getter
+        boolean hasWireKey = wireKey().isPresent() && !wireKey().get().isEmpty();
+        if (!hasWireKey || (!nullable() && !aliasOfNullable())) {
             return Optional.empty();
         }
 

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/WrappedRequestGenerator.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/WrappedRequestGenerator.java
@@ -111,8 +111,15 @@ public final class WrappedRequestGenerator extends AbstractFileGenerator {
             if (defaultValueExtractor.hasDefaultValue(valueType)) {
                 valueType = TypeReference.container(ContainerType.optional(valueType));
             }
+            // Create header property with modified name that has NO wire value
+            // This ensures the property gets @JsonIgnore instead of @JsonProperty
+            // Headers should only be sent as HTTP headers, not in JSON body
+            NameAndWireValue nameWithoutWire = NameAndWireValue.builder()
+                    .wireValue("") // Empty wire value → @JsonIgnore
+                    .name(httpHeader.getName().getName())
+                    .build();
             headerObjectProperties.add(ObjectProperty.builder()
-                    .name(httpHeader.getName())
+                    .name(nameWithoutWire)
                     .valueType(valueType)
                     .docs(httpHeader.getDocs())
                     .build());
@@ -122,8 +129,15 @@ public final class WrappedRequestGenerator extends AbstractFileGenerator {
             if (defaultValueExtractor.hasDefaultValue(valueType)) {
                 valueType = TypeReference.container(ContainerType.optional(valueType));
             }
+            // Create header property with modified name that has NO wire value
+            // This ensures the property gets @JsonIgnore instead of @JsonProperty
+            // Headers should only be sent as HTTP headers, not in JSON body
+            NameAndWireValue nameWithoutWire = NameAndWireValue.builder()
+                    .wireValue("") // Empty wire value → @JsonIgnore
+                    .name(httpHeader.getName().getName())
+                    .build();
             headerObjectProperties.add(ObjectProperty.builder()
-                    .name(httpHeader.getName())
+                    .name(nameWithoutWire)
                     .valueType(valueType)
                     .docs(httpHeader.getDocs())
                     .build());

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/WrappedRequestGenerator.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/WrappedRequestGenerator.java
@@ -111,8 +111,6 @@ public final class WrappedRequestGenerator extends AbstractFileGenerator {
             if (defaultValueExtractor.hasDefaultValue(valueType)) {
                 valueType = TypeReference.container(ContainerType.optional(valueType));
             }
-            // Create header property with modified name that has NO wire value
-            // This ensures the property gets @JsonIgnore instead of @JsonProperty
             // Headers should only be sent as HTTP headers, not in JSON body
             NameAndWireValue nameWithoutWire = NameAndWireValue.builder()
                     .wireValue("") // Empty wire value → @JsonIgnore
@@ -129,8 +127,6 @@ public final class WrappedRequestGenerator extends AbstractFileGenerator {
             if (defaultValueExtractor.hasDefaultValue(valueType)) {
                 valueType = TypeReference.container(ContainerType.optional(valueType));
             }
-            // Create header property with modified name that has NO wire value
-            // This ensures the property gets @JsonIgnore instead of @JsonProperty
             // Headers should only be sent as HTTP headers, not in JSON body
             NameAndWireValue nameWithoutWire = NameAndWireValue.builder()
                     .wireValue("") // Empty wire value → @JsonIgnore

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/WrappedRequestEndpointWriter.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/WrappedRequestEndpointWriter.java
@@ -136,7 +136,6 @@ public final class WrappedRequestEndpointWriter extends AbstractEndpointWriter {
             } else if (generatedWrappedRequest.requestBodyGetter().get() instanceof InlinedRequestBodyGetters) {
                 InlinedRequestBodyGetters inlinedRequestBodyGetter = ((InlinedRequestBodyGetters)
                         generatedWrappedRequest.requestBodyGetter().get());
-                // Serialize the request object directly instead of manually building a properties map.
                 initializeRequestBody(
                         generatedObjectMapper,
                         requestParameterName,
@@ -192,8 +191,6 @@ public final class WrappedRequestEndpointWriter extends AbstractEndpointWriter {
         requestBodyCodeBlock.add(";\n");
         requestBodyCodeBlock.unindent();
         for (EnrichedObjectProperty header : generatedWrappedRequest.headerParams()) {
-            // Use the original header name from the Name object
-            // The wireValue is empty to trigger @JsonIgnore, so we get the name from Name.getOriginalName()
             String headerName = header.objectProperty().getName().getName().getOriginalName();
             if (typeNameIsOptional(header.poetTypeName())) {
                 requestBodyCodeBlock

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/WrappedRequestEndpointWriter.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/WrappedRequestEndpointWriter.java
@@ -49,8 +49,6 @@ import com.squareup.javapoet.FieldSpec;
 import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 import java.nio.file.Files;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
 import okhttp3.*;
 
@@ -138,11 +136,10 @@ public final class WrappedRequestEndpointWriter extends AbstractEndpointWriter {
             } else if (generatedWrappedRequest.requestBodyGetter().get() instanceof InlinedRequestBodyGetters) {
                 InlinedRequestBodyGetters inlinedRequestBodyGetter = ((InlinedRequestBodyGetters)
                         generatedWrappedRequest.requestBodyGetter().get());
-                // Build a properties map with only body parameters, preserving nullable semantics
-                initializeRequestBodyProperties(inlinedRequestBodyGetter, requestBodyCodeBlock);
+                // Serialize the request object directly instead of manually building a properties map.
                 initializeRequestBody(
                         generatedObjectMapper,
-                        variables.getRequestBodyPropertiesName(),
+                        requestParameterName,
                         requestBodyCodeBlock,
                         sendContentType,
                         contentType);
@@ -195,13 +192,16 @@ public final class WrappedRequestEndpointWriter extends AbstractEndpointWriter {
         requestBodyCodeBlock.add(";\n");
         requestBodyCodeBlock.unindent();
         for (EnrichedObjectProperty header : generatedWrappedRequest.headerParams()) {
+            // Use the original header name from the Name object
+            // The wireValue is empty to trigger @JsonIgnore, so we get the name from Name.getOriginalName()
+            String headerName = header.objectProperty().getName().getName().getOriginalName();
             if (typeNameIsOptional(header.poetTypeName())) {
                 requestBodyCodeBlock
                         .beginControlFlow("if ($L.$N().isPresent())", requestParameterName, header.getterProperty())
                         .addStatement(
                                 "$L.addHeader($S, $L)",
                                 AbstractEndpointWriter.REQUEST_BUILDER_NAME,
-                                header.wireKey().get(),
+                                headerName,
                                 PoetTypeNameStringifier.stringify(
                                         CodeBlock.of("$L.$N().get()", "request", header.getterProperty())
                                                 .toString(),
@@ -211,7 +211,7 @@ public final class WrappedRequestEndpointWriter extends AbstractEndpointWriter {
                 requestBodyCodeBlock.addStatement(
                         "$L.addHeader($S, $L)",
                         AbstractEndpointWriter.REQUEST_BUILDER_NAME,
-                        header.wireKey().get(),
+                        headerName,
                         PoetTypeNameStringifier.stringify(
                                 CodeBlock.of("$L.$N()", "request", header.getterProperty())
                                         .toString(),
@@ -221,22 +221,6 @@ public final class WrappedRequestEndpointWriter extends AbstractEndpointWriter {
         requestBodyCodeBlock.addStatement(
                 "$T $L = $L.build()", Request.class, variables.getOkhttpRequestName(), REQUEST_BUILDER_NAME);
         return requestBodyCodeBlock.build();
-    }
-
-    private void initializeRequestBodyProperties(
-            InlinedRequestBodyGetters inlinedRequestBody, CodeBlock.Builder requestBodyCodeBlock) {
-        requestBodyCodeBlock.addStatement(
-                "$T $L = new $T<>()",
-                ParameterizedTypeName.get(Map.class, String.class, Object.class),
-                variables.getRequestBodyPropertiesName(),
-                HashMap.class);
-        for (EnrichedObjectProperty bodyProperty : inlinedRequestBody.properties()) {
-            requestBodyCodeBlock.addStatement(
-                    "$L.put($S, $L)",
-                    variables.getRequestBodyPropertiesName(),
-                    bodyProperty.wireKey().get(),
-                    requestParameterName + "." + bodyProperty.getterProperty().name + "()");
-        }
     }
 
     private void initializeRequestBody(

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,3 +1,11 @@
+- version: 3.14.10
+  changelogEntry:
+    - summary: |
+        Fix wire test failures for numeric type mismatches and header serialization. Wire tests now use numeric equivalence comparison to handle integer vs double type differences from OpenAPI specs. Headers are no longer incorrectly serialized into JSON request bodies - they now use @JsonIgnore and are sent only as HTTP headers.
+      type: fix
+  createdAt: "2025-11-12"
+  irVersion: 61
+
 - version: 3.14.9
   changelogEntry:
     - summary: Fix wire test compilation errors when using staged builders with collections. Builder method calls now correctly order required fields before collections like Lists, Sets, and Maps.

--- a/seed/java-sdk/exhaustive/custom-client-class-name/README.md
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/README.md
@@ -5,6 +5,21 @@
 
 The Seed Java library provides convenient access to the Seed APIs from Java.
 
+## Table of Contents
+
+- [Installation](#installation)
+- [Reference](#reference)
+- [Usage](#usage)
+- [Base Url](#base-url)
+- [Exception Handling](#exception-handling)
+- [Advanced](#advanced)
+  - [Custom Client](#custom-client)
+  - [Retries](#retries)
+  - [Timeouts](#timeouts)
+  - [Custom Headers](#custom-headers)
+  - [Access Raw Response Data](#access-raw-response-data)
+- [Contributing](#contributing)
+
 ## Installation
 
 ### Gradle

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/reqwithheaders/requests/ReqWithHeaders.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/reqwithheaders/requests/ReqWithHeaders.java
@@ -5,6 +5,7 @@ package com.seed.exhaustive.resources.reqwithheaders.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -38,12 +39,12 @@ public final class ReqWithHeaders {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonProperty("X-TEST-SERVICE-HEADER")
+    @JsonIgnore
     public String getXTestServiceHeader() {
         return xTestServiceHeader;
     }
 
-    @JsonProperty("X-TEST-ENDPOINT-HEADER")
+    @JsonIgnore
     public String getXTestEndpointHeader() {
         return xTestEndpointHeader;
     }
@@ -125,14 +126,12 @@ public final class ReqWithHeaders {
         }
 
         @java.lang.Override
-        @JsonSetter("X-TEST-SERVICE-HEADER")
         public XTestEndpointHeaderStage xTestServiceHeader(@NotNull String xTestServiceHeader) {
             this.xTestServiceHeader = Objects.requireNonNull(xTestServiceHeader, "xTestServiceHeader must not be null");
             return this;
         }
 
         @java.lang.Override
-        @JsonSetter("X-TEST-ENDPOINT-HEADER")
         public BodyStage xTestEndpointHeader(@NotNull String xTestEndpointHeader) {
             this.xTestEndpointHeader =
                     Objects.requireNonNull(xTestEndpointHeader, "xTestEndpointHeader must not be null");

--- a/seed/java-sdk/exhaustive/custom-dependency/README.md
+++ b/seed/java-sdk/exhaustive/custom-dependency/README.md
@@ -5,6 +5,21 @@
 
 The Seed Java library provides convenient access to the Seed APIs from Java.
 
+## Table of Contents
+
+- [Installation](#installation)
+- [Reference](#reference)
+- [Usage](#usage)
+- [Base Url](#base-url)
+- [Exception Handling](#exception-handling)
+- [Advanced](#advanced)
+  - [Custom Client](#custom-client)
+  - [Retries](#retries)
+  - [Timeouts](#timeouts)
+  - [Custom Headers](#custom-headers)
+  - [Access Raw Response Data](#access-raw-response-data)
+- [Contributing](#contributing)
+
 ## Installation
 
 ### Gradle

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/reqwithheaders/requests/ReqWithHeaders.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/reqwithheaders/requests/ReqWithHeaders.java
@@ -5,6 +5,7 @@ package com.seed.exhaustive.resources.reqwithheaders.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -38,12 +39,12 @@ public final class ReqWithHeaders {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonProperty("X-TEST-SERVICE-HEADER")
+    @JsonIgnore
     public String getXTestServiceHeader() {
         return xTestServiceHeader;
     }
 
-    @JsonProperty("X-TEST-ENDPOINT-HEADER")
+    @JsonIgnore
     public String getXTestEndpointHeader() {
         return xTestEndpointHeader;
     }
@@ -125,14 +126,12 @@ public final class ReqWithHeaders {
         }
 
         @java.lang.Override
-        @JsonSetter("X-TEST-SERVICE-HEADER")
         public XTestEndpointHeaderStage xTestServiceHeader(@NotNull String xTestServiceHeader) {
             this.xTestServiceHeader = Objects.requireNonNull(xTestServiceHeader, "xTestServiceHeader must not be null");
             return this;
         }
 
         @java.lang.Override
-        @JsonSetter("X-TEST-ENDPOINT-HEADER")
         public BodyStage xTestEndpointHeader(@NotNull String xTestEndpointHeader) {
             this.xTestEndpointHeader =
                     Objects.requireNonNull(xTestEndpointHeader, "xTestEndpointHeader must not be null");

--- a/seed/java-sdk/exhaustive/custom-error-names/README.md
+++ b/seed/java-sdk/exhaustive/custom-error-names/README.md
@@ -5,6 +5,21 @@
 
 The Seed Java library provides convenient access to the Seed APIs from Java.
 
+## Table of Contents
+
+- [Installation](#installation)
+- [Reference](#reference)
+- [Usage](#usage)
+- [Base Url](#base-url)
+- [Exception Handling](#exception-handling)
+- [Advanced](#advanced)
+  - [Custom Client](#custom-client)
+  - [Retries](#retries)
+  - [Timeouts](#timeouts)
+  - [Custom Headers](#custom-headers)
+  - [Access Raw Response Data](#access-raw-response-data)
+- [Contributing](#contributing)
+
 ## Installation
 
 ### Gradle

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/reqwithheaders/requests/ReqWithHeaders.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/reqwithheaders/requests/ReqWithHeaders.java
@@ -5,6 +5,7 @@ package com.seed.exhaustive.resources.reqwithheaders.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -38,12 +39,12 @@ public final class ReqWithHeaders {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonProperty("X-TEST-SERVICE-HEADER")
+    @JsonIgnore
     public String getXTestServiceHeader() {
         return xTestServiceHeader;
     }
 
-    @JsonProperty("X-TEST-ENDPOINT-HEADER")
+    @JsonIgnore
     public String getXTestEndpointHeader() {
         return xTestEndpointHeader;
     }
@@ -125,14 +126,12 @@ public final class ReqWithHeaders {
         }
 
         @java.lang.Override
-        @JsonSetter("X-TEST-SERVICE-HEADER")
         public XTestEndpointHeaderStage xTestServiceHeader(@NotNull String xTestServiceHeader) {
             this.xTestServiceHeader = Objects.requireNonNull(xTestServiceHeader, "xTestServiceHeader must not be null");
             return this;
         }
 
         @java.lang.Override
-        @JsonSetter("X-TEST-ENDPOINT-HEADER")
         public BodyStage xTestEndpointHeader(@NotNull String xTestEndpointHeader) {
             this.xTestEndpointHeader =
                     Objects.requireNonNull(xTestEndpointHeader, "xTestEndpointHeader must not be null");

--- a/seed/java-sdk/exhaustive/custom-license/README.md
+++ b/seed/java-sdk/exhaustive/custom-license/README.md
@@ -5,6 +5,21 @@
 
 The Seed Java library provides convenient access to the Seed APIs from Java.
 
+## Table of Contents
+
+- [Installation](#installation)
+- [Reference](#reference)
+- [Usage](#usage)
+- [Base Url](#base-url)
+- [Exception Handling](#exception-handling)
+- [Advanced](#advanced)
+  - [Custom Client](#custom-client)
+  - [Retries](#retries)
+  - [Timeouts](#timeouts)
+  - [Custom Headers](#custom-headers)
+  - [Access Raw Response Data](#access-raw-response-data)
+- [Contributing](#contributing)
+
 ## Installation
 
 ### Gradle

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/reqwithheaders/requests/ReqWithHeaders.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/reqwithheaders/requests/ReqWithHeaders.java
@@ -5,6 +5,7 @@ package com.seed.exhaustive.resources.reqwithheaders.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -38,12 +39,12 @@ public final class ReqWithHeaders {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonProperty("X-TEST-SERVICE-HEADER")
+    @JsonIgnore
     public String getXTestServiceHeader() {
         return xTestServiceHeader;
     }
 
-    @JsonProperty("X-TEST-ENDPOINT-HEADER")
+    @JsonIgnore
     public String getXTestEndpointHeader() {
         return xTestEndpointHeader;
     }
@@ -125,14 +126,12 @@ public final class ReqWithHeaders {
         }
 
         @java.lang.Override
-        @JsonSetter("X-TEST-SERVICE-HEADER")
         public XTestEndpointHeaderStage xTestServiceHeader(@NotNull String xTestServiceHeader) {
             this.xTestServiceHeader = Objects.requireNonNull(xTestServiceHeader, "xTestServiceHeader must not be null");
             return this;
         }
 
         @java.lang.Override
-        @JsonSetter("X-TEST-ENDPOINT-HEADER")
         public BodyStage xTestEndpointHeader(@NotNull String xTestEndpointHeader) {
             this.xTestEndpointHeader =
                     Objects.requireNonNull(xTestEndpointHeader, "xTestEndpointHeader must not be null");

--- a/seed/java-sdk/exhaustive/enable-public-constructors/README.md
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/README.md
@@ -5,6 +5,21 @@
 
 The Seed Java library provides convenient access to the Seed APIs from Java.
 
+## Table of Contents
+
+- [Installation](#installation)
+- [Reference](#reference)
+- [Usage](#usage)
+- [Base Url](#base-url)
+- [Exception Handling](#exception-handling)
+- [Advanced](#advanced)
+  - [Custom Client](#custom-client)
+  - [Retries](#retries)
+  - [Timeouts](#timeouts)
+  - [Custom Headers](#custom-headers)
+  - [Access Raw Response Data](#access-raw-response-data)
+- [Contributing](#contributing)
+
 ## Installation
 
 ### Gradle

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/reqwithheaders/requests/ReqWithHeaders.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/reqwithheaders/requests/ReqWithHeaders.java
@@ -5,6 +5,7 @@ package com.seed.exhaustive.resources.reqwithheaders.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -38,12 +39,12 @@ public final class ReqWithHeaders {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonProperty("X-TEST-SERVICE-HEADER")
+    @JsonIgnore
     public String getXTestServiceHeader() {
         return xTestServiceHeader;
     }
 
-    @JsonProperty("X-TEST-ENDPOINT-HEADER")
+    @JsonIgnore
     public String getXTestEndpointHeader() {
         return xTestEndpointHeader;
     }
@@ -125,14 +126,12 @@ public final class ReqWithHeaders {
         }
 
         @java.lang.Override
-        @JsonSetter("X-TEST-SERVICE-HEADER")
         public XTestEndpointHeaderStage xTestServiceHeader(@NotNull String xTestServiceHeader) {
             this.xTestServiceHeader = Objects.requireNonNull(xTestServiceHeader, "xTestServiceHeader must not be null");
             return this;
         }
 
         @java.lang.Override
-        @JsonSetter("X-TEST-ENDPOINT-HEADER")
         public BodyStage xTestEndpointHeader(@NotNull String xTestEndpointHeader) {
             this.xTestEndpointHeader =
                     Objects.requireNonNull(xTestEndpointHeader, "xTestEndpointHeader must not be null");

--- a/seed/java-sdk/exhaustive/flat-package-layout/README.md
+++ b/seed/java-sdk/exhaustive/flat-package-layout/README.md
@@ -5,6 +5,21 @@
 
 The Seed Java library provides convenient access to the Seed APIs from Java.
 
+## Table of Contents
+
+- [Installation](#installation)
+- [Reference](#reference)
+- [Usage](#usage)
+- [Base Url](#base-url)
+- [Exception Handling](#exception-handling)
+- [Advanced](#advanced)
+  - [Custom Client](#custom-client)
+  - [Retries](#retries)
+  - [Timeouts](#timeouts)
+  - [Custom Headers](#custom-headers)
+  - [Access Raw Response Data](#access-raw-response-data)
+- [Contributing](#contributing)
+
 ## Installation
 
 ### Gradle

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/types/ReqWithHeaders.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/types/ReqWithHeaders.java
@@ -5,6 +5,7 @@ package com.seed.exhaustive.types;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -38,12 +39,12 @@ public final class ReqWithHeaders {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonProperty("X-TEST-SERVICE-HEADER")
+    @JsonIgnore
     public String getXTestServiceHeader() {
         return xTestServiceHeader;
     }
 
-    @JsonProperty("X-TEST-ENDPOINT-HEADER")
+    @JsonIgnore
     public String getXTestEndpointHeader() {
         return xTestEndpointHeader;
     }
@@ -125,14 +126,12 @@ public final class ReqWithHeaders {
         }
 
         @java.lang.Override
-        @JsonSetter("X-TEST-SERVICE-HEADER")
         public XTestEndpointHeaderStage xTestServiceHeader(@NotNull String xTestServiceHeader) {
             this.xTestServiceHeader = Objects.requireNonNull(xTestServiceHeader, "xTestServiceHeader must not be null");
             return this;
         }
 
         @java.lang.Override
-        @JsonSetter("X-TEST-ENDPOINT-HEADER")
         public BodyStage xTestEndpointHeader(@NotNull String xTestEndpointHeader) {
             this.xTestEndpointHeader =
                     Objects.requireNonNull(xTestEndpointHeader, "xTestEndpointHeader must not be null");

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/README.md
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/README.md
@@ -5,6 +5,21 @@
 
 The Seed Java library provides convenient access to the Seed APIs from Java.
 
+## Table of Contents
+
+- [Installation](#installation)
+- [Reference](#reference)
+- [Usage](#usage)
+- [Base Url](#base-url)
+- [Exception Handling](#exception-handling)
+- [Advanced](#advanced)
+  - [Custom Client](#custom-client)
+  - [Retries](#retries)
+  - [Timeouts](#timeouts)
+  - [Custom Headers](#custom-headers)
+  - [Access Raw Response Data](#access-raw-response-data)
+- [Contributing](#contributing)
+
 ## Installation
 
 ### Gradle

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/reqwithheaders/requests/ReqWithHeaders.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/reqwithheaders/requests/ReqWithHeaders.java
@@ -5,6 +5,7 @@ package com.seed.exhaustive.resources.reqwithheaders.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -38,12 +39,12 @@ public final class ReqWithHeaders {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonProperty("X-TEST-SERVICE-HEADER")
+    @JsonIgnore
     public String getXTestServiceHeader() {
         return xTestServiceHeader;
     }
 
-    @JsonProperty("X-TEST-ENDPOINT-HEADER")
+    @JsonIgnore
     public String getXTestEndpointHeader() {
         return xTestEndpointHeader;
     }
@@ -125,14 +126,12 @@ public final class ReqWithHeaders {
         }
 
         @java.lang.Override
-        @JsonSetter("X-TEST-SERVICE-HEADER")
         public XTestEndpointHeaderStage xTestServiceHeader(@NotNull String xTestServiceHeader) {
             this.xTestServiceHeader = Objects.requireNonNull(xTestServiceHeader, "xTestServiceHeader must not be null");
             return this;
         }
 
         @java.lang.Override
-        @JsonSetter("X-TEST-ENDPOINT-HEADER")
         public BodyStage xTestEndpointHeader(@NotNull String xTestEndpointHeader) {
             this.xTestEndpointHeader =
                     Objects.requireNonNull(xTestEndpointHeader, "xTestEndpointHeader must not be null");

--- a/seed/java-sdk/exhaustive/json-include-non-empty/README.md
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/README.md
@@ -5,6 +5,21 @@
 
 The Seed Java library provides convenient access to the Seed APIs from Java.
 
+## Table of Contents
+
+- [Installation](#installation)
+- [Reference](#reference)
+- [Usage](#usage)
+- [Base Url](#base-url)
+- [Exception Handling](#exception-handling)
+- [Advanced](#advanced)
+  - [Custom Client](#custom-client)
+  - [Retries](#retries)
+  - [Timeouts](#timeouts)
+  - [Custom Headers](#custom-headers)
+  - [Access Raw Response Data](#access-raw-response-data)
+- [Contributing](#contributing)
+
 ## Installation
 
 ### Gradle

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/reqwithheaders/requests/ReqWithHeaders.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/reqwithheaders/requests/ReqWithHeaders.java
@@ -5,6 +5,7 @@ package com.seed.exhaustive.resources.reqwithheaders.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -38,12 +39,12 @@ public final class ReqWithHeaders {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonProperty("X-TEST-SERVICE-HEADER")
+    @JsonIgnore
     public String getXTestServiceHeader() {
         return xTestServiceHeader;
     }
 
-    @JsonProperty("X-TEST-ENDPOINT-HEADER")
+    @JsonIgnore
     public String getXTestEndpointHeader() {
         return xTestEndpointHeader;
     }
@@ -125,14 +126,12 @@ public final class ReqWithHeaders {
         }
 
         @java.lang.Override
-        @JsonSetter("X-TEST-SERVICE-HEADER")
         public XTestEndpointHeaderStage xTestServiceHeader(@NotNull String xTestServiceHeader) {
             this.xTestServiceHeader = Objects.requireNonNull(xTestServiceHeader, "xTestServiceHeader must not be null");
             return this;
         }
 
         @java.lang.Override
-        @JsonSetter("X-TEST-ENDPOINT-HEADER")
         public BodyStage xTestEndpointHeader(@NotNull String xTestEndpointHeader) {
             this.xTestEndpointHeader =
                     Objects.requireNonNull(xTestEndpointHeader, "xTestEndpointHeader must not be null");

--- a/seed/java-sdk/exhaustive/local-files/README.md
+++ b/seed/java-sdk/exhaustive/local-files/README.md
@@ -4,6 +4,20 @@
 
 The Seed Java library provides convenient access to the Seed APIs from Java.
 
+## Table of Contents
+
+- [Reference](#reference)
+- [Usage](#usage)
+- [Base Url](#base-url)
+- [Exception Handling](#exception-handling)
+- [Advanced](#advanced)
+  - [Custom Client](#custom-client)
+  - [Retries](#retries)
+  - [Timeouts](#timeouts)
+  - [Custom Headers](#custom-headers)
+  - [Access Raw Response Data](#access-raw-response-data)
+- [Contributing](#contributing)
+
 ## Reference
 
 A full reference for this library is available [here](./reference.md).

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/reqwithheaders/requests/ReqWithHeaders.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/reqwithheaders/requests/ReqWithHeaders.java
@@ -6,6 +6,7 @@ package com.fern.sdk.resources.reqwithheaders.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -40,12 +41,12 @@ public final class ReqWithHeaders {
     this.additionalProperties = additionalProperties;
   }
 
-  @JsonProperty("X-TEST-SERVICE-HEADER")
+  @JsonIgnore
   public String getXTestServiceHeader() {
     return xTestServiceHeader;
   }
 
-  @JsonProperty("X-TEST-ENDPOINT-HEADER")
+  @JsonIgnore
   public String getXTestEndpointHeader() {
     return xTestEndpointHeader;
   }
@@ -127,14 +128,12 @@ public final class ReqWithHeaders {
     }
 
     @java.lang.Override
-    @JsonSetter("X-TEST-SERVICE-HEADER")
     public XTestEndpointHeaderStage xTestServiceHeader(@NotNull String xTestServiceHeader) {
       this.xTestServiceHeader = Objects.requireNonNull(xTestServiceHeader, "xTestServiceHeader must not be null");
       return this;
     }
 
     @java.lang.Override
-    @JsonSetter("X-TEST-ENDPOINT-HEADER")
     public BodyStage xTestEndpointHeader(@NotNull String xTestEndpointHeader) {
       this.xTestEndpointHeader = Objects.requireNonNull(xTestEndpointHeader, "xTestEndpointHeader must not be null");
       return this;

--- a/seed/java-sdk/exhaustive/no-custom-config/README.md
+++ b/seed/java-sdk/exhaustive/no-custom-config/README.md
@@ -5,6 +5,21 @@
 
 The Seed Java library provides convenient access to the Seed APIs from Java.
 
+## Table of Contents
+
+- [Installation](#installation)
+- [Reference](#reference)
+- [Usage](#usage)
+- [Base Url](#base-url)
+- [Exception Handling](#exception-handling)
+- [Advanced](#advanced)
+  - [Custom Client](#custom-client)
+  - [Retries](#retries)
+  - [Timeouts](#timeouts)
+  - [Custom Headers](#custom-headers)
+  - [Access Raw Response Data](#access-raw-response-data)
+- [Contributing](#contributing)
+
 ## Installation
 
 ### Gradle

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/reqwithheaders/requests/ReqWithHeaders.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/reqwithheaders/requests/ReqWithHeaders.java
@@ -5,6 +5,7 @@ package com.seed.exhaustive.resources.reqwithheaders.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -38,12 +39,12 @@ public final class ReqWithHeaders {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonProperty("X-TEST-SERVICE-HEADER")
+    @JsonIgnore
     public String getXTestServiceHeader() {
         return xTestServiceHeader;
     }
 
-    @JsonProperty("X-TEST-ENDPOINT-HEADER")
+    @JsonIgnore
     public String getXTestEndpointHeader() {
         return xTestEndpointHeader;
     }
@@ -125,14 +126,12 @@ public final class ReqWithHeaders {
         }
 
         @java.lang.Override
-        @JsonSetter("X-TEST-SERVICE-HEADER")
         public XTestEndpointHeaderStage xTestServiceHeader(@NotNull String xTestServiceHeader) {
             this.xTestServiceHeader = Objects.requireNonNull(xTestServiceHeader, "xTestServiceHeader must not be null");
             return this;
         }
 
         @java.lang.Override
-        @JsonSetter("X-TEST-ENDPOINT-HEADER")
         public BodyStage xTestEndpointHeader(@NotNull String xTestEndpointHeader) {
             this.xTestEndpointHeader =
                     Objects.requireNonNull(xTestEndpointHeader, "xTestEndpointHeader must not be null");

--- a/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsContainerWireTest.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsContainerWireTest.java
@@ -52,7 +52,7 @@ public class EndpointsContainerWireTest {
         String expectedRequestBody = "" + "[\n" + "  \"string\",\n" + "  \"string\"\n" + "]";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        Assertions.assertTrue(jsonEquals(expectedJson, actualJson), "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -83,8 +83,9 @@ public class EndpointsContainerWireTest {
         String expectedResponseBody = "" + "[\n" + "  \"string\",\n" + "  \"string\"\n" + "]";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
-        Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+        Assertions.assertTrue(
+                jsonEquals(expectedResponseNode, actualResponseNode),
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -136,7 +137,7 @@ public class EndpointsContainerWireTest {
                 + "]";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        Assertions.assertTrue(jsonEquals(expectedJson, actualJson), "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -175,8 +176,9 @@ public class EndpointsContainerWireTest {
                 + "]";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
-        Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+        Assertions.assertTrue(
+                jsonEquals(expectedResponseNode, actualResponseNode),
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -217,7 +219,7 @@ public class EndpointsContainerWireTest {
         String expectedRequestBody = "" + "[\n" + "  \"string\"\n" + "]";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        Assertions.assertTrue(jsonEquals(expectedJson, actualJson), "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -248,8 +250,9 @@ public class EndpointsContainerWireTest {
         String expectedResponseBody = "" + "[\n" + "  \"string\"\n" + "]";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
-        Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+        Assertions.assertTrue(
+                jsonEquals(expectedResponseNode, actualResponseNode),
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -291,7 +294,7 @@ public class EndpointsContainerWireTest {
         String expectedRequestBody = "" + "[\n" + "  {\n" + "    \"string\": \"string\"\n" + "  }\n" + "]";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        Assertions.assertTrue(jsonEquals(expectedJson, actualJson), "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -322,8 +325,9 @@ public class EndpointsContainerWireTest {
         String expectedResponseBody = "" + "[\n" + "  {\n" + "    \"string\": \"string\"\n" + "  }\n" + "]";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
-        Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+        Assertions.assertTrue(
+                jsonEquals(expectedResponseNode, actualResponseNode),
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -368,7 +372,7 @@ public class EndpointsContainerWireTest {
         String expectedRequestBody = "" + "{\n" + "  \"string\": \"string\"\n" + "}";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        Assertions.assertTrue(jsonEquals(expectedJson, actualJson), "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -399,8 +403,9 @@ public class EndpointsContainerWireTest {
         String expectedResponseBody = "" + "{\n" + "  \"string\": \"string\"\n" + "}";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
-        Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+        Assertions.assertTrue(
+                jsonEquals(expectedResponseNode, actualResponseNode),
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -449,7 +454,7 @@ public class EndpointsContainerWireTest {
         String expectedRequestBody = "" + "{\n" + "  \"string\": {\n" + "    \"string\": \"string\"\n" + "  }\n" + "}";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        Assertions.assertTrue(jsonEquals(expectedJson, actualJson), "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -480,8 +485,9 @@ public class EndpointsContainerWireTest {
         String expectedResponseBody = "" + "{\n" + "  \"string\": {\n" + "    \"string\": \"string\"\n" + "  }\n" + "}";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
-        Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+        Assertions.assertTrue(
+                jsonEquals(expectedResponseNode, actualResponseNode),
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -523,7 +529,7 @@ public class EndpointsContainerWireTest {
         String expectedRequestBody = "" + "{\n" + "  \"string\": \"string\"\n" + "}";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        Assertions.assertTrue(jsonEquals(expectedJson, actualJson), "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -554,8 +560,9 @@ public class EndpointsContainerWireTest {
         String expectedResponseBody = "" + "{\n" + "  \"string\": \"string\"\n" + "}";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
-        Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+        Assertions.assertTrue(
+                jsonEquals(expectedResponseNode, actualResponseNode),
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -580,5 +587,30 @@ public class EndpointsContainerWireTest {
         if (actualResponseNode.isObject()) {
             Assertions.assertTrue(actualResponseNode.size() >= 0, "Object should have valid field count");
         }
+    }
+
+    /**
+     * Compares two JsonNodes with numeric equivalence (149 == 149.0).
+     */
+    private boolean jsonEquals(JsonNode a, JsonNode b) {
+        if (a.equals(b)) return true;
+        if (a.isNumber() && b.isNumber()) return Math.abs(a.doubleValue() - b.doubleValue()) < 1e-10;
+        if (a.isObject() && b.isObject()) {
+            if (a.size() != b.size()) return false;
+            java.util.Iterator<java.util.Map.Entry<String, JsonNode>> iter = a.fields();
+            while (iter.hasNext()) {
+                java.util.Map.Entry<String, JsonNode> entry = iter.next();
+                if (!jsonEquals(entry.getValue(), b.get(entry.getKey()))) return false;
+            }
+            return true;
+        }
+        if (a.isArray() && b.isArray()) {
+            if (a.size() != b.size()) return false;
+            for (int i = 0; i < a.size(); i++) {
+                if (!jsonEquals(a.get(i), b.get(i))) return false;
+            }
+            return true;
+        }
+        return false;
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsContentTypeWireTest.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsContentTypeWireTest.java
@@ -93,7 +93,7 @@ public class EndpointsContentTypeWireTest {
                 + "}";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        Assertions.assertTrue(jsonEquals(expectedJson, actualJson), "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -173,7 +173,7 @@ public class EndpointsContentTypeWireTest {
                 + "}";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        Assertions.assertTrue(jsonEquals(expectedJson, actualJson), "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -197,5 +197,30 @@ public class EndpointsContentTypeWireTest {
         if (actualJson.isObject()) {
             Assertions.assertTrue(actualJson.size() >= 0, "Object should have valid field count");
         }
+    }
+
+    /**
+     * Compares two JsonNodes with numeric equivalence (149 == 149.0).
+     */
+    private boolean jsonEquals(JsonNode a, JsonNode b) {
+        if (a.equals(b)) return true;
+        if (a.isNumber() && b.isNumber()) return Math.abs(a.doubleValue() - b.doubleValue()) < 1e-10;
+        if (a.isObject() && b.isObject()) {
+            if (a.size() != b.size()) return false;
+            java.util.Iterator<java.util.Map.Entry<String, JsonNode>> iter = a.fields();
+            while (iter.hasNext()) {
+                java.util.Map.Entry<String, JsonNode> entry = iter.next();
+                if (!jsonEquals(entry.getValue(), b.get(entry.getKey()))) return false;
+            }
+            return true;
+        }
+        if (a.isArray() && b.isArray()) {
+            if (a.size() != b.size()) return false;
+            for (int i = 0; i < a.size(); i++) {
+                if (!jsonEquals(a.get(i), b.get(i))) return false;
+            }
+            return true;
+        }
+        return false;
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsEnumWireTest.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsEnumWireTest.java
@@ -44,7 +44,7 @@ public class EndpointsEnumWireTest {
         String expectedRequestBody = "" + "\"SUNNY\"";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        Assertions.assertTrue(jsonEquals(expectedJson, actualJson), "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -75,8 +75,9 @@ public class EndpointsEnumWireTest {
         String expectedResponseBody = "" + "\"SUNNY\"";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
-        Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+        Assertions.assertTrue(
+                jsonEquals(expectedResponseNode, actualResponseNode),
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -101,5 +102,30 @@ public class EndpointsEnumWireTest {
         if (actualResponseNode.isObject()) {
             Assertions.assertTrue(actualResponseNode.size() >= 0, "Object should have valid field count");
         }
+    }
+
+    /**
+     * Compares two JsonNodes with numeric equivalence (149 == 149.0).
+     */
+    private boolean jsonEquals(JsonNode a, JsonNode b) {
+        if (a.equals(b)) return true;
+        if (a.isNumber() && b.isNumber()) return Math.abs(a.doubleValue() - b.doubleValue()) < 1e-10;
+        if (a.isObject() && b.isObject()) {
+            if (a.size() != b.size()) return false;
+            java.util.Iterator<java.util.Map.Entry<String, JsonNode>> iter = a.fields();
+            while (iter.hasNext()) {
+                java.util.Map.Entry<String, JsonNode> entry = iter.next();
+                if (!jsonEquals(entry.getValue(), b.get(entry.getKey()))) return false;
+            }
+            return true;
+        }
+        if (a.isArray() && b.isArray()) {
+            if (a.size() != b.size()) return false;
+            for (int i = 0; i < a.size(); i++) {
+                if (!jsonEquals(a.get(i), b.get(i))) return false;
+            }
+            return true;
+        }
+        return false;
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsHttpMethodsWireTest.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsHttpMethodsWireTest.java
@@ -54,8 +54,9 @@ public class EndpointsHttpMethodsWireTest {
         String expectedResponseBody = "" + "\"string\"";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
-        Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+        Assertions.assertTrue(
+                jsonEquals(expectedResponseNode, actualResponseNode),
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -100,7 +101,7 @@ public class EndpointsHttpMethodsWireTest {
         String expectedRequestBody = "" + "{\n" + "  \"string\": \"string\"\n" + "}";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        Assertions.assertTrue(jsonEquals(expectedJson, actualJson), "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -153,8 +154,9 @@ public class EndpointsHttpMethodsWireTest {
                 + "}";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
-        Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+        Assertions.assertTrue(
+                jsonEquals(expectedResponseNode, actualResponseNode),
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -200,7 +202,7 @@ public class EndpointsHttpMethodsWireTest {
         String expectedRequestBody = "" + "{\n" + "  \"string\": \"string\"\n" + "}";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        Assertions.assertTrue(jsonEquals(expectedJson, actualJson), "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -253,8 +255,9 @@ public class EndpointsHttpMethodsWireTest {
                 + "}";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
-        Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+        Assertions.assertTrue(
+                jsonEquals(expectedResponseNode, actualResponseNode),
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -341,7 +344,7 @@ public class EndpointsHttpMethodsWireTest {
                 + "}";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        Assertions.assertTrue(jsonEquals(expectedJson, actualJson), "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -394,8 +397,9 @@ public class EndpointsHttpMethodsWireTest {
                 + "}";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
-        Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+        Assertions.assertTrue(
+                jsonEquals(expectedResponseNode, actualResponseNode),
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -436,8 +440,9 @@ public class EndpointsHttpMethodsWireTest {
         String expectedResponseBody = "" + "true";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
-        Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+        Assertions.assertTrue(
+                jsonEquals(expectedResponseNode, actualResponseNode),
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -462,5 +467,30 @@ public class EndpointsHttpMethodsWireTest {
         if (actualResponseNode.isObject()) {
             Assertions.assertTrue(actualResponseNode.size() >= 0, "Object should have valid field count");
         }
+    }
+
+    /**
+     * Compares two JsonNodes with numeric equivalence (149 == 149.0).
+     */
+    private boolean jsonEquals(JsonNode a, JsonNode b) {
+        if (a.equals(b)) return true;
+        if (a.isNumber() && b.isNumber()) return Math.abs(a.doubleValue() - b.doubleValue()) < 1e-10;
+        if (a.isObject() && b.isObject()) {
+            if (a.size() != b.size()) return false;
+            java.util.Iterator<java.util.Map.Entry<String, JsonNode>> iter = a.fields();
+            while (iter.hasNext()) {
+                java.util.Map.Entry<String, JsonNode> entry = iter.next();
+                if (!jsonEquals(entry.getValue(), b.get(entry.getKey()))) return false;
+            }
+            return true;
+        }
+        if (a.isArray() && b.isArray()) {
+            if (a.size() != b.size()) return false;
+            for (int i = 0; i < a.size(); i++) {
+                if (!jsonEquals(a.get(i), b.get(i))) return false;
+            }
+            return true;
+        }
+        return false;
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsObjectWireTest.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsObjectWireTest.java
@@ -102,7 +102,7 @@ public class EndpointsObjectWireTest {
                 + "}";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        Assertions.assertTrue(jsonEquals(expectedJson, actualJson), "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -155,8 +155,9 @@ public class EndpointsObjectWireTest {
                 + "}";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
-        Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+        Assertions.assertTrue(
+                jsonEquals(expectedResponseNode, actualResponseNode),
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -198,7 +199,7 @@ public class EndpointsObjectWireTest {
         String expectedRequestBody = "" + "{\n" + "  \"string\": \"string\"\n" + "}";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        Assertions.assertTrue(jsonEquals(expectedJson, actualJson), "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -229,8 +230,9 @@ public class EndpointsObjectWireTest {
         String expectedResponseBody = "" + "{\n" + "  \"string\": \"string\"\n" + "}";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
-        Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+        Assertions.assertTrue(
+                jsonEquals(expectedResponseNode, actualResponseNode),
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -288,7 +290,7 @@ public class EndpointsObjectWireTest {
                 + "}";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        Assertions.assertTrue(jsonEquals(expectedJson, actualJson), "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -326,8 +328,9 @@ public class EndpointsObjectWireTest {
                 + "}";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
-        Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+        Assertions.assertTrue(
+                jsonEquals(expectedResponseNode, actualResponseNode),
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -418,7 +421,7 @@ public class EndpointsObjectWireTest {
                 + "}";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        Assertions.assertTrue(jsonEquals(expectedJson, actualJson), "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -474,8 +477,9 @@ public class EndpointsObjectWireTest {
                 + "}";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
-        Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+        Assertions.assertTrue(
+                jsonEquals(expectedResponseNode, actualResponseNode),
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -568,7 +572,7 @@ public class EndpointsObjectWireTest {
                 + "}";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        Assertions.assertTrue(jsonEquals(expectedJson, actualJson), "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -624,8 +628,9 @@ public class EndpointsObjectWireTest {
                 + "}";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
-        Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+        Assertions.assertTrue(
+                jsonEquals(expectedResponseNode, actualResponseNode),
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -766,7 +771,7 @@ public class EndpointsObjectWireTest {
                 + "]";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        Assertions.assertTrue(jsonEquals(expectedJson, actualJson), "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -822,8 +827,9 @@ public class EndpointsObjectWireTest {
                 + "}";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
-        Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+        Assertions.assertTrue(
+                jsonEquals(expectedResponseNode, actualResponseNode),
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -848,5 +854,30 @@ public class EndpointsObjectWireTest {
         if (actualResponseNode.isObject()) {
             Assertions.assertTrue(actualResponseNode.size() >= 0, "Object should have valid field count");
         }
+    }
+
+    /**
+     * Compares two JsonNodes with numeric equivalence (149 == 149.0).
+     */
+    private boolean jsonEquals(JsonNode a, JsonNode b) {
+        if (a.equals(b)) return true;
+        if (a.isNumber() && b.isNumber()) return Math.abs(a.doubleValue() - b.doubleValue()) < 1e-10;
+        if (a.isObject() && b.isObject()) {
+            if (a.size() != b.size()) return false;
+            java.util.Iterator<java.util.Map.Entry<String, JsonNode>> iter = a.fields();
+            while (iter.hasNext()) {
+                java.util.Map.Entry<String, JsonNode> entry = iter.next();
+                if (!jsonEquals(entry.getValue(), b.get(entry.getKey()))) return false;
+            }
+            return true;
+        }
+        if (a.isArray() && b.isArray()) {
+            if (a.size() != b.size()) return false;
+            for (int i = 0; i < a.size(); i++) {
+                if (!jsonEquals(a.get(i), b.get(i))) return false;
+            }
+            return true;
+        }
+        return false;
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsParamsWireTest.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsParamsWireTest.java
@@ -47,8 +47,9 @@ public class EndpointsParamsWireTest {
         String expectedResponseBody = "" + "\"string\"";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
-        Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+        Assertions.assertTrue(
+                jsonEquals(expectedResponseNode, actualResponseNode),
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -89,8 +90,9 @@ public class EndpointsParamsWireTest {
         String expectedResponseBody = "" + "\"string\"";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
-        Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+        Assertions.assertTrue(
+                jsonEquals(expectedResponseNode, actualResponseNode),
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -175,7 +177,7 @@ public class EndpointsParamsWireTest {
         String expectedRequestBody = "" + "\"string\"";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        Assertions.assertTrue(jsonEquals(expectedJson, actualJson), "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -206,8 +208,9 @@ public class EndpointsParamsWireTest {
         String expectedResponseBody = "" + "\"string\"";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
-        Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+        Assertions.assertTrue(
+                jsonEquals(expectedResponseNode, actualResponseNode),
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -246,7 +249,7 @@ public class EndpointsParamsWireTest {
         String expectedRequestBody = "" + "\"string\"";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        Assertions.assertTrue(jsonEquals(expectedJson, actualJson), "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -277,8 +280,9 @@ public class EndpointsParamsWireTest {
         String expectedResponseBody = "" + "\"string\"";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
-        Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+        Assertions.assertTrue(
+                jsonEquals(expectedResponseNode, actualResponseNode),
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -303,5 +307,30 @@ public class EndpointsParamsWireTest {
         if (actualResponseNode.isObject()) {
             Assertions.assertTrue(actualResponseNode.size() >= 0, "Object should have valid field count");
         }
+    }
+
+    /**
+     * Compares two JsonNodes with numeric equivalence (149 == 149.0).
+     */
+    private boolean jsonEquals(JsonNode a, JsonNode b) {
+        if (a.equals(b)) return true;
+        if (a.isNumber() && b.isNumber()) return Math.abs(a.doubleValue() - b.doubleValue()) < 1e-10;
+        if (a.isObject() && b.isObject()) {
+            if (a.size() != b.size()) return false;
+            java.util.Iterator<java.util.Map.Entry<String, JsonNode>> iter = a.fields();
+            while (iter.hasNext()) {
+                java.util.Map.Entry<String, JsonNode> entry = iter.next();
+                if (!jsonEquals(entry.getValue(), b.get(entry.getKey()))) return false;
+            }
+            return true;
+        }
+        if (a.isArray() && b.isArray()) {
+            if (a.size() != b.size()) return false;
+            for (int i = 0; i < a.size(); i++) {
+                if (!jsonEquals(a.get(i), b.get(i))) return false;
+            }
+            return true;
+        }
+        return false;
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsPrimitiveWireTest.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsPrimitiveWireTest.java
@@ -45,7 +45,7 @@ public class EndpointsPrimitiveWireTest {
         String expectedRequestBody = "" + "\"string\"";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        Assertions.assertTrue(jsonEquals(expectedJson, actualJson), "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -76,8 +76,9 @@ public class EndpointsPrimitiveWireTest {
         String expectedResponseBody = "" + "\"string\"";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
-        Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+        Assertions.assertTrue(
+                jsonEquals(expectedResponseNode, actualResponseNode),
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -116,7 +117,7 @@ public class EndpointsPrimitiveWireTest {
         String expectedRequestBody = "" + "1";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        Assertions.assertTrue(jsonEquals(expectedJson, actualJson), "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -147,8 +148,9 @@ public class EndpointsPrimitiveWireTest {
         String expectedResponseBody = "" + "1";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
-        Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+        Assertions.assertTrue(
+                jsonEquals(expectedResponseNode, actualResponseNode),
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -187,7 +189,7 @@ public class EndpointsPrimitiveWireTest {
         String expectedRequestBody = "" + "1000000";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        Assertions.assertTrue(jsonEquals(expectedJson, actualJson), "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -218,8 +220,9 @@ public class EndpointsPrimitiveWireTest {
         String expectedResponseBody = "" + "1000000";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
-        Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+        Assertions.assertTrue(
+                jsonEquals(expectedResponseNode, actualResponseNode),
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -258,7 +261,7 @@ public class EndpointsPrimitiveWireTest {
         String expectedRequestBody = "" + "1.1";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        Assertions.assertTrue(jsonEquals(expectedJson, actualJson), "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -289,8 +292,9 @@ public class EndpointsPrimitiveWireTest {
         String expectedResponseBody = "" + "1.1";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
-        Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+        Assertions.assertTrue(
+                jsonEquals(expectedResponseNode, actualResponseNode),
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -329,7 +333,7 @@ public class EndpointsPrimitiveWireTest {
         String expectedRequestBody = "" + "true";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        Assertions.assertTrue(jsonEquals(expectedJson, actualJson), "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -360,8 +364,9 @@ public class EndpointsPrimitiveWireTest {
         String expectedResponseBody = "" + "true";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
-        Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+        Assertions.assertTrue(
+                jsonEquals(expectedResponseNode, actualResponseNode),
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -401,7 +406,7 @@ public class EndpointsPrimitiveWireTest {
         String expectedRequestBody = "" + "\"2024-01-15T09:30:00Z\"";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        Assertions.assertTrue(jsonEquals(expectedJson, actualJson), "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -432,8 +437,9 @@ public class EndpointsPrimitiveWireTest {
         String expectedResponseBody = "" + "\"2024-01-15T09:30:00Z\"";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
-        Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+        Assertions.assertTrue(
+                jsonEquals(expectedResponseNode, actualResponseNode),
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -472,7 +478,7 @@ public class EndpointsPrimitiveWireTest {
         String expectedRequestBody = "" + "\"2023-01-15\"";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        Assertions.assertTrue(jsonEquals(expectedJson, actualJson), "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -503,8 +509,9 @@ public class EndpointsPrimitiveWireTest {
         String expectedResponseBody = "" + "\"2023-01-15\"";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
-        Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+        Assertions.assertTrue(
+                jsonEquals(expectedResponseNode, actualResponseNode),
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -545,7 +552,7 @@ public class EndpointsPrimitiveWireTest {
         String expectedRequestBody = "" + "\"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32\"";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        Assertions.assertTrue(jsonEquals(expectedJson, actualJson), "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -576,8 +583,9 @@ public class EndpointsPrimitiveWireTest {
         String expectedResponseBody = "" + "\"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32\"";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
-        Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+        Assertions.assertTrue(
+                jsonEquals(expectedResponseNode, actualResponseNode),
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -616,7 +624,7 @@ public class EndpointsPrimitiveWireTest {
         String expectedRequestBody = "" + "\"SGVsbG8gd29ybGQh\"";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        Assertions.assertTrue(jsonEquals(expectedJson, actualJson), "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -647,8 +655,9 @@ public class EndpointsPrimitiveWireTest {
         String expectedResponseBody = "" + "\"SGVsbG8gd29ybGQh\"";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
-        Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+        Assertions.assertTrue(
+                jsonEquals(expectedResponseNode, actualResponseNode),
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -673,5 +682,30 @@ public class EndpointsPrimitiveWireTest {
         if (actualResponseNode.isObject()) {
             Assertions.assertTrue(actualResponseNode.size() >= 0, "Object should have valid field count");
         }
+    }
+
+    /**
+     * Compares two JsonNodes with numeric equivalence (149 == 149.0).
+     */
+    private boolean jsonEquals(JsonNode a, JsonNode b) {
+        if (a.equals(b)) return true;
+        if (a.isNumber() && b.isNumber()) return Math.abs(a.doubleValue() - b.doubleValue()) < 1e-10;
+        if (a.isObject() && b.isObject()) {
+            if (a.size() != b.size()) return false;
+            java.util.Iterator<java.util.Map.Entry<String, JsonNode>> iter = a.fields();
+            while (iter.hasNext()) {
+                java.util.Map.Entry<String, JsonNode> entry = iter.next();
+                if (!jsonEquals(entry.getValue(), b.get(entry.getKey()))) return false;
+            }
+            return true;
+        }
+        if (a.isArray() && b.isArray()) {
+            if (a.size() != b.size()) return false;
+            for (int i = 0; i < a.size(); i++) {
+                if (!jsonEquals(a.get(i), b.get(i))) return false;
+            }
+            return true;
+        }
+        return false;
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsPutWireTest.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsPutWireTest.java
@@ -68,8 +68,9 @@ public class EndpointsPutWireTest {
                 + "}";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
-        Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+        Assertions.assertTrue(
+                jsonEquals(expectedResponseNode, actualResponseNode),
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -94,5 +95,30 @@ public class EndpointsPutWireTest {
         if (actualResponseNode.isObject()) {
             Assertions.assertTrue(actualResponseNode.size() >= 0, "Object should have valid field count");
         }
+    }
+
+    /**
+     * Compares two JsonNodes with numeric equivalence (149 == 149.0).
+     */
+    private boolean jsonEquals(JsonNode a, JsonNode b) {
+        if (a.equals(b)) return true;
+        if (a.isNumber() && b.isNumber()) return Math.abs(a.doubleValue() - b.doubleValue()) < 1e-10;
+        if (a.isObject() && b.isObject()) {
+            if (a.size() != b.size()) return false;
+            java.util.Iterator<java.util.Map.Entry<String, JsonNode>> iter = a.fields();
+            while (iter.hasNext()) {
+                java.util.Map.Entry<String, JsonNode> entry = iter.next();
+                if (!jsonEquals(entry.getValue(), b.get(entry.getKey()))) return false;
+            }
+            return true;
+        }
+        if (a.isArray() && b.isArray()) {
+            if (a.size() != b.size()) return false;
+            for (int i = 0; i < a.size(); i++) {
+                if (!jsonEquals(a.get(i), b.get(i))) return false;
+            }
+            return true;
+        }
+        return false;
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsUnionWireTest.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsUnionWireTest.java
@@ -51,7 +51,7 @@ public class EndpointsUnionWireTest {
                 "" + "{\n" + "  \"animal\": \"dog\",\n" + "  \"name\": \"name\",\n" + "  \"likesToWoof\": true\n" + "}";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        Assertions.assertTrue(jsonEquals(expectedJson, actualJson), "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -83,8 +83,9 @@ public class EndpointsUnionWireTest {
                 "" + "{\n" + "  \"animal\": \"dog\",\n" + "  \"name\": \"name\",\n" + "  \"likesToWoof\": true\n" + "}";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
-        Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+        Assertions.assertTrue(
+                jsonEquals(expectedResponseNode, actualResponseNode),
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -109,5 +110,30 @@ public class EndpointsUnionWireTest {
         if (actualResponseNode.isObject()) {
             Assertions.assertTrue(actualResponseNode.size() >= 0, "Object should have valid field count");
         }
+    }
+
+    /**
+     * Compares two JsonNodes with numeric equivalence (149 == 149.0).
+     */
+    private boolean jsonEquals(JsonNode a, JsonNode b) {
+        if (a.equals(b)) return true;
+        if (a.isNumber() && b.isNumber()) return Math.abs(a.doubleValue() - b.doubleValue()) < 1e-10;
+        if (a.isObject() && b.isObject()) {
+            if (a.size() != b.size()) return false;
+            java.util.Iterator<java.util.Map.Entry<String, JsonNode>> iter = a.fields();
+            while (iter.hasNext()) {
+                java.util.Map.Entry<String, JsonNode> entry = iter.next();
+                if (!jsonEquals(entry.getValue(), b.get(entry.getKey()))) return false;
+            }
+            return true;
+        }
+        if (a.isArray() && b.isArray()) {
+            if (a.size() != b.size()) return false;
+            for (int i = 0; i < a.size(); i++) {
+                if (!jsonEquals(a.get(i), b.get(i))) return false;
+            }
+            return true;
+        }
+        return false;
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsUrlsWireTest.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsUrlsWireTest.java
@@ -45,8 +45,9 @@ public class EndpointsUrlsWireTest {
         String expectedResponseBody = "" + "\"string\"";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
-        Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+        Assertions.assertTrue(
+                jsonEquals(expectedResponseNode, actualResponseNode),
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -87,8 +88,9 @@ public class EndpointsUrlsWireTest {
         String expectedResponseBody = "" + "\"string\"";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
-        Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+        Assertions.assertTrue(
+                jsonEquals(expectedResponseNode, actualResponseNode),
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -129,8 +131,9 @@ public class EndpointsUrlsWireTest {
         String expectedResponseBody = "" + "\"string\"";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
-        Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+        Assertions.assertTrue(
+                jsonEquals(expectedResponseNode, actualResponseNode),
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -171,8 +174,9 @@ public class EndpointsUrlsWireTest {
         String expectedResponseBody = "" + "\"string\"";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
-        Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+        Assertions.assertTrue(
+                jsonEquals(expectedResponseNode, actualResponseNode),
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -197,5 +201,30 @@ public class EndpointsUrlsWireTest {
         if (actualResponseNode.isObject()) {
             Assertions.assertTrue(actualResponseNode.size() >= 0, "Object should have valid field count");
         }
+    }
+
+    /**
+     * Compares two JsonNodes with numeric equivalence (149 == 149.0).
+     */
+    private boolean jsonEquals(JsonNode a, JsonNode b) {
+        if (a.equals(b)) return true;
+        if (a.isNumber() && b.isNumber()) return Math.abs(a.doubleValue() - b.doubleValue()) < 1e-10;
+        if (a.isObject() && b.isObject()) {
+            if (a.size() != b.size()) return false;
+            java.util.Iterator<java.util.Map.Entry<String, JsonNode>> iter = a.fields();
+            while (iter.hasNext()) {
+                java.util.Map.Entry<String, JsonNode> entry = iter.next();
+                if (!jsonEquals(entry.getValue(), b.get(entry.getKey()))) return false;
+            }
+            return true;
+        }
+        if (a.isArray() && b.isArray()) {
+            if (a.size() != b.size()) return false;
+            for (int i = 0; i < a.size(); i++) {
+                if (!jsonEquals(a.get(i), b.get(i))) return false;
+            }
+            return true;
+        }
+        return false;
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/InlinedRequestsWireTest.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/InlinedRequestsWireTest.java
@@ -105,7 +105,7 @@ public class InlinedRequestsWireTest {
                 + "}";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        Assertions.assertTrue(jsonEquals(expectedJson, actualJson), "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -158,8 +158,9 @@ public class InlinedRequestsWireTest {
                 + "}";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
-        Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+        Assertions.assertTrue(
+                jsonEquals(expectedResponseNode, actualResponseNode),
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -184,5 +185,30 @@ public class InlinedRequestsWireTest {
         if (actualResponseNode.isObject()) {
             Assertions.assertTrue(actualResponseNode.size() >= 0, "Object should have valid field count");
         }
+    }
+
+    /**
+     * Compares two JsonNodes with numeric equivalence (149 == 149.0).
+     */
+    private boolean jsonEquals(JsonNode a, JsonNode b) {
+        if (a.equals(b)) return true;
+        if (a.isNumber() && b.isNumber()) return Math.abs(a.doubleValue() - b.doubleValue()) < 1e-10;
+        if (a.isObject() && b.isObject()) {
+            if (a.size() != b.size()) return false;
+            java.util.Iterator<java.util.Map.Entry<String, JsonNode>> iter = a.fields();
+            while (iter.hasNext()) {
+                java.util.Map.Entry<String, JsonNode> entry = iter.next();
+                if (!jsonEquals(entry.getValue(), b.get(entry.getKey()))) return false;
+            }
+            return true;
+        }
+        if (a.isArray() && b.isArray()) {
+            if (a.size() != b.size()) return false;
+            for (int i = 0; i < a.size(); i++) {
+                if (!jsonEquals(a.get(i), b.get(i))) return false;
+            }
+            return true;
+        }
+        return false;
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/NoAuthWireTest.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/NoAuthWireTest.java
@@ -48,7 +48,7 @@ public class NoAuthWireTest {
         String expectedRequestBody = "" + "{\n" + "  \"key\": \"value\"\n" + "}";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        Assertions.assertTrue(jsonEquals(expectedJson, actualJson), "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -79,8 +79,9 @@ public class NoAuthWireTest {
         String expectedResponseBody = "" + "true";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
-        Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+        Assertions.assertTrue(
+                jsonEquals(expectedResponseNode, actualResponseNode),
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -105,5 +106,30 @@ public class NoAuthWireTest {
         if (actualResponseNode.isObject()) {
             Assertions.assertTrue(actualResponseNode.size() >= 0, "Object should have valid field count");
         }
+    }
+
+    /**
+     * Compares two JsonNodes with numeric equivalence (149 == 149.0).
+     */
+    private boolean jsonEquals(JsonNode a, JsonNode b) {
+        if (a.equals(b)) return true;
+        if (a.isNumber() && b.isNumber()) return Math.abs(a.doubleValue() - b.doubleValue()) < 1e-10;
+        if (a.isObject() && b.isObject()) {
+            if (a.size() != b.size()) return false;
+            java.util.Iterator<java.util.Map.Entry<String, JsonNode>> iter = a.fields();
+            while (iter.hasNext()) {
+                java.util.Map.Entry<String, JsonNode> entry = iter.next();
+                if (!jsonEquals(entry.getValue(), b.get(entry.getKey()))) return false;
+            }
+            return true;
+        }
+        if (a.isArray() && b.isArray()) {
+            if (a.size() != b.size()) return false;
+            for (int i = 0; i < a.size(); i++) {
+                if (!jsonEquals(a.get(i), b.get(i))) return false;
+            }
+            return true;
+        }
+        return false;
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/NoReqBodyWireTest.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/NoReqBodyWireTest.java
@@ -72,8 +72,9 @@ public class NoReqBodyWireTest {
                 + "}";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
-        Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+        Assertions.assertTrue(
+                jsonEquals(expectedResponseNode, actualResponseNode),
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -114,8 +115,9 @@ public class NoReqBodyWireTest {
         String expectedResponseBody = "" + "\"string\"";
         JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);
         JsonNode expectedResponseNode = objectMapper.readTree(expectedResponseBody);
-        Assertions.assertEquals(
-                expectedResponseNode, actualResponseNode, "Response body structure does not match expected");
+        Assertions.assertTrue(
+                jsonEquals(expectedResponseNode, actualResponseNode),
+                "Response body structure does not match expected");
         if (actualResponseNode.has("type") || actualResponseNode.has("_type") || actualResponseNode.has("kind")) {
             String discriminator = null;
             if (actualResponseNode.has("type"))
@@ -140,5 +142,30 @@ public class NoReqBodyWireTest {
         if (actualResponseNode.isObject()) {
             Assertions.assertTrue(actualResponseNode.size() >= 0, "Object should have valid field count");
         }
+    }
+
+    /**
+     * Compares two JsonNodes with numeric equivalence (149 == 149.0).
+     */
+    private boolean jsonEquals(JsonNode a, JsonNode b) {
+        if (a.equals(b)) return true;
+        if (a.isNumber() && b.isNumber()) return Math.abs(a.doubleValue() - b.doubleValue()) < 1e-10;
+        if (a.isObject() && b.isObject()) {
+            if (a.size() != b.size()) return false;
+            java.util.Iterator<java.util.Map.Entry<String, JsonNode>> iter = a.fields();
+            while (iter.hasNext()) {
+                java.util.Map.Entry<String, JsonNode> entry = iter.next();
+                if (!jsonEquals(entry.getValue(), b.get(entry.getKey()))) return false;
+            }
+            return true;
+        }
+        if (a.isArray() && b.isArray()) {
+            if (a.size() != b.size()) return false;
+            for (int i = 0; i < a.size(); i++) {
+                if (!jsonEquals(a.get(i), b.get(i))) return false;
+            }
+            return true;
+        }
+        return false;
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/ReqWithHeadersWireTest.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/ReqWithHeadersWireTest.java
@@ -59,7 +59,7 @@ public class ReqWithHeadersWireTest {
         String expectedRequestBody = "" + "\"string\"";
         JsonNode actualJson = objectMapper.readTree(actualRequestBody);
         JsonNode expectedJson = objectMapper.readTree(expectedRequestBody);
-        Assertions.assertEquals(expectedJson, actualJson, "Request body structure does not match expected");
+        Assertions.assertTrue(jsonEquals(expectedJson, actualJson), "Request body structure does not match expected");
         if (actualJson.has("type") || actualJson.has("_type") || actualJson.has("kind")) {
             String discriminator = null;
             if (actualJson.has("type")) discriminator = actualJson.get("type").asText();
@@ -83,5 +83,30 @@ public class ReqWithHeadersWireTest {
         if (actualJson.isObject()) {
             Assertions.assertTrue(actualJson.size() >= 0, "Object should have valid field count");
         }
+    }
+
+    /**
+     * Compares two JsonNodes with numeric equivalence (149 == 149.0).
+     */
+    private boolean jsonEquals(JsonNode a, JsonNode b) {
+        if (a.equals(b)) return true;
+        if (a.isNumber() && b.isNumber()) return Math.abs(a.doubleValue() - b.doubleValue()) < 1e-10;
+        if (a.isObject() && b.isObject()) {
+            if (a.size() != b.size()) return false;
+            java.util.Iterator<java.util.Map.Entry<String, JsonNode>> iter = a.fields();
+            while (iter.hasNext()) {
+                java.util.Map.Entry<String, JsonNode> entry = iter.next();
+                if (!jsonEquals(entry.getValue(), b.get(entry.getKey()))) return false;
+            }
+            return true;
+        }
+        if (a.isArray() && b.isArray()) {
+            if (a.size() != b.size()) return false;
+            for (int i = 0; i < a.size(); i++) {
+                if (!jsonEquals(a.get(i), b.get(i))) return false;
+            }
+            return true;
+        }
+        return false;
     }
 }

--- a/seed/java-sdk/exhaustive/publish-to/README.md
+++ b/seed/java-sdk/exhaustive/publish-to/README.md
@@ -5,6 +5,21 @@
 
 The Seed Java library provides convenient access to the Seed APIs from Java.
 
+## Table of Contents
+
+- [Installation](#installation)
+- [Reference](#reference)
+- [Usage](#usage)
+- [Base Url](#base-url)
+- [Exception Handling](#exception-handling)
+- [Advanced](#advanced)
+  - [Custom Client](#custom-client)
+  - [Retries](#retries)
+  - [Timeouts](#timeouts)
+  - [Custom Headers](#custom-headers)
+  - [Access Raw Response Data](#access-raw-response-data)
+- [Contributing](#contributing)
+
 ## Installation
 
 ### Gradle

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/reqwithheaders/requests/ReqWithHeaders.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/reqwithheaders/requests/ReqWithHeaders.java
@@ -5,6 +5,7 @@ package com.seed.exhaustive.resources.reqwithheaders.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -38,12 +39,12 @@ public final class ReqWithHeaders {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonProperty("X-TEST-SERVICE-HEADER")
+    @JsonIgnore
     public String getXTestServiceHeader() {
         return xTestServiceHeader;
     }
 
-    @JsonProperty("X-TEST-ENDPOINT-HEADER")
+    @JsonIgnore
     public String getXTestEndpointHeader() {
         return xTestEndpointHeader;
     }
@@ -125,14 +126,12 @@ public final class ReqWithHeaders {
         }
 
         @java.lang.Override
-        @JsonSetter("X-TEST-SERVICE-HEADER")
         public XTestEndpointHeaderStage xTestServiceHeader(@NotNull String xTestServiceHeader) {
             this.xTestServiceHeader = Objects.requireNonNull(xTestServiceHeader, "xTestServiceHeader must not be null");
             return this;
         }
 
         @java.lang.Override
-        @JsonSetter("X-TEST-ENDPOINT-HEADER")
         public BodyStage xTestEndpointHeader(@NotNull String xTestEndpointHeader) {
             this.xTestEndpointHeader =
                     Objects.requireNonNull(xTestEndpointHeader, "xTestEndpointHeader must not be null");

--- a/seed/java-sdk/exhaustive/signed_publish/README.md
+++ b/seed/java-sdk/exhaustive/signed_publish/README.md
@@ -5,6 +5,21 @@
 
 The Seed Java library provides convenient access to the Seed APIs from Java.
 
+## Table of Contents
+
+- [Installation](#installation)
+- [Reference](#reference)
+- [Usage](#usage)
+- [Base Url](#base-url)
+- [Exception Handling](#exception-handling)
+- [Advanced](#advanced)
+  - [Custom Client](#custom-client)
+  - [Retries](#retries)
+  - [Timeouts](#timeouts)
+  - [Custom Headers](#custom-headers)
+  - [Access Raw Response Data](#access-raw-response-data)
+- [Contributing](#contributing)
+
 ## Installation
 
 ### Gradle

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/reqwithheaders/requests/ReqWithHeaders.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/reqwithheaders/requests/ReqWithHeaders.java
@@ -5,6 +5,7 @@ package com.seed.exhaustive.resources.reqwithheaders.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -38,12 +39,12 @@ public final class ReqWithHeaders {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonProperty("X-TEST-SERVICE-HEADER")
+    @JsonIgnore
     public String getXTestServiceHeader() {
         return xTestServiceHeader;
     }
 
-    @JsonProperty("X-TEST-ENDPOINT-HEADER")
+    @JsonIgnore
     public String getXTestEndpointHeader() {
         return xTestEndpointHeader;
     }
@@ -125,14 +126,12 @@ public final class ReqWithHeaders {
         }
 
         @java.lang.Override
-        @JsonSetter("X-TEST-SERVICE-HEADER")
         public XTestEndpointHeaderStage xTestServiceHeader(@NotNull String xTestServiceHeader) {
             this.xTestServiceHeader = Objects.requireNonNull(xTestServiceHeader, "xTestServiceHeader must not be null");
             return this;
         }
 
         @java.lang.Override
-        @JsonSetter("X-TEST-ENDPOINT-HEADER")
         public BodyStage xTestEndpointHeader(@NotNull String xTestEndpointHeader) {
             this.xTestEndpointHeader =
                     Objects.requireNonNull(xTestEndpointHeader, "xTestEndpointHeader must not be null");


### PR DESCRIPTION
## Description
Linear ticket: Closes [FER-7692: \[Java\] Headers in body](https://linear.app/buildwithfern/issue/FER-7692/java-headers-in-body)
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
<!-- Provide a clear and concise description of the changes made in this PR -->

Fix two separate wire test issues in Java SDK generation:
  1.  HTTP headers incorrectly serialized to JSON request body
  2. Numeric comparison failures (like 149 vs 149.0) in wire test validation

With both of these Bill Java SDK is green. 

```
  **Before:**
  ```java
  @JsonProperty("X-TEST-SERVICE-HEADER")  // Serializes to JSON
  @JsonSetter("X-TEST-SERVICE-HEADER")    //  In builder

  After:
  @JsonIgnore  //  Excluded from JSON, only sent as HTTP header
  // No @JsonSetter in builder
```

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
  - Headers use empty wireValue("") pattern to exclude from JSON
  serialization
  - HTTP header names preserved via Name.getOriginalName()
  - Numeric comparison uses Math.abs(a - b) < 1e-10 with recursive
  deep equality
- [ ] Updated README.md generator (if applicable)

## Testing
<!-- Describe how you tested these changes -->
- [ ] Unit tests added/updated
- [ ] Manual testing completed
Updating seed soon! 
