### PR TITLE
fix(python): More circular reference fixes with unions

### DIFF
--- a/generators/python/fastapi/versions.yml
+++ b/generators/python/fastapi/versions.yml
@@ -1,5 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 1.11.3
+  changelogEntry:
+    - summary: Fix circular reference issue for recursive types and unions.
+      type: fix
+  createdAt: "2025-11-14"
+  irVersion: 61
+
 - version: 1.11.2
   changelogEntry:
     - summary: Resolve PydanticUserError for mutually recursive models in Pydantic v2.

--- a/generators/python/pydantic/versions.yml
+++ b/generators/python/pydantic/versions.yml
@@ -1,5 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 1.9.3
+  changelogEntry:
+    - summary: Fix circular reference issue for recursive types and unions.
+      type: fix
+  createdAt: "2025-11-14"
+  irVersion: 61
+
 - version: 1.9.2
   changelogEntry:
     - summary: Resolve PydanticUserError for mutually recursive models in Pydantic v2.

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 4.36.2
+  changelogEntry:
+    - summary: Fix circular reference issue for recursive types and unions.
+      type: fix
+  createdAt: "2025-11-14"
+  irVersion: 61
+
 - version: 4.36.1
   changelogEntry:
     - summary: Resolve PydanticUserError for mutually recursive models in Pydantic v2.

--- a/generators/python/src/fern_python/generators/pydantic_model/fern_aware_pydantic_model.py
+++ b/generators/python/src/fern_python/generators/pydantic_model/fern_aware_pydantic_model.py
@@ -168,8 +168,7 @@ class FernAwarePydanticModel:
                 # Force must_import_after_current_declaration=True for union dependencies
                 # so their imports appear at bottom before update_forward_refs call
                 ghost_ref = dataclasses.replace(
-                    self.get_class_reference_for_type_id(dependency),
-                    must_import_after_current_declaration=True
+                    self.get_class_reference_for_type_id(dependency), must_import_after_current_declaration=True
                 )
                 self._pydantic_model.add_ghost_reference(ghost_ref)
                 self._self_referential_union_member_dependencies.add(dependency)
@@ -310,8 +309,7 @@ class FernAwarePydanticModel:
             # go into _import_to_statements_that_must_precede_it and appear at bottom
             ghost_references = [
                 dataclasses.replace(
-                    self.get_class_reference_for_type_id(dependency_type_id),
-                    must_import_after_current_declaration=True
+                    self.get_class_reference_for_type_id(dependency_type_id), must_import_after_current_declaration=True
                 )
                 for dependency_type_id in self._self_referential_union_member_dependencies
             ]

--- a/generators/python/src/fern_python/generators/pydantic_model/fern_aware_pydantic_model.py
+++ b/generators/python/src/fern_python/generators/pydantic_model/fern_aware_pydantic_model.py
@@ -163,7 +163,15 @@ class FernAwarePydanticModel:
         )[type_id]
         for dependency in self_referencing_dependencies_from_union_types:
             if dependency not in self._forward_referenced_models:
-                self.add_ghost_reference(dependency)
+                import dataclasses
+
+                # Force must_import_after_current_declaration=True for union dependencies
+                # so their imports appear at bottom before update_forward_refs call
+                ghost_ref = dataclasses.replace(
+                    self.get_class_reference_for_type_id(dependency),
+                    must_import_after_current_declaration=True
+                )
+                self._pydantic_model.add_ghost_reference(ghost_ref)
                 self._self_referential_union_member_dependencies.add(dependency)
 
     def add_private_instance_field_unsafe(
@@ -296,8 +304,15 @@ class FernAwarePydanticModel:
             self._get_validators_generator().add_validators()
         # Handle self-referential union member dependencies specially
         if self._self_referential_union_member_dependencies:
+            import dataclasses
+
+            # Force must_import_after_current_declaration=True to ensure these imports
+            # go into _import_to_statements_that_must_precede_it and appear at bottom
             ghost_references = [
-                self.get_class_reference_for_type_id(dependency_type_id)
+                dataclasses.replace(
+                    self.get_class_reference_for_type_id(dependency_type_id),
+                    must_import_after_current_declaration=True
+                )
                 for dependency_type_id in self._self_referential_union_member_dependencies
             ]
             self._pydantic_model.update_forward_refs_with_ghost_references(ghost_references)

--- a/generators/python/src/fern_python/generators/pydantic_model/type_declaration_handler/pydantic_models/pydantic_model_simple_discriminated_union_generator.py
+++ b/generators/python/src/fern_python/generators/pydantic_model/type_declaration_handler/pydantic_models/pydantic_model_simple_discriminated_union_generator.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Set, Union
+from typing import List, Optional, Union
 
 from ....context.pydantic_generator_context import PydanticGeneratorContext
 from ...custom_config import PydanticModelCustomConfig, UnionNamingVersions
@@ -17,6 +17,7 @@ from fern_python.generators.pydantic_model.type_declaration_handler.discriminate
 from fern_python.pydantic_codegen import PydanticField, PydanticModel
 from fern_python.pydantic_codegen.pydantic_field import FernAwarePydanticField
 from fern_python.snippet import SnippetWriter
+from ordered_set import OrderedSet
 
 import fern.ir.resources as ir_types
 
@@ -202,12 +203,12 @@ class PydanticModelSimpleDiscriminatedUnionGenerator(AbstractSimpleDiscriminated
         internal_pydantic_model_for_single_union_type: PydanticModel,
         single_union_type: ir_types.SingleUnionType,
     ) -> None:
-        referenced_type_ids: Set[ir_types.TypeId] = single_union_type.shape.visit(
-            same_properties_as_object=lambda _: set(),
-            single_property=lambda single_property: set(
+        referenced_type_ids: OrderedSet[ir_types.TypeId] = single_union_type.shape.visit(
+            same_properties_as_object=lambda _: OrderedSet(),
+            single_property=lambda single_property: OrderedSet(
                 self._context.get_referenced_types_of_type_reference(single_property.type) or []
             ),
-            no_properties=lambda: set(),
+            no_properties=lambda: OrderedSet(),
         )
 
         # Check if any referenced types are self-referencing union members

--- a/generators/python/src/fern_python/pydantic_codegen/pydantic_model.py
+++ b/generators/python/src/fern_python/pydantic_codegen/pydantic_model.py
@@ -448,8 +448,8 @@ class PydanticModel:
         # 2. Kwarg refs with must_import_after_current_declaration=False so they resolve correctly
         import dataclasses
 
-        constraint_refs = []  # For adding footer constraint
-        kwarg_refs = []  # For actual function call
+        constraint_refs: list[AST.Reference] = []  # For adding footer constraint
+        kwarg_refs: list[AST.Reference] = []  # For actual function call
 
         for ghost_ref in filtered_ghost_refs:
             # Constraint ref: keeps import in dict until write_remaining_imports

--- a/generators/python/src/fern_python/pydantic_codegen/pydantic_model.py
+++ b/generators/python/src/fern_python/pydantic_codegen/pydantic_model.py
@@ -443,12 +443,24 @@ class PydanticModel:
         if not filtered_ghost_refs:
             return
 
-        # Create new references without must_import_after_current_declaration flag
-        # since these will already be imported as ghost references
-        kwarg_refs = []
-        for ghost_ref in filtered_ghost_refs:
-            import dataclasses
+        # Create two sets of references:
+        # 1. Constraint refs with must_import_after_current_declaration=True to keep imports at bottom
+        # 2. Kwarg refs with must_import_after_current_declaration=False so they resolve correctly
+        import dataclasses
 
+        constraint_refs = []  # For adding footer constraint
+        kwarg_refs = []  # For actual function call
+
+        for ghost_ref in filtered_ghost_refs:
+            # Constraint ref: keeps import in dict until write_remaining_imports
+            constraint_ref = dataclasses.replace(
+                ghost_ref,
+                must_import_after_current_declaration=True,
+                is_forward_reference=False,
+            )
+            constraint_refs.append(constraint_ref)
+
+            # Kwarg ref: resolves as actual reference (not string)
             kwarg_ref = dataclasses.replace(
                 ghost_ref,
                 must_import_after_current_declaration=False,
@@ -456,21 +468,41 @@ class PydanticModel:
             )
             kwarg_refs.append(kwarg_ref)
 
-        self._source_file.add_footer_expression(
-            AST.Expression(
-                AST.FunctionInvocation(
-                    function_definition=self._update_forward_ref_function_reference,
-                    args=[AST.Expression(self._local_class_reference)],
-                    kwargs=[
-                        (
-                            get_named_import_or_throw(kwarg_ref),
-                            AST.Expression(kwarg_ref),
-                        )
-                        for kwarg_ref in kwarg_refs
-                    ],
-                )
-            )
+        # Create a custom AST node that includes constraint refs in metadata but doesn't write them
+        class UpdateForwardRefsNode(AST.AstNode):
+            def __init__(self, constraint_refs: List[AST.Reference], func_invocation: AST.FunctionInvocation):
+                self.constraint_refs = constraint_refs
+                self.func_invocation = func_invocation
+
+            def get_metadata(self) -> AST.AstNodeMetadata:
+                metadata = AST.AstNodeMetadata()
+                # Add constraint refs to metadata
+                for ref in self.constraint_refs:
+                    metadata.references.add(ref)
+                # Add function invocation metadata
+                metadata.update(self.func_invocation.get_metadata())
+                return metadata
+
+            def write(self, writer: AST.NodeWriter, should_write_as_snippet: Optional[bool] = None) -> None:
+                # Only write the function invocation, not the constraint refs
+                writer.write_node(self.func_invocation)
+
+        update_node = UpdateForwardRefsNode(
+            constraint_refs=constraint_refs,
+            func_invocation=AST.FunctionInvocation(
+                function_definition=self._update_forward_ref_function_reference,
+                args=[AST.Expression(self._local_class_reference)],
+                kwargs=[
+                    (
+                        get_named_import_or_throw(kwarg_ref),
+                        AST.Expression(kwarg_ref),
+                    )
+                    for kwarg_ref in kwarg_refs
+                ],
+            ),
         )
+
+        self._source_file.add_footer_expression(AST.Expression(update_node))
 
     def _get_v1_config_class(self) -> Optional[AST.ClassDeclaration]:
         config = AST.ClassDeclaration(name="Config")

--- a/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/ast/types/cat.py
+++ b/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/ast/types/cat.py
@@ -25,4 +25,4 @@ from .acai import Acai  # noqa: E402, I001
 from .fig import Fig  # noqa: E402, I001
 from .fruit import Fruit  # noqa: E402, I001
 
-update_forward_refs(Cat, Fig=Fig, Acai=Acai)
+update_forward_refs(Cat, Acai=Acai, Fig=Fig)

--- a/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/ast/types/container_value.py
+++ b/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/ast/types/container_value.py
@@ -38,7 +38,7 @@ class ContainerValue_Optional(UniversalBaseModel):
 ContainerValue = typing_extensions.Annotated[
     typing.Union[ContainerValue_List, ContainerValue_Optional], pydantic.Field(discriminator="type")
 ]
-from .field_value import FieldValue  # noqa: E402, F401, I001
+from .field_value import FieldValue  # noqa: E402, I001
 
 update_forward_refs(ContainerValue_List)
 update_forward_refs(ContainerValue_Optional)

--- a/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/ast/types/dog.py
+++ b/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/ast/types/dog.py
@@ -25,4 +25,4 @@ from .acai import Acai  # noqa: E402, I001
 from .fig import Fig  # noqa: E402, I001
 from .fruit import Fruit  # noqa: E402, I001
 
-update_forward_refs(Dog, Fig=Fig, Acai=Acai)
+update_forward_refs(Dog, Acai=Acai, Fig=Fig)

--- a/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/ast/types/field_value.py
+++ b/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/ast/types/field_value.py
@@ -53,6 +53,6 @@ FieldValue = typing_extensions.Annotated[
     typing.Union[FieldValue_PrimitiveValue, FieldValue_ObjectValue, FieldValue_ContainerValue],
     pydantic.Field(discriminator="type"),
 ]
-from .container_value import ContainerValue  # noqa: E402, F401, I001
+from .container_value import ContainerValue  # noqa: E402, I001
 
 update_forward_refs(FieldValue_ContainerValue)

--- a/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/ast/types/object_field_value.py
+++ b/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/ast/types/object_field_value.py
@@ -27,6 +27,6 @@ class ObjectFieldValue(UniversalBaseModel):
             extra = pydantic.Extra.allow
 
 
-from .field_value import FieldValue  # noqa: E402, F401, I001
+from .field_value import FieldValue  # noqa: E402, I001
 
 update_forward_refs(ObjectFieldValue)

--- a/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/tests/custom/test_client.py
+++ b/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/tests/custom/test_client.py
@@ -1,0 +1,7 @@
+import pytest
+
+
+# Get started with writing tests with pytest at https://docs.pytest.org
+@pytest.mark.skip(reason="Unimplemented")
+def test_client() -> None:
+    assert True


### PR DESCRIPTION
Ensures ghost reference imports for update_forward_refs appear at the bottom of the file by:
- Setting must_import_after_current_declaration=True on ghost references
- Creating custom AST node that includes constraint refs in metadata
- Using separate kwarg refs that resolve as actual references (not strings)

This fixes import ordering issues where transitive circular dependencies weren't being imported before the update_forward_refs call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)