### PR TITLE
fix(java): return raw response type for custom pagination endpoint instead of failing 

### DIFF
--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/AbstractHttpResponseParserGenerator.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/AbstractHttpResponseParserGenerator.java
@@ -272,7 +272,10 @@ public abstract class AbstractHttpResponseParserGenerator {
 
                             @Override
                             public TypeName visitCustom(CustomPagination customPagination) {
-                                throw new RuntimeException("Unknown pagination type custom");
+                                // For custom pagination, return the response type directly
+                                // without wrapping in a Pager. The user is responsible for
+                                // implementing their own pagination logic.
+                                return responseType;
                             }
 
                             @Override
@@ -1547,7 +1550,13 @@ public abstract class AbstractHttpResponseParserGenerator {
 
         @Override
         public Void visitCustom(CustomPagination customPagination) {
-            throw new RuntimeException("Unknown pagination type custom");
+            // For custom pagination, handle the response as non-paginated
+            // and return the parsed response directly. The user is responsible
+            // for implementing their own pagination logic.
+            TypeName responseType = getResponseType(httpEndpoint, clientGeneratorContext);
+            handleSuccessfulResult(httpResponseBuilder, CodeBlock.of("$L", variables.getParsedResponseVariableName()));
+            endpointMethodBuilder.returns(responseType);
+            return null;
         }
 
         @Override

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,3 +1,11 @@
+- version: 3.15.1
+  changelogEntry:
+    - summary: |
+        Fix SDK generation failures for endpoints with custom pagination. Endpoints using `x-fern-pagination: type: custom` now generate successfully, returning the raw response type without automatic pagination wrappers.
+      type: fix
+  createdAt: "2025-11-14"
+  irVersion: 61
+
 - version: 3.15.0
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description
Linear ticket: Closes [FER-7712: \[Java, Payroc\] dont' fail on custom pagination type](https://linear.app/buildwithfern/issue/FER-7712/java-payroc-dont-fail-on-custom-pagination-type)
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
<!-- Provide a clear and concise description of the changes made in this PR -->

Fix java generation failures when endpoints use custom pagination (x-fern-pagination: type: custom).

Custom pagination allows users to implement their own pagination logic instead of auto-generated pagination helpers. This brings Java in parity with TS as we now handle custom pagination by returning the raw response type without wrapping it in `SyncPagingIterable`. 

This fixes "Unknown pagination type custom" errors. 

## Testing
<!-- Describe how you tested these changes -->
- [ ] Unit tests added/updated
- [ ] Manual testing completed
