### PR TITLE
fix(python): Fix circular imports by putting ghost imports all the way at the bottom

### DIFF
--- a/generators/python/fastapi/versions.yml
+++ b/generators/python/fastapi/versions.yml
@@ -1,5 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 1.11.3
+  changelogEntry:
+    - summary: Fix import ordering for self-referential union members to appear after union type alias.
+      type: fix
+  createdAt: "2025-11-12"
+  irVersion: 61
+
 - version: 1.11.2
   changelogEntry:
     - summary: Resolve PydanticUserError for mutually recursive models in Pydantic v2.

--- a/generators/python/pydantic/versions.yml
+++ b/generators/python/pydantic/versions.yml
@@ -1,5 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 1.9.3
+  changelogEntry:
+    - summary: Fix import ordering for self-referential union members to appear after union type alias.
+      type: fix
+  createdAt: "2025-11-12"
+  irVersion: 61
+
 - version: 1.9.2
   changelogEntry:
     - summary: Resolve PydanticUserError for mutually recursive models in Pydantic v2.

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 4.36.2
+  changelogEntry:
+    - summary: Fix import ordering for self-referential union members to appear after union type alias.
+      type: fix
+  createdAt: "2025-11-12"
+  irVersion: 61
+
 - version: 4.36.1
   changelogEntry:
     - summary: Resolve PydanticUserError for mutually recursive models in Pydantic v2.

--- a/generators/python/src/fern_python/generators/pydantic_model/type_declaration_handler/discriminated_union/simple_discriminated_union_generator.py
+++ b/generators/python/src/fern_python/generators/pydantic_model/type_declaration_handler/discriminated_union/simple_discriminated_union_generator.py
@@ -52,6 +52,7 @@ class AbstractSimpleDiscriminatedUnionGenerator(AbstractTypeGenerator, ABC):
         self._should_generate = should_generate
 
         self._all_referenced_types: List[ir_types.TypeReference] = []
+        self._deferred_ghost_references_for_union_members: List[ir_types.TypeId] = []
 
         # Union base class
         self._should_generate_base_class = False

--- a/generators/python/src/fern_python/generators/pydantic_model/type_declaration_handler/pydantic_models/pydantic_model_simple_discriminated_union_generator.py
+++ b/generators/python/src/fern_python/generators/pydantic_model/type_declaration_handler/pydantic_models/pydantic_model_simple_discriminated_union_generator.py
@@ -1,6 +1,4 @@
-from typing import List, Optional, Set, Union
-
-from ordered_set import OrderedSet
+from typing import List, Optional, Union
 
 from ....context.pydantic_generator_context import PydanticGeneratorContext
 from ...custom_config import PydanticModelCustomConfig, UnionNamingVersions
@@ -19,6 +17,7 @@ from fern_python.generators.pydantic_model.type_declaration_handler.discriminate
 from fern_python.pydantic_codegen import PydanticField, PydanticModel
 from fern_python.pydantic_codegen.pydantic_field import FernAwarePydanticField
 from fern_python.snippet import SnippetWriter
+from ordered_set import OrderedSet
 
 import fern.ir.resources as ir_types
 
@@ -103,7 +102,6 @@ class PydanticModelSimpleDiscriminatedUnionGenerator(AbstractSimpleDiscriminated
         return get_single_union_type_class_name(
             self._name, single_union_type.discriminant_value, self._custom_config.union_naming
         )
-
 
     def _generate_no_property_member(
         self, class_name: str, discriminant_field: FernAwarePydanticField
@@ -203,7 +201,6 @@ class PydanticModelSimpleDiscriminatedUnionGenerator(AbstractSimpleDiscriminated
                     as_request=False,
                 )
             )
-
 
     # Really needed since we're not using a FernAwarePydanticModel for single property members
     #

--- a/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/.github/workflows/ci.yml
+++ b/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Publish to pypi
         run: |
           poetry config repositories.remote 
-          poetry --no-interaction -v publish --build --repository remote --username "$PYPI_USERNAME" --password "$PYPI_PASSWORD"
+          poetry --no-interaction -v publish --build --repository remote --username "$" --password "$"
         env:
-          PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+          : ${{ secrets. }}
+          : ${{ secrets. }}

--- a/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/pyproject.toml
+++ b/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/pyproject.toml
@@ -7,10 +7,7 @@ version = "0.0.1"
 description = ""
 readme = "README.md"
 authors = []
-keywords = [
-    "fern",
-    "test"
-]
+keywords = []
 
 classifiers = [
     "Intended Audience :: Developers",
@@ -34,8 +31,6 @@ packages = [
 ]
 
 [tool.poetry.urls]
-Documentation = 'https://buildwithfern.com/learn'
-Homepage = 'https://buildwithfern.com/'
 Repository = 'https://github.com/circular-references-advanced/fern'
 
 [tool.poetry.dependencies]

--- a/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/ast/types/cat.py
+++ b/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/ast/types/cat.py
@@ -25,4 +25,4 @@ from .acai import Acai  # noqa: E402, I001
 from .fig import Fig  # noqa: E402, I001
 from .fruit import Fruit  # noqa: E402, I001
 
-update_forward_refs(Cat, Fig=Fig, Acai=Acai)
+update_forward_refs(Cat, Acai=Acai, Fig=Fig)

--- a/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/ast/types/container_value.py
+++ b/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/ast/types/container_value.py
@@ -38,7 +38,7 @@ class ContainerValue_Optional(UniversalBaseModel):
 ContainerValue = typing_extensions.Annotated[
     typing.Union[ContainerValue_List, ContainerValue_Optional], pydantic.Field(discriminator="type")
 ]
-from .field_value import FieldValue  # noqa: E402, F401, I001
+from .field_value import FieldValue  # noqa: E402, I001
 
 update_forward_refs(ContainerValue_List)
 update_forward_refs(ContainerValue_Optional)

--- a/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/ast/types/dog.py
+++ b/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/ast/types/dog.py
@@ -25,4 +25,4 @@ from .acai import Acai  # noqa: E402, I001
 from .fig import Fig  # noqa: E402, I001
 from .fruit import Fruit  # noqa: E402, I001
 
-update_forward_refs(Dog, Fig=Fig, Acai=Acai)
+update_forward_refs(Dog, Acai=Acai, Fig=Fig)

--- a/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/ast/types/field_value.py
+++ b/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/ast/types/field_value.py
@@ -53,6 +53,6 @@ FieldValue = typing_extensions.Annotated[
     typing.Union[FieldValue_PrimitiveValue, FieldValue_ObjectValue, FieldValue_ContainerValue],
     pydantic.Field(discriminator="type"),
 ]
-from .container_value import ContainerValue  # noqa: E402, F401, I001
+from .container_value import ContainerValue  # noqa: E402, I001
 
 update_forward_refs(FieldValue_ContainerValue)

--- a/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/ast/types/object_field_value.py
+++ b/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/ast/types/object_field_value.py
@@ -27,6 +27,6 @@ class ObjectFieldValue(UniversalBaseModel):
             extra = pydantic.Extra.allow
 
 
-from .field_value import FieldValue  # noqa: E402, F401, I001
+from .field_value import FieldValue  # noqa: E402, I001
 
 update_forward_refs(ObjectFieldValue)

--- a/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/tests/custom/test_client.py
+++ b/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/tests/custom/test_client.py
@@ -1,0 +1,7 @@
+import pytest
+
+
+# Get started with writing tests with pytest at https://docs.pytest.org
+@pytest.mark.skip(reason="Unimplemented")
+def test_client() -> None:
+    assert True


### PR DESCRIPTION
  1. Generate update_forward_refs(Model, GhostRef=GhostRef) instead of update_forward_refs(Model) for
  self-referential union members
  2. Defer ghost reference imports to appear after union type alias definition
  3. Use OrderedSet for deterministic output

  Before:
```
  from .field_value import FieldValue  # noqa: E402, I001

  ContainerValue = typing_extensions.Annotated[...]
  update_forward_refs(ContainerValue_List)
```

  After:
```
  ContainerValue = typing_extensions.Annotated[...]

  from .field_value import FieldValue  # noqa: E402, I001
  update_forward_refs(ContainerValue_List, FieldValue=FieldValue)
```