### PR TITLE
chore(deps): address node types issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
       "es-toolkit": "^1.39.10",
       "ts-essentials": "^10.1.1",
       "form-data": "^4.0.4",
-      "@types/node@": "^20.19.0"
+      "@types/node": "^20.19.0"
     }
   },
   "catalog": {

--- a/package.json
+++ b/package.json
@@ -128,7 +128,8 @@
       "@fern-api/fdr-sdk": "0.140.3-057adfab3",
       "es-toolkit": "^1.39.10",
       "ts-essentials": "^10.1.1",
-      "form-data": "^4.0.4"
+      "form-data": "^4.0.4",
+      "@types/node@": "^20.19.0"
     }
   },
   "catalog": {

--- a/packages/cli/cli/src/cli-context/TtyAwareLogger.ts
+++ b/packages/cli/cli/src/cli-context/TtyAwareLogger.ts
@@ -12,7 +12,7 @@ export class TtyAwareLogger {
     private tasks: TaskContextImpl[] = [];
     private lastPaint = "";
     private spinner = ora({ spinner: "dots11" });
-    private interval: NodeJS.Timer | undefined;
+    private interval: ReturnType<typeof setInterval> | undefined;
 
     constructor(
         private readonly stdout: NodeJS.WriteStream,

--- a/packages/snippets/core/package.json
+++ b/packages/snippets/core/package.json
@@ -43,7 +43,7 @@
     "@fern-api/ir-sdk": "workspace:*",
     "@fern-api/source-resolver": "workspace:*",
     "@fern-api/task-context": "workspace:*",
-    "@types/node": "18.15.3",
+    "@types/node": "^20.19.25",
     "depcheck": "^1.4.7",
     "openapi-types": "^12.1.3",
     "tsup": "^8.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,7 @@ overrides:
   es-toolkit: ^1.39.10
   ts-essentials: ^10.1.1
   form-data: ^4.0.4
+  '@types/node@': ^20.19.0
 
 importers:
 
@@ -93,7 +94,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@24.10.0)(jsdom@27.1.0)(msw@2.12.1(@types/node@24.10.0)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/base:
     dependencies:
@@ -135,8 +136,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -145,7 +146,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/browser-compatible-base:
     dependencies:
@@ -172,8 +173,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -182,7 +183,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/csharp/base:
     devDependencies:
@@ -211,8 +212,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -224,7 +225,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/csharp/codegen:
     dependencies:
@@ -248,8 +249,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -258,7 +259,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/csharp/dynamic-snippets:
     devDependencies:
@@ -284,8 +285,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -300,7 +301,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/csharp/formatter:
     dependencies:
@@ -315,8 +316,8 @@ importers:
         specifier: workspace:*
         version: link:../base
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -328,7 +329,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/csharp/model:
     devDependencies:
@@ -357,8 +358,8 @@ importers:
         specifier: ^61.7.0
         version: 61.7.0
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -370,7 +371,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/csharp/sdk:
     devDependencies:
@@ -411,8 +412,8 @@ importers:
         specifier: ^61.7.0
         version: 61.7.0
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       '@types/url-join':
         specifier: 4.0.1
         version: 4.0.1
@@ -430,7 +431,7 @@ importers:
         version: 4.0.1
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/go-v2/ast:
     devDependencies:
@@ -447,8 +448,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/commons/path-utils
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -457,7 +458,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
       zod:
         specifier: ^3.22.3
         version: 3.25.76
@@ -492,8 +493,8 @@ importers:
         specifier: ^61.7.0
         version: 61.7.0
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       dedent:
         specifier: ^1.5.1
         version: 1.7.0(babel-plugin-macros@3.1.0)
@@ -508,7 +509,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/go-v2/dynamic-snippets:
     devDependencies:
@@ -540,8 +541,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/commons/path-utils
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -553,7 +554,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/go-v2/formatter:
     dependencies:
@@ -568,8 +569,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -578,7 +579,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/go-v2/model:
     devDependencies:
@@ -604,8 +605,8 @@ importers:
         specifier: ^61.7.0
         version: 61.7.0
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -617,7 +618,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/go-v2/sdk:
     devDependencies:
@@ -661,8 +662,8 @@ importers:
         specifier: ^61.7.0
         version: 61.7.0
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       dedent:
         specifier: ^1.5.1
         version: 1.7.0(babel-plugin-macros@3.1.0)
@@ -677,7 +678,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/java-v2/ast:
     dependencies:
@@ -695,8 +696,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -705,7 +706,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/java-v2/base:
     devDependencies:
@@ -728,8 +729,8 @@ importers:
         specifier: ^61.7.0
         version: 61.7.0
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -738,7 +739,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/java-v2/dynamic-snippets:
     devDependencies:
@@ -770,8 +771,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -786,7 +787,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/java-v2/sdk:
     devDependencies:
@@ -827,8 +828,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -843,7 +844,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/openapi:
     devDependencies:
@@ -869,8 +870,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       '@types/url-join':
         specifier: ^4.0.3
         version: 4.0.3
@@ -897,7 +898,7 @@ importers:
         version: 4.0.1
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/php/base:
     devDependencies:
@@ -926,8 +927,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -942,7 +943,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/php/codegen:
     dependencies:
@@ -963,8 +964,8 @@ importers:
         specifier: 4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -973,7 +974,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
       zod:
         specifier: ^3.22.3
         version: 3.25.76
@@ -1008,8 +1009,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -1024,7 +1025,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/php/model:
     devDependencies:
@@ -1047,8 +1048,8 @@ importers:
         specifier: ^61.7.0
         version: 61.7.0
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -1060,7 +1061,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
       zod:
         specifier: ^3.22.3
         version: 3.25.76
@@ -1107,8 +1108,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -1123,7 +1124,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
       zod:
         specifier: ^3.22.3
         version: 3.25.76
@@ -1152,8 +1153,8 @@ importers:
         specifier: ^4.17.4
         version: 4.17.20
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -1171,7 +1172,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
       zod:
         specifier: ^3.22.3
         version: 3.25.76
@@ -1188,8 +1189,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/commons/core-utils
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -1198,7 +1199,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/python-v2/base:
     dependencies:
@@ -1234,8 +1235,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -1244,7 +1245,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/python-v2/browser-compatible-base:
     devDependencies:
@@ -1252,8 +1253,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -1262,7 +1263,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
       zod:
         specifier: ^3.22.3
         version: 3.25.76
@@ -1300,8 +1301,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -1316,7 +1317,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/python-v2/fastapi:
     devDependencies:
@@ -1324,8 +1325,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -1337,7 +1338,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/python-v2/formatter:
     devDependencies:
@@ -1348,8 +1349,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       '@wasm-fmt/ruff_fmt':
         specifier: ^0.6.1
         version: 0.6.1
@@ -1361,7 +1362,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/python-v2/pydantic-model:
     devDependencies:
@@ -1390,8 +1391,8 @@ importers:
         specifier: ^61.7.0
         version: 61.7.0
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -1403,7 +1404,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
       zod:
         specifier: ^3.22.4
         version: 3.25.76
@@ -1432,8 +1433,8 @@ importers:
         specifier: ^61.7.0
         version: 61.7.0
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -1445,7 +1446,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
       zod:
         specifier: ^3.22.4
         version: 3.25.76
@@ -1466,8 +1467,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -1476,7 +1477,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/ruby-v2/base:
     devDependencies:
@@ -1508,8 +1509,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       dedent:
         specifier: ^1.5.1
         version: 1.7.0(babel-plugin-macros@3.1.0)
@@ -1530,7 +1531,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/ruby-v2/dynamic-snippets:
     devDependencies:
@@ -1562,8 +1563,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -1578,7 +1579,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/ruby-v2/model:
     devDependencies:
@@ -1604,8 +1605,8 @@ importers:
         specifier: ^61.7.0
         version: 61.7.0
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -1617,7 +1618,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/ruby-v2/sdk:
     devDependencies:
@@ -1670,8 +1671,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       dedent:
         specifier: ^1.5.1
         version: 1.7.0(babel-plugin-macros@3.1.0)
@@ -1689,7 +1690,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/ruby/cli:
     dependencies:
@@ -1716,8 +1717,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -1726,7 +1727,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/ruby/codegen:
     dependencies:
@@ -1756,8 +1757,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       '@types/url-join':
         specifier: ^4.0.3
         version: 4.0.3
@@ -1769,7 +1770,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/ruby/model:
     devDependencies:
@@ -1798,8 +1799,8 @@ importers:
         specifier: ^39
         version: 39.0.0
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -1811,7 +1812,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
       zod:
         specifier: ^3.22.3
         version: 3.25.76
@@ -1846,8 +1847,8 @@ importers:
         specifier: ^39
         version: 39.0.0
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -1859,7 +1860,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
       zod:
         specifier: ^3.22.3
         version: 3.25.76
@@ -1895,8 +1896,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -1905,7 +1906,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/rust/codegen:
     dependencies:
@@ -1917,8 +1918,8 @@ importers:
         version: 3.25.76
     devDependencies:
       '@types/node':
-        specifier: ^18.7.18
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.6
         version: 1.4.7
@@ -1927,7 +1928,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/rust/dynamic-snippets:
     dependencies:
@@ -1954,8 +1955,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/commons/path-utils
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       '@yarnpkg/esbuild-plugin-pnp':
         specifier: 3.0.0-rc.15
         version: 3.0.0-rc.15(esbuild@0.25.10)
@@ -1970,7 +1971,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/rust/model:
     devDependencies:
@@ -2002,8 +2003,8 @@ importers:
         specifier: ^61.7.0
         version: 61.7.0
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -2015,7 +2016,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
       zod:
         specifier: ^3.22.4
         version: 3.25.76
@@ -2063,8 +2064,8 @@ importers:
         specifier: ^61.7.0
         version: 61.7.0
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -2076,7 +2077,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
       zod:
         specifier: ^3.22.4
         version: 3.25.76
@@ -2102,8 +2103,8 @@ importers:
         specifier: ^61.7.0
         version: 61.7.0
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -2112,7 +2113,7 @@ importers:
         version: 5.9.2
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.2))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.2))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/swift/codegen:
     dependencies:
@@ -2139,8 +2140,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       '@types/number-to-words':
         specifier: 1.2.3
         version: 1.2.3
@@ -2152,7 +2153,7 @@ importers:
         version: 5.9.2
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.2))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.2))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/swift/dynamic-snippets:
     devDependencies:
@@ -2184,8 +2185,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -2200,7 +2201,7 @@ importers:
         version: 5.9.2
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.2))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.2))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/swift/model:
     dependencies:
@@ -2236,8 +2237,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -2249,7 +2250,7 @@ importers:
         version: 5.9.2
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.2))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.2))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
       zod:
         specifier: ^3.22.3
         version: 3.25.76
@@ -2305,8 +2306,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -2321,7 +2322,7 @@ importers:
         version: 5.9.2
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.2))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.2))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
       zod:
         specifier: ^3.25.75
         version: 3.25.76
@@ -2353,8 +2354,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -2366,7 +2367,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/typescript-mcp/model:
     devDependencies:
@@ -2389,8 +2390,8 @@ importers:
         specifier: ^58.2.0
         version: 58.3.0
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -2402,7 +2403,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/typescript-mcp/server:
     devDependencies:
@@ -2434,8 +2435,8 @@ importers:
         specifier: workspace:*
         version: link:../../typescript/sdk/cli
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -2447,7 +2448,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/typescript-v2/ast:
     dependencies:
@@ -2465,8 +2466,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/commons/core-utils
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -2475,7 +2476,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/typescript-v2/base:
     devDependencies:
@@ -2493,7 +2494,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@24.10.0)(jsdom@27.1.0)(msw@2.12.1(@types/node@24.10.0)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/typescript-v2/browser-compatible-base:
     devDependencies:
@@ -2517,7 +2518,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@24.10.0)(jsdom@27.1.0)(msw@2.12.1(@types/node@24.10.0)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/typescript-v2/dynamic-snippets:
     devDependencies:
@@ -2549,8 +2550,8 @@ importers:
         specifier: workspace:*
         version: link:../browser-compatible-base
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -2562,7 +2563,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/typescript-v2/formatter:
     dependencies:
@@ -2577,8 +2578,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       '@types/prettier2':
         specifier: npm:@types/prettier@^2.7.3
         version: '@types/prettier@2.7.3'
@@ -2590,7 +2591,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/typescript/express/cli:
     devDependencies:
@@ -2662,8 +2663,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -2672,7 +2673,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/typescript/express/express-error-generator:
     dependencies:
@@ -2696,8 +2697,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -2706,7 +2707,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/typescript/express/express-error-schema-generator:
     dependencies:
@@ -2733,8 +2734,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -2743,7 +2744,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/typescript/express/express-inlined-request-body-generator:
     dependencies:
@@ -2761,8 +2762,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -2771,7 +2772,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/typescript/express/express-inlined-request-body-schema-generator:
     dependencies:
@@ -2795,8 +2796,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -2805,7 +2806,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/typescript/express/express-register-generator:
     dependencies:
@@ -2835,8 +2836,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -2845,7 +2846,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/typescript/express/express-service-generator:
     dependencies:
@@ -2869,8 +2870,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -2879,7 +2880,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/typescript/express/generator:
     dependencies:
@@ -2948,8 +2949,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -2958,7 +2959,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/typescript/express/generic-express-error-generators:
     dependencies:
@@ -2979,8 +2980,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -2989,7 +2990,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/typescript/model/type-generator:
     dependencies:
@@ -3013,8 +3014,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -3023,7 +3024,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/typescript/model/type-reference-converters:
     dependencies:
@@ -3047,8 +3048,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -3057,7 +3058,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/typescript/model/type-reference-example-generator:
     dependencies:
@@ -3081,8 +3082,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -3091,7 +3092,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/typescript/model/type-schema-generator:
     dependencies:
@@ -3118,8 +3119,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -3128,7 +3129,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/typescript/model/union-generator:
     dependencies:
@@ -3152,8 +3153,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -3162,7 +3163,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/typescript/model/union-schema-generator:
     dependencies:
@@ -3186,8 +3187,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -3196,7 +3197,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/typescript/sdk/cli:
     devDependencies:
@@ -3234,8 +3235,8 @@ importers:
         specifier: workspace:*
         version: link:../generator
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -3280,8 +3281,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -3290,7 +3291,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/typescript/sdk/endpoint-error-union-generator:
     dependencies:
@@ -3317,8 +3318,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -3327,7 +3328,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/typescript/sdk/environments-generator:
     dependencies:
@@ -3348,8 +3349,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -3358,7 +3359,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/typescript/sdk/generator:
     dependencies:
@@ -3454,8 +3455,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -3464,7 +3465,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/typescript/sdk/generic-sdk-error-generators:
     dependencies:
@@ -3485,8 +3486,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -3495,7 +3496,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/typescript/sdk/request-wrapper-generator:
     dependencies:
@@ -3519,8 +3520,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -3529,7 +3530,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/typescript/sdk/sdk-endpoint-type-schemas-generator:
     dependencies:
@@ -3562,8 +3563,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -3572,7 +3573,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/typescript/sdk/sdk-error-generator:
     dependencies:
@@ -3596,8 +3597,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -3606,7 +3607,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/typescript/sdk/sdk-error-schema-generator:
     dependencies:
@@ -3633,8 +3634,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -3643,7 +3644,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/typescript/sdk/sdk-inlined-request-body-schema-generator:
     dependencies:
@@ -3667,8 +3668,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -3677,7 +3678,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/typescript/sdk/websocket-type-schema-generator:
     dependencies:
@@ -3701,8 +3702,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -3711,7 +3712,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/typescript/utils/abstract-error-class-generator:
     dependencies:
@@ -3729,8 +3730,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -3739,7 +3740,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/typescript/utils/abstract-generator-cli:
     dependencies:
@@ -3778,8 +3779,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -3788,7 +3789,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/typescript/utils/abstract-schema-generator:
     dependencies:
@@ -3806,8 +3807,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -3816,7 +3817,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/typescript/utils/commons:
     dependencies:
@@ -3876,8 +3877,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       '@types/url-join':
         specifier: 4.0.1
         version: 4.0.1
@@ -3895,7 +3896,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/typescript/utils/contexts:
     dependencies:
@@ -3925,8 +3926,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -3935,7 +3936,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   generators/typescript/utils/resolvers:
     dependencies:
@@ -3950,8 +3951,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -3960,7 +3961,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/api-importers/asyncapi-to-ir:
     dependencies:
@@ -3990,8 +3991,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -4000,7 +4001,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/api-importers/commons:
     dependencies:
@@ -4027,8 +4028,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -4037,7 +4038,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/api-importers/conjure/conjure-sdk:
     devDependencies:
@@ -4045,8 +4046,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -4055,7 +4056,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/api-importers/conjure/conjure-to-fern:
     dependencies:
@@ -4085,8 +4086,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.9
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -4095,7 +4096,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/api-importers/conjure/conjure-to-fern-tests:
     dependencies:
@@ -4113,8 +4114,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -4123,7 +4124,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/api-importers/openapi-pruner:
     dependencies:
@@ -4135,8 +4136,8 @@ importers:
         specifier: workspace:*
         version: link:../../../configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -4145,7 +4146,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/api-importers/openapi-to-ir:
     dependencies:
@@ -4184,8 +4185,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -4194,7 +4195,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/api-importers/openapi/openapi-ir:
     dependencies:
@@ -4209,8 +4210,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -4219,7 +4220,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/api-importers/openapi/openapi-ir-parser:
     dependencies:
@@ -4261,8 +4262,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -4271,7 +4272,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/api-importers/openapi/openapi-ir-to-fern:
     dependencies:
@@ -4310,8 +4311,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -4320,7 +4321,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/api-importers/openapi/openapi-ir-to-fern-tests:
     dependencies:
@@ -4353,8 +4354,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.9
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -4363,7 +4364,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/api-importers/openrpc-to-ir:
     dependencies:
@@ -4390,8 +4391,8 @@ importers:
         specifier: workspace:*
         version: link:../../../configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -4400,7 +4401,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/api-importers/v3-importer-commons:
     dependencies:
@@ -4457,8 +4458,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -4467,7 +4468,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/api-importers/v3-importer-tests:
     dependencies:
@@ -4494,8 +4495,8 @@ importers:
         specifier: workspace:*
         version: link:../../generation/ir-generator
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -4504,7 +4505,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/auth:
     dependencies:
@@ -4537,8 +4538,8 @@ importers:
         specifier: ^9.0.6
         version: 9.0.10
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -4547,7 +4548,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/cli:
     devDependencies:
@@ -4694,7 +4695,7 @@ importers:
         version: 0.114.0-5745f9e74
       '@inquirer/prompts':
         specifier: ^7.1.0
-        version: 7.8.6(@types/node@18.15.3)
+        version: 7.8.6(@types/node@20.19.25)
       '@types/axios':
         specifier: ^0.14.0
         version: 0.14.4
@@ -4717,8 +4718,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       '@types/semver':
         specifier: ^7.5.8
         version: 7.7.1
@@ -4799,7 +4800,7 @@ importers:
         version: 5.0.1
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
       yaml:
         specifier: 2.3.3
         version: 2.3.3
@@ -4817,8 +4818,8 @@ importers:
         specifier: workspace:*
         version: link:../../configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -4827,7 +4828,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/cli-migrations:
     dependencies:
@@ -4863,7 +4864,7 @@ importers:
         version: 11.0.3
       inquirer:
         specifier: ^9.2.23
-        version: 9.3.8(@types/node@18.15.3)
+        version: 9.3.8(@types/node@20.19.25)
       js-yaml:
         specifier: ^4.1.0
         version: 4.1.0
@@ -4884,8 +4885,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.9
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -4897,7 +4898,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/cli-source-resolver:
     dependencies:
@@ -4921,8 +4922,8 @@ importers:
         specifier: workspace:*
         version: link:../../configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -4931,7 +4932,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/configuration:
     dependencies:
@@ -4967,8 +4968,8 @@ importers:
         specifier: workspace:*
         version: link:../../configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       '@types/node-fetch':
         specifier: '2'
         version: 2.6.9
@@ -4986,7 +4987,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/configuration-loader:
     dependencies:
@@ -5055,8 +5056,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       '@types/semver':
         specifier: ^7.5.8
         version: 7.7.1
@@ -5071,7 +5072,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/docs-importers/commons:
     dependencies:
@@ -5098,8 +5099,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.9
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -5108,7 +5109,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/docs-importers/mintlify:
     dependencies:
@@ -5141,8 +5142,8 @@ importers:
         specifier: workspace:*
         version: link:../../../configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -5151,7 +5152,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/docs-importers/readme:
     dependencies:
@@ -5220,8 +5221,8 @@ importers:
         specifier: ^4.0.4
         version: 4.0.4
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -5230,7 +5231,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/docs-markdown-utils:
     dependencies:
@@ -5296,8 +5297,8 @@ importers:
         specifier: ^4.0.4
         version: 4.0.4
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -5309,7 +5310,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
       zod:
         specifier: ^3.22.3
         version: 3.25.76
@@ -5393,8 +5394,8 @@ importers:
         specifier: ^4.17.21
         version: 4.17.23
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       '@types/uuid':
         specifier: ^9.0.8
         version: 9.0.8
@@ -5412,7 +5413,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/docs-resolver:
     dependencies:
@@ -5502,8 +5503,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       '@types/url-join':
         specifier: ^4.0.3
         version: 4.0.3
@@ -5515,7 +5516,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/ete-tests:
     dependencies:
@@ -5566,8 +5567,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.9
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       '@types/node-fetch':
         specifier: 2.6.9
         version: 2.6.9
@@ -5579,7 +5580,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/fern-definition/formatter:
     dependencies:
@@ -5609,8 +5610,8 @@ importers:
         specifier: workspace:*
         version: link:../../../configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       '@types/prettier2':
         specifier: npm:@types/prettier@^2.7.3
         version: '@types/prettier@2.7.3'
@@ -5622,7 +5623,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/fern-definition/ir-to-jsonschema:
     dependencies:
@@ -5667,8 +5668,8 @@ importers:
         specifier: ^7.0.15
         version: 7.0.15
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -5677,7 +5678,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/fern-definition/schema:
     dependencies:
@@ -5692,8 +5693,8 @@ importers:
         specifier: workspace:*
         version: link:../../../configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -5702,7 +5703,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/fern-definition/validator:
     dependencies:
@@ -5762,8 +5763,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       '@types/url-join':
         specifier: ^4.0.3
         version: 4.0.3
@@ -5775,7 +5776,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/generation/ir-generator:
     devDependencies:
@@ -5816,8 +5817,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       '@types/url-join':
         specifier: 4.0.1
         version: 4.0.1
@@ -5841,7 +5842,7 @@ importers:
         version: 9.0.1
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/generation/ir-generator-tests:
     dependencies:
@@ -5880,8 +5881,8 @@ importers:
         specifier: workspace:*
         version: link:../../../configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -5890,7 +5891,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/generation/ir-migrations:
     dependencies:
@@ -6115,8 +6116,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -6125,7 +6126,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/generation/local-generation/docker-utils:
     dependencies:
@@ -6149,8 +6150,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -6159,7 +6160,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/generation/local-generation/local-workspace-runner:
     dependencies:
@@ -6267,8 +6268,8 @@ importers:
         specifier: ^4.2.7
         version: 4.2.7
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -6277,7 +6278,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/generation/protoc-gen-fern:
     dependencies:
@@ -6316,8 +6317,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -6326,7 +6327,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/generation/protoc-gen-fern/bin: {}
 
@@ -6442,8 +6443,8 @@ importers:
         specifier: ^2.1.4
         version: 2.1.4
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       '@types/tar':
         specifier: ^6.1.11
         version: 6.1.13
@@ -6461,7 +6462,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/generation/source-resolver:
     dependencies:
@@ -6476,8 +6477,8 @@ importers:
         specifier: workspace:*
         version: link:../../../configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -6486,7 +6487,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/init:
     dependencies:
@@ -6552,8 +6553,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -6562,7 +6563,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/logger:
     dependencies:
@@ -6574,8 +6575,8 @@ importers:
         specifier: workspace:*
         version: link:../../configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -6584,7 +6585,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/login:
     dependencies:
@@ -6611,7 +6612,7 @@ importers:
         version: 5.6.2
       inquirer:
         specifier: ^9.2.23
-        version: 9.3.8(@types/node@18.15.3)
+        version: 9.3.8(@types/node@20.19.25)
       open:
         specifier: ^8.4.0
         version: 8.4.2
@@ -6629,8 +6630,8 @@ importers:
         specifier: ^9.0.7
         version: 9.0.9
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       '@types/qs':
         specifier: 6.9.15
         version: 6.9.15
@@ -6642,7 +6643,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/mock:
     dependencies:
@@ -6675,8 +6676,8 @@ importers:
         specifier: ^4.17.21
         version: 4.17.23
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       '@types/url-join':
         specifier: 4.0.1
         version: 4.0.1
@@ -6688,7 +6689,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/posthog-manager:
     dependencies:
@@ -6712,8 +6713,8 @@ importers:
         specifier: workspace:*
         version: link:../../configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       '@types/uuid':
         specifier: ^9.0.8
         version: 9.0.8
@@ -6725,7 +6726,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/project-loader:
     dependencies:
@@ -6752,8 +6753,8 @@ importers:
         specifier: workspace:*
         version: link:../../configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -6762,7 +6763,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/register:
     dependencies:
@@ -6831,8 +6832,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -6841,7 +6842,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/semver-utils:
     dependencies:
@@ -6853,8 +6854,8 @@ importers:
         specifier: workspace:*
         version: link:../../configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -6863,7 +6864,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/task-context:
     dependencies:
@@ -6875,8 +6876,8 @@ importers:
         specifier: workspace:*
         version: link:../../configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -6885,7 +6886,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/workspace/browser-compatible-fern-workspace:
     dependencies:
@@ -6918,8 +6919,8 @@ importers:
         specifier: workspace:*
         version: link:../../../configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -6928,7 +6929,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/workspace/commons:
     dependencies:
@@ -6988,8 +6989,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       '@types/semver':
         specifier: ^7.5.8
         version: 7.7.1
@@ -7001,7 +7002,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/workspace/lazy-fern-workspace:
     dependencies:
@@ -7124,8 +7125,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       '@types/object-hash':
         specifier: ^3.0.6
         version: 3.0.6
@@ -7143,7 +7144,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/workspace/loader:
     dependencies:
@@ -7191,8 +7192,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.9
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -7201,7 +7202,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/workspace/oss-validator:
     dependencies:
@@ -7231,8 +7232,8 @@ importers:
         specifier: workspace:*
         version: link:../../../configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -7241,7 +7242,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/yaml/docs-validator:
     dependencies:
@@ -7352,8 +7353,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.9
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       '@types/unist':
         specifier: ^3.0.3
         version: 3.0.3
@@ -7368,7 +7369,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/cli/yaml/generators-validator:
     dependencies:
@@ -7413,8 +7414,8 @@ importers:
         specifier: workspace:*
         version: link:../../../configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -7423,7 +7424,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/commons/casings-generator:
     dependencies:
@@ -7447,8 +7448,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -7457,7 +7458,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/commons/core-utils:
     dependencies:
@@ -7505,8 +7506,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       '@types/title':
         specifier: ^3.4.3
         version: 3.4.3
@@ -7524,7 +7525,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/commons/fs-utils:
     dependencies:
@@ -7551,8 +7552,8 @@ importers:
         specifier: workspace:*
         version: link:../../configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       '@types/stream-json':
         specifier: ^1.7.7
         version: 1.7.8
@@ -7564,7 +7565,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/commons/github:
     dependencies:
@@ -7582,8 +7583,8 @@ importers:
         specifier: workspace:*
         version: link:../../configs
       '@types/node':
-        specifier: ^22.0.0
-        version: 22.19.0
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -7595,7 +7596,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@22.19.0)(jsdom@27.1.0)(msw@2.12.1(@types/node@22.19.0)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/commons/ir-utils:
     dependencies:
@@ -7625,8 +7626,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -7635,7 +7636,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/commons/loadable:
     dependencies:
@@ -7647,8 +7648,8 @@ importers:
         specifier: workspace:*
         version: link:../../configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -7657,7 +7658,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/commons/logging-execa:
     dependencies:
@@ -7675,8 +7676,8 @@ importers:
         specifier: workspace:*
         version: link:../../configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -7685,7 +7686,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/commons/mock-utils:
     dependencies:
@@ -7706,17 +7707,17 @@ importers:
         specifier: ^29.5.5
         version: 29.5.14
       '@types/node':
-        specifier: ^18.17.13
-        version: 18.19.129
+        specifier: ^20.19.0
+        version: 20.19.25
       '@types/uuid':
         specifier: ^9.0.0
         version: 9.0.8
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@18.19.129)(babel-plugin-macros@3.1.0)
+        version: 29.7.0(@types/node@20.19.25)(babel-plugin-macros@3.1.0)
       ts-jest:
         specifier: ^29.1.1
-        version: 29.4.5(@babel/core@7.28.4)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.4))(jest-util@30.2.0)(jest@29.7.0(@types/node@18.19.129)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
+        version: 29.4.5(@babel/core@7.28.4)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.4))(jest-util@30.2.0)(jest@29.7.0(@types/node@20.19.25)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
       typescript:
         specifier: ^5.2.2
         version: 5.9.3
@@ -7727,8 +7728,8 @@ importers:
         specifier: workspace:*
         version: link:../../configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -7737,7 +7738,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/commons/test-utils:
     devDependencies:
@@ -7769,8 +7770,8 @@ importers:
         specifier: workspace:*
         version: link:../../cli/workspace/loader
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -7779,13 +7780,13 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/configs:
     devDependencies:
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@24.10.0)(jsdom@27.1.0)(msw@2.12.1(@types/node@24.10.0)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/core:
     dependencies:
@@ -7809,8 +7810,8 @@ importers:
         specifier: workspace:*
         version: link:../configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -7819,7 +7820,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/generator-cli:
     devDependencies:
@@ -7839,8 +7840,8 @@ importers:
         specifier: ^29.5.11
         version: 29.5.14
       '@types/node':
-        specifier: ^22.0.0
-        version: 22.19.0
+        specifier: ^20.19.0
+        version: 20.19.25
       '@types/yargs':
         specifier: ^17.0.32
         version: 17.0.33
@@ -7867,7 +7868,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@22.19.0)(jsdom@27.1.0)(msw@2.12.1(@types/node@22.19.0)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
       yargs:
         specifier: ^17.4.1
         version: 17.7.2
@@ -7878,8 +7879,8 @@ importers:
         specifier: workspace:*
         version: link:../configs
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -7888,7 +7889,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   packages/scripts:
     devDependencies:
@@ -7902,8 +7903,8 @@ importers:
         specifier: workspace:*
         version: link:../cli/generation/ir-migrations
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       '@types/yargs':
         specifier: ^17.0.32
         version: 17.0.33
@@ -7915,7 +7916,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
       yaml:
         specifier: 2.3.3
         version: 2.3.3
@@ -7974,8 +7975,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       '@types/pretty-ms':
         specifier: ^5.0.1
         version: 5.0.1
@@ -8029,7 +8030,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
       yargs:
         specifier: ^17.4.1
         version: 17.7.2
@@ -8067,8 +8068,8 @@ importers:
         specifier: workspace:*
         version: link:../../cli/task-context
       '@types/node':
-        specifier: 18.15.3
-        version: 18.15.3
+        specifier: ^20.19.0
+        version: 20.19.25
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -8083,7 +8084,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
 packages:
 
@@ -9944,7 +9945,7 @@ packages:
     resolution: {integrity: sha512-2n9Vgf4HSciFq8ttKXk+qy+GsyTXPV1An6QAwe/8bkbbqvG4VW1I/ZY1pNu2rf+h9bdzMLPbRSfcNxkHBy/Ydw==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': '>=18'
+      '@types/node': ^20.19.0
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -9953,7 +9954,7 @@ packages:
     resolution: {integrity: sha512-MilmWOzHa3Ks11tzvuAmFoAd/wRuaP3SwlT1IZhyMke31FKLxPiuDWcGXhU+PKveNOpAc4axzAgrgxuIJJRmLw==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': '>=18'
+      '@types/node': ^20.19.0
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -9962,7 +9963,7 @@ packages:
     resolution: {integrity: sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': '>=18'
+      '@types/node': ^20.19.0
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -9971,7 +9972,7 @@ packages:
     resolution: {integrity: sha512-yXq/4QUnk4sHMtmbd7irwiepjB8jXU0kkFRL4nr/aDBA2mDz13cMakEWdDwX3eSCTkk03kwcndD1zfRAIlELxA==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': '>=18'
+      '@types/node': ^20.19.0
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -9980,7 +9981,7 @@ packages:
     resolution: {integrity: sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': '>=18'
+      '@types/node': ^20.19.0
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -9989,7 +9990,7 @@ packages:
     resolution: {integrity: sha512-7omh5y5bK672Q+Brk4HBbnHNowOZwrb/78IFXdrEB9PfdxL3GudQyDk8O9vQ188wj3xrEebS2M9n18BjJoI83g==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': '>=18'
+      '@types/node': ^20.19.0
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -9998,7 +9999,7 @@ packages:
     resolution: {integrity: sha512-Dt9S+6qUg94fEvgn54F2Syf0Z3U8xmnBI9ATq2f5h9xt09fs2IJXSCIXyyVHwvggKWFXEY/7jATRo2K6Dkn6Ow==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': '>=18'
+      '@types/node': ^20.19.0
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -10007,7 +10008,7 @@ packages:
     resolution: {integrity: sha512-yy9cOoBnx58TlsPrIxauKIFQTiyH+0MK4e97y4sV9ERbI+zDxw7i2hxHLCIEGIE/8PPvDxGhgzIOTSOWcs6/MQ==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': '>=18'
+      '@types/node': ^20.19.0
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -10024,7 +10025,7 @@ packages:
     resolution: {integrity: sha512-cwSGpLBMwpwcZZsc6s1gThm0J+it/KIJ+1qFL2euLmSKUMGumJ5TcbMgxEjMjNHRGadouIYbiIgruKoDZk7klw==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': '>=18'
+      '@types/node': ^20.19.0
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -10033,7 +10034,7 @@ packages:
     resolution: {integrity: sha512-bbooay64VD1Z6uMfNehED2A2YOPHSJnQLs9/4WNiV/EK+vXczf/R988itL2XLDGTgmhMF2KkiWZo+iEZmc4jqg==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': '>=18'
+      '@types/node': ^20.19.0
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -10042,7 +10043,7 @@ packages:
     resolution: {integrity: sha512-nxSaPV2cPvvoOmRygQR+h0B+Av73B01cqYLcr7NXcGXhbmsYfUb8fDdw2Us1bI2YsX+VvY7I7upgFYsyf8+Nug==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': '>=18'
+      '@types/node': ^20.19.0
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -10051,7 +10052,7 @@ packages:
     resolution: {integrity: sha512-68JhkiojicX9SBUD8FE/pSKbOKtwoyaVj1kwqLfvjlVXZvOy3iaSWX4dCLsZyYx/5Ur07Fq+yuDNOen+5ce6ig==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': '>=18'
+      '@types/node': ^20.19.0
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -10060,7 +10061,7 @@ packages:
     resolution: {integrity: sha512-CQ2VkIASbgI2PxdzlkeeieLRmniaUU1Aoi5ggEdm6BIyqopE9GuDXdDOj9XiwOqK5qm72oI2i6J+Gnjaa26ejg==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': '>=18'
+      '@types/node': ^20.19.0
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -10069,7 +10070,7 @@ packages:
     resolution: {integrity: sha512-D5T6ioybJJH0IiSUK/JXcoRrrm8sXwzrVMjibuPs+AgxmogKslaafy1oxFiorNI4s3ElSkeQZbhYQgLqiL8h6Q==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': '>=18'
+      '@types/node': ^20.19.0
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -10078,7 +10079,7 @@ packages:
     resolution: {integrity: sha512-Qp20nySRmfbuJBBsgPU7E/cL62Hf250vMZRzYDcBHty2zdD1kKCnoDFWRr0WO2ZzaXp3R7a4esaVGJUx0E6zvA==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': '>=18'
+      '@types/node': ^20.19.0
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -10087,7 +10088,7 @@ packages:
     resolution: {integrity: sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': '>=18'
+      '@types/node': ^20.19.0
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -10096,7 +10097,7 @@ packages:
     resolution: {integrity: sha512-lg9Whz8onIHRthWaN1Q9EGLa/0LFJjyM8mEUbL1eTi6yMGvBf8gvyDLtxSXztQsxMvhxxNpJYrwa1YHdq+w4Jw==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': '>=18'
+      '@types/node': ^20.19.0
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -11146,20 +11147,8 @@ packages:
   '@types/node-fetch@2.6.9':
     resolution: {integrity: sha512-bQVlnMLFJ2d35DkPNjEPmd9ueO/rh5EiaZt2bhqiSarPjZIuIV6bPQVqcrEyvNo+AfTrRGVazle1tl597w3gfA==}
 
-  '@types/node@18.15.3':
-    resolution: {integrity: sha512-p6ua9zBxz5otCmbpb5D3U4B5Nanw6Pk3PPyX05xnxbB/fRv71N7CPmORg7uAD5P70T0xmx1pzAx/FUfa5X+3cw==}
-
-  '@types/node@18.19.129':
-    resolution: {integrity: sha512-hrmi5jWt2w60ayox3iIXwpMEnfUvOLJCRtrOPbHtH15nTjvO7uhnelvrdAs0dO0/zl5DZ3ZbahiaXEVb54ca/A==}
-
-  '@types/node@18.19.130':
-    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
-
-  '@types/node@22.19.0':
-    resolution: {integrity: sha512-xpr/lmLPQEj+TUnHmR+Ab91/glhJvsqcjB+yY0Ix9GO70H6Lb4FHH5GeqdOE5btAx7eIMwuHkp4H2MSkLcqWbA==}
-
-  '@types/node@24.10.0':
-    resolution: {integrity: sha512-qzQZRBqkFsYyaSWXuEHc2WR9c0a0CXwiE5FWUvn7ZM+vdy1uZLfCunD38UzhuB7YN/J11ndbDBcTmOdxJo9Q7A==}
+  '@types/node@20.19.25':
+    resolution: {integrity: sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -13416,7 +13405,7 @@ packages:
     resolution: {integrity: sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
-      '@types/node': '*'
+      '@types/node': ^20.19.0
       ts-node: '>=9.0.0'
     peerDependenciesMeta:
       '@types/node':
@@ -15665,14 +15654,8 @@ packages:
   unbzip2-stream@1.4.3:
     resolution: {integrity: sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==}
 
-  undici-types@5.26.5:
-    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
-
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
-
-  undici-types@7.16.0:
-    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
   undici@6.21.3:
     resolution: {integrity: sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==}
@@ -15815,7 +15798,7 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
+      '@types/node': ^20.19.0
       jiti: '>=1.21.0'
       less: ^4.0.0
       lightningcss: ^1.21.0
@@ -15857,7 +15840,7 @@ packages:
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@types/debug': ^4.1.12
-      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@types/node': ^20.19.0
       '@vitest/browser-playwright': 4.0.8
       '@vitest/browser-preview': 4.0.8
       '@vitest/browser-webdriverio': 4.0.8
@@ -17993,212 +17976,158 @@ snapshots:
   '@inquirer/ansi@1.0.2':
     optional: true
 
-  '@inquirer/checkbox@4.2.4(@types/node@18.15.3)':
+  '@inquirer/checkbox@4.2.4(@types/node@20.19.25)':
     dependencies:
       '@inquirer/ansi': 1.0.0
-      '@inquirer/core': 10.2.2(@types/node@18.15.3)
+      '@inquirer/core': 10.2.2(@types/node@20.19.25)
       '@inquirer/figures': 1.0.13
-      '@inquirer/type': 3.0.8(@types/node@18.15.3)
+      '@inquirer/type': 3.0.8(@types/node@20.19.25)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 18.15.3
+      '@types/node': 20.19.25
 
-  '@inquirer/confirm@5.1.18(@types/node@18.15.3)':
+  '@inquirer/confirm@5.1.18(@types/node@20.19.25)':
     dependencies:
-      '@inquirer/core': 10.2.2(@types/node@18.15.3)
-      '@inquirer/type': 3.0.8(@types/node@18.15.3)
+      '@inquirer/core': 10.2.2(@types/node@20.19.25)
+      '@inquirer/type': 3.0.8(@types/node@20.19.25)
     optionalDependencies:
-      '@types/node': 18.15.3
+      '@types/node': 20.19.25
 
-  '@inquirer/confirm@5.1.21(@types/node@18.15.3)':
+  '@inquirer/confirm@5.1.21(@types/node@20.19.25)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@18.15.3)
-      '@inquirer/type': 3.0.10(@types/node@18.15.3)
+      '@inquirer/core': 10.3.2(@types/node@20.19.25)
+      '@inquirer/type': 3.0.10(@types/node@20.19.25)
     optionalDependencies:
-      '@types/node': 18.15.3
+      '@types/node': 20.19.25
     optional: true
 
-  '@inquirer/confirm@5.1.21(@types/node@22.19.0)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.19.0)
-      '@inquirer/type': 3.0.10(@types/node@22.19.0)
-    optionalDependencies:
-      '@types/node': 22.19.0
-    optional: true
-
-  '@inquirer/confirm@5.1.21(@types/node@24.10.0)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.10.0)
-      '@inquirer/type': 3.0.10(@types/node@24.10.0)
-    optionalDependencies:
-      '@types/node': 24.10.0
-    optional: true
-
-  '@inquirer/core@10.2.2(@types/node@18.15.3)':
+  '@inquirer/core@10.2.2(@types/node@20.19.25)':
     dependencies:
       '@inquirer/ansi': 1.0.0
       '@inquirer/figures': 1.0.13
-      '@inquirer/type': 3.0.8(@types/node@18.15.3)
+      '@inquirer/type': 3.0.8(@types/node@20.19.25)
       cli-width: 4.1.0
       mute-stream: 2.0.0
       signal-exit: 4.1.0
       wrap-ansi: 6.2.0
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 18.15.3
+      '@types/node': 20.19.25
 
-  '@inquirer/core@10.3.2(@types/node@18.15.3)':
+  '@inquirer/core@10.3.2(@types/node@20.19.25)':
     dependencies:
       '@inquirer/ansi': 1.0.2
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@18.15.3)
+      '@inquirer/type': 3.0.10(@types/node@20.19.25)
       cli-width: 4.1.0
       mute-stream: 2.0.0
       signal-exit: 4.1.0
       wrap-ansi: 6.2.0
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 18.15.3
+      '@types/node': 20.19.25
     optional: true
 
-  '@inquirer/core@10.3.2(@types/node@22.19.0)':
+  '@inquirer/editor@4.2.20(@types/node@20.19.25)':
     dependencies:
-      '@inquirer/ansi': 1.0.2
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@22.19.0)
-      cli-width: 4.1.0
-      mute-stream: 2.0.0
-      signal-exit: 4.1.0
-      wrap-ansi: 6.2.0
+      '@inquirer/core': 10.2.2(@types/node@20.19.25)
+      '@inquirer/external-editor': 1.0.2(@types/node@20.19.25)
+      '@inquirer/type': 3.0.8(@types/node@20.19.25)
+    optionalDependencies:
+      '@types/node': 20.19.25
+
+  '@inquirer/expand@4.0.20(@types/node@20.19.25)':
+    dependencies:
+      '@inquirer/core': 10.2.2(@types/node@20.19.25)
+      '@inquirer/type': 3.0.8(@types/node@20.19.25)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 22.19.0
-    optional: true
+      '@types/node': 20.19.25
 
-  '@inquirer/core@10.3.2(@types/node@24.10.0)':
-    dependencies:
-      '@inquirer/ansi': 1.0.2
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@24.10.0)
-      cli-width: 4.1.0
-      mute-stream: 2.0.0
-      signal-exit: 4.1.0
-      wrap-ansi: 6.2.0
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 24.10.0
-    optional: true
-
-  '@inquirer/editor@4.2.20(@types/node@18.15.3)':
-    dependencies:
-      '@inquirer/core': 10.2.2(@types/node@18.15.3)
-      '@inquirer/external-editor': 1.0.2(@types/node@18.15.3)
-      '@inquirer/type': 3.0.8(@types/node@18.15.3)
-    optionalDependencies:
-      '@types/node': 18.15.3
-
-  '@inquirer/expand@4.0.20(@types/node@18.15.3)':
-    dependencies:
-      '@inquirer/core': 10.2.2(@types/node@18.15.3)
-      '@inquirer/type': 3.0.8(@types/node@18.15.3)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 18.15.3
-
-  '@inquirer/external-editor@1.0.2(@types/node@18.15.3)':
+  '@inquirer/external-editor@1.0.2(@types/node@20.19.25)':
     dependencies:
       chardet: 2.1.0
       iconv-lite: 0.7.0
     optionalDependencies:
-      '@types/node': 18.15.3
+      '@types/node': 20.19.25
 
   '@inquirer/figures@1.0.13': {}
 
   '@inquirer/figures@1.0.15':
     optional: true
 
-  '@inquirer/input@4.2.4(@types/node@18.15.3)':
+  '@inquirer/input@4.2.4(@types/node@20.19.25)':
     dependencies:
-      '@inquirer/core': 10.2.2(@types/node@18.15.3)
-      '@inquirer/type': 3.0.8(@types/node@18.15.3)
+      '@inquirer/core': 10.2.2(@types/node@20.19.25)
+      '@inquirer/type': 3.0.8(@types/node@20.19.25)
     optionalDependencies:
-      '@types/node': 18.15.3
+      '@types/node': 20.19.25
 
-  '@inquirer/number@3.0.20(@types/node@18.15.3)':
+  '@inquirer/number@3.0.20(@types/node@20.19.25)':
     dependencies:
-      '@inquirer/core': 10.2.2(@types/node@18.15.3)
-      '@inquirer/type': 3.0.8(@types/node@18.15.3)
+      '@inquirer/core': 10.2.2(@types/node@20.19.25)
+      '@inquirer/type': 3.0.8(@types/node@20.19.25)
     optionalDependencies:
-      '@types/node': 18.15.3
+      '@types/node': 20.19.25
 
-  '@inquirer/password@4.0.20(@types/node@18.15.3)':
-    dependencies:
-      '@inquirer/ansi': 1.0.0
-      '@inquirer/core': 10.2.2(@types/node@18.15.3)
-      '@inquirer/type': 3.0.8(@types/node@18.15.3)
-    optionalDependencies:
-      '@types/node': 18.15.3
-
-  '@inquirer/prompts@7.8.6(@types/node@18.15.3)':
-    dependencies:
-      '@inquirer/checkbox': 4.2.4(@types/node@18.15.3)
-      '@inquirer/confirm': 5.1.18(@types/node@18.15.3)
-      '@inquirer/editor': 4.2.20(@types/node@18.15.3)
-      '@inquirer/expand': 4.0.20(@types/node@18.15.3)
-      '@inquirer/input': 4.2.4(@types/node@18.15.3)
-      '@inquirer/number': 3.0.20(@types/node@18.15.3)
-      '@inquirer/password': 4.0.20(@types/node@18.15.3)
-      '@inquirer/rawlist': 4.1.8(@types/node@18.15.3)
-      '@inquirer/search': 3.1.3(@types/node@18.15.3)
-      '@inquirer/select': 4.3.4(@types/node@18.15.3)
-    optionalDependencies:
-      '@types/node': 18.15.3
-
-  '@inquirer/rawlist@4.1.8(@types/node@18.15.3)':
-    dependencies:
-      '@inquirer/core': 10.2.2(@types/node@18.15.3)
-      '@inquirer/type': 3.0.8(@types/node@18.15.3)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 18.15.3
-
-  '@inquirer/search@3.1.3(@types/node@18.15.3)':
-    dependencies:
-      '@inquirer/core': 10.2.2(@types/node@18.15.3)
-      '@inquirer/figures': 1.0.13
-      '@inquirer/type': 3.0.8(@types/node@18.15.3)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 18.15.3
-
-  '@inquirer/select@4.3.4(@types/node@18.15.3)':
+  '@inquirer/password@4.0.20(@types/node@20.19.25)':
     dependencies:
       '@inquirer/ansi': 1.0.0
-      '@inquirer/core': 10.2.2(@types/node@18.15.3)
-      '@inquirer/figures': 1.0.13
-      '@inquirer/type': 3.0.8(@types/node@18.15.3)
+      '@inquirer/core': 10.2.2(@types/node@20.19.25)
+      '@inquirer/type': 3.0.8(@types/node@20.19.25)
+    optionalDependencies:
+      '@types/node': 20.19.25
+
+  '@inquirer/prompts@7.8.6(@types/node@20.19.25)':
+    dependencies:
+      '@inquirer/checkbox': 4.2.4(@types/node@20.19.25)
+      '@inquirer/confirm': 5.1.18(@types/node@20.19.25)
+      '@inquirer/editor': 4.2.20(@types/node@20.19.25)
+      '@inquirer/expand': 4.0.20(@types/node@20.19.25)
+      '@inquirer/input': 4.2.4(@types/node@20.19.25)
+      '@inquirer/number': 3.0.20(@types/node@20.19.25)
+      '@inquirer/password': 4.0.20(@types/node@20.19.25)
+      '@inquirer/rawlist': 4.1.8(@types/node@20.19.25)
+      '@inquirer/search': 3.1.3(@types/node@20.19.25)
+      '@inquirer/select': 4.3.4(@types/node@20.19.25)
+    optionalDependencies:
+      '@types/node': 20.19.25
+
+  '@inquirer/rawlist@4.1.8(@types/node@20.19.25)':
+    dependencies:
+      '@inquirer/core': 10.2.2(@types/node@20.19.25)
+      '@inquirer/type': 3.0.8(@types/node@20.19.25)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 18.15.3
+      '@types/node': 20.19.25
 
-  '@inquirer/type@3.0.10(@types/node@18.15.3)':
+  '@inquirer/search@3.1.3(@types/node@20.19.25)':
+    dependencies:
+      '@inquirer/core': 10.2.2(@types/node@20.19.25)
+      '@inquirer/figures': 1.0.13
+      '@inquirer/type': 3.0.8(@types/node@20.19.25)
+      yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 18.15.3
+      '@types/node': 20.19.25
+
+  '@inquirer/select@4.3.4(@types/node@20.19.25)':
+    dependencies:
+      '@inquirer/ansi': 1.0.0
+      '@inquirer/core': 10.2.2(@types/node@20.19.25)
+      '@inquirer/figures': 1.0.13
+      '@inquirer/type': 3.0.8(@types/node@20.19.25)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 20.19.25
+
+  '@inquirer/type@3.0.10(@types/node@20.19.25)':
+    optionalDependencies:
+      '@types/node': 20.19.25
     optional: true
 
-  '@inquirer/type@3.0.10(@types/node@22.19.0)':
+  '@inquirer/type@3.0.8(@types/node@20.19.25)':
     optionalDependencies:
-      '@types/node': 22.19.0
-    optional: true
-
-  '@inquirer/type@3.0.10(@types/node@24.10.0)':
-    optionalDependencies:
-      '@types/node': 24.10.0
-    optional: true
-
-  '@inquirer/type@3.0.8(@types/node@18.15.3)':
-    optionalDependencies:
-      '@types/node': 18.15.3
+      '@types/node': 20.19.25
 
   '@isaacs/balanced-match@4.0.1': {}
 
@@ -18228,7 +18157,7 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 18.19.130
+      '@types/node': 20.19.25
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -18241,14 +18170,14 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.130
+      '@types/node': 20.19.25
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)
+      jest-config: 29.7.0(@types/node@20.19.25)(babel-plugin-macros@3.1.0)
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -18275,7 +18204,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.130
+      '@types/node': 20.19.25
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -18293,7 +18222,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 18.19.130
+      '@types/node': 20.19.25
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -18311,7 +18240,7 @@ snapshots:
 
   '@jest/pattern@30.0.1':
     dependencies:
-      '@types/node': 18.19.130
+      '@types/node': 20.19.25
       jest-regex-util: 30.0.1
     optional: true
 
@@ -18323,7 +18252,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.31
-      '@types/node': 18.19.130
+      '@types/node': 20.19.25
       chalk: 4.1.2
       collect-v8-coverage: 1.0.3
       exit: 0.1.2
@@ -18418,7 +18347,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 18.19.130
+      '@types/node': 20.19.25
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
@@ -18428,7 +18357,7 @@ snapshots:
       '@jest/schemas': 30.0.5
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 18.19.130
+      '@types/node': 20.19.25
       '@types/yargs': 17.0.34
       chalk: 4.1.2
     optional: true
@@ -19318,7 +19247,7 @@ snapshots:
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 18.19.130
+      '@types/node': 20.19.25
 
   '@types/boxen@3.0.5':
     dependencies:
@@ -19331,15 +19260,15 @@ snapshots:
 
   '@types/cli-progress@3.11.6':
     dependencies:
-      '@types/node': 18.19.130
+      '@types/node': 20.19.25
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 18.19.130
+      '@types/node': 20.19.25
 
   '@types/cors@2.8.19':
     dependencies:
-      '@types/node': 18.19.130
+      '@types/node': 20.19.25
 
   '@types/debug@4.1.12':
     dependencies:
@@ -19347,7 +19276,7 @@ snapshots:
 
   '@types/decompress@4.2.7':
     dependencies:
-      '@types/node': 18.15.3
+      '@types/node': 20.19.25
 
   '@types/deep-eql@4.0.2': {}
 
@@ -19363,7 +19292,7 @@ snapshots:
 
   '@types/express-serve-static-core@4.19.6':
     dependencies:
-      '@types/node': 18.19.130
+      '@types/node': 20.19.25
       '@types/qs': 6.9.15
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.5
@@ -19384,7 +19313,7 @@ snapshots:
   '@types/fs-extra@11.0.4':
     dependencies:
       '@types/jsonfile': 6.1.4
-      '@types/node': 18.19.130
+      '@types/node': 20.19.25
 
   '@types/get-port@4.2.0':
     dependencies:
@@ -19392,7 +19321,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 18.19.130
+      '@types/node': 20.19.25
 
   '@types/har-format@1.2.16': {}
 
@@ -19432,12 +19361,12 @@ snapshots:
 
   '@types/jsonfile@6.1.4':
     dependencies:
-      '@types/node': 18.19.130
+      '@types/node': 20.19.25
 
   '@types/jsonwebtoken@9.0.10':
     dependencies:
       '@types/ms': 2.1.0
-      '@types/node': 18.19.130
+      '@types/node': 20.19.25
 
   '@types/katex@0.16.7': {}
 
@@ -19469,27 +19398,12 @@ snapshots:
 
   '@types/node-fetch@2.6.9':
     dependencies:
-      '@types/node': 18.19.130
+      '@types/node': 20.19.25
       form-data: 4.0.4
 
-  '@types/node@18.15.3': {}
-
-  '@types/node@18.19.129':
-    dependencies:
-      undici-types: 5.26.5
-
-  '@types/node@18.19.130':
-    dependencies:
-      undici-types: 5.26.5
-
-  '@types/node@22.19.0':
+  '@types/node@20.19.25':
     dependencies:
       undici-types: 6.21.0
-
-  '@types/node@24.10.0':
-    dependencies:
-      undici-types: 7.16.0
-    optional: true
 
   '@types/normalize-package-data@2.4.4': {}
 
@@ -19515,19 +19429,19 @@ snapshots:
 
   '@types/readable-stream@4.0.22':
     dependencies:
-      '@types/node': 18.19.130
+      '@types/node': 20.19.25
 
   '@types/semver@7.7.1': {}
 
   '@types/send@0.17.5':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 18.19.130
+      '@types/node': 20.19.25
 
   '@types/serve-static@1.15.8':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 18.19.130
+      '@types/node': 20.19.25
       '@types/send': 0.17.5
 
   '@types/stack-utils@2.0.3': {}
@@ -19537,21 +19451,21 @@ snapshots:
 
   '@types/stream-chain@2.1.0':
     dependencies:
-      '@types/node': 18.19.130
+      '@types/node': 20.19.25
 
   '@types/stream-json@1.7.8':
     dependencies:
-      '@types/node': 18.19.130
+      '@types/node': 20.19.25
       '@types/stream-chain': 2.1.0
 
   '@types/swagger2openapi@7.0.4':
     dependencies:
-      '@types/node': 18.19.130
+      '@types/node': 20.19.25
       openapi-types: 12.1.3
 
   '@types/tar@6.1.13':
     dependencies:
-      '@types/node': 18.19.130
+      '@types/node': 20.19.25
       minipass: 4.2.8
 
   '@types/terminal-link@1.2.0':
@@ -19560,7 +19474,7 @@ snapshots:
 
   '@types/through@0.0.33':
     dependencies:
-      '@types/node': 18.19.130
+      '@types/node': 20.19.25
 
   '@types/tinycolor2@1.4.6': {}
 
@@ -19584,11 +19498,11 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 18.19.130
+      '@types/node': 20.19.25
 
   '@types/xml2js@0.4.14':
     dependencies:
-      '@types/node': 18.19.130
+      '@types/node': 20.19.25
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -19603,7 +19517,7 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 18.19.130
+      '@types/node': 20.19.25
     optional: true
 
   '@typescript-eslint/project-service@8.45.0(typescript@5.9.3)':
@@ -19676,41 +19590,23 @@ snapshots:
       chai: 6.2.1
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.8(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.2))(vite@7.2.2(@types/node@18.15.3)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3))':
+  '@vitest/mocker@4.0.8(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.2))(vite@7.2.2(@types/node@20.19.25)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3))':
     dependencies:
       '@vitest/spy': 4.0.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      msw: 2.12.1(@types/node@18.15.3)(typescript@5.9.2)
-      vite: 7.2.2(@types/node@18.15.3)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+      msw: 2.12.1(@types/node@20.19.25)(typescript@5.9.2)
+      vite: 7.2.2(@types/node@20.19.25)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
-  '@vitest/mocker@4.0.8(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(vite@7.2.2(@types/node@18.15.3)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3))':
+  '@vitest/mocker@4.0.8(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(vite@7.2.2(@types/node@20.19.25)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3))':
     dependencies:
       '@vitest/spy': 4.0.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      msw: 2.12.1(@types/node@18.15.3)(typescript@5.9.3)
-      vite: 7.2.2(@types/node@18.15.3)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
-
-  '@vitest/mocker@4.0.8(msw@2.12.1(@types/node@22.19.0)(typescript@5.9.3))(vite@7.2.2(@types/node@22.19.0)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3))':
-    dependencies:
-      '@vitest/spy': 4.0.8
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      msw: 2.12.1(@types/node@22.19.0)(typescript@5.9.3)
-      vite: 7.2.2(@types/node@22.19.0)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
-
-  '@vitest/mocker@4.0.8(msw@2.12.1(@types/node@24.10.0)(typescript@5.9.3))(vite@7.2.2(@types/node@24.10.0)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3))':
-    dependencies:
-      '@vitest/spy': 4.0.8
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      msw: 2.12.1(@types/node@24.10.0)(typescript@5.9.3)
-      vite: 7.2.2(@types/node@24.10.0)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+      msw: 2.12.1(@types/node@20.19.25)(typescript@5.9.3)
+      vite: 7.2.2(@types/node@20.19.25)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
   '@vitest/pretty-format@4.0.8':
     dependencies:
@@ -20465,13 +20361,13 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  create-jest@29.7.0(@types/node@18.19.129)(babel-plugin-macros@3.1.0):
+  create-jest@29.7.0(@types/node@20.19.25)(babel-plugin-macros@3.1.0):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@18.19.129)(babel-plugin-macros@3.1.0)
+      jest-config: 29.7.0(@types/node@20.19.25)(babel-plugin-macros@3.1.0)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -21961,9 +21857,9 @@ snapshots:
 
   inline-style-parser@0.2.4: {}
 
-  inquirer@9.3.8(@types/node@18.15.3):
+  inquirer@9.3.8(@types/node@20.19.25):
     dependencies:
-      '@inquirer/external-editor': 1.0.2(@types/node@18.15.3)
+      '@inquirer/external-editor': 1.0.2(@types/node@20.19.25)
       '@inquirer/figures': 1.0.13
       ansi-escapes: 4.3.2
       cli-width: 4.1.0
@@ -22142,7 +22038,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.130
+      '@types/node': 20.19.25
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.7.0(babel-plugin-macros@3.1.0)
@@ -22162,16 +22058,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@18.19.129)(babel-plugin-macros@3.1.0):
+  jest-cli@29.7.0(@types/node@20.19.25)(babel-plugin-macros@3.1.0):
     dependencies:
       '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@18.19.129)(babel-plugin-macros@3.1.0)
+      create-jest: 29.7.0(@types/node@20.19.25)(babel-plugin-macros@3.1.0)
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@18.19.129)(babel-plugin-macros@3.1.0)
+      jest-config: 29.7.0(@types/node@20.19.25)(babel-plugin-macros@3.1.0)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -22181,7 +22077,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@18.19.129)(babel-plugin-macros@3.1.0):
+  jest-config@29.7.0(@types/node@20.19.25)(babel-plugin-macros@3.1.0):
     dependencies:
       '@babel/core': 7.28.4
       '@jest/test-sequencer': 29.7.0
@@ -22206,37 +22102,7 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 18.19.129
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@29.7.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0):
-    dependencies:
-      '@babel/core': 7.28.4
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.28.4)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0(babel-plugin-macros@3.1.0)
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 18.19.130
+      '@types/node': 20.19.25
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -22272,7 +22138,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.130
+      '@types/node': 20.19.25
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -22282,7 +22148,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 18.19.130
+      '@types/node': 20.19.25
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -22297,7 +22163,7 @@ snapshots:
   jest-haste-map@30.2.0:
     dependencies:
       '@jest/types': 30.2.0
-      '@types/node': 18.19.130
+      '@types/node': 20.19.25
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -22337,7 +22203,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 18.19.130
+      '@types/node': 20.19.25
       jest-util: 29.7.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
@@ -22375,7 +22241,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.130
+      '@types/node': 20.19.25
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -22403,7 +22269,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.130
+      '@types/node': 20.19.25
       chalk: 4.1.2
       cjs-module-lexer: 1.4.3
       collect-v8-coverage: 1.0.3
@@ -22449,7 +22315,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 18.19.130
+      '@types/node': 20.19.25
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -22458,7 +22324,7 @@ snapshots:
   jest-util@30.2.0:
     dependencies:
       '@jest/types': 30.2.0
-      '@types/node': 18.19.130
+      '@types/node': 20.19.25
       chalk: 4.1.2
       ci-info: 4.3.1
       graceful-fs: 4.2.11
@@ -22478,7 +22344,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.130
+      '@types/node': 20.19.25
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -22487,26 +22353,26 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 18.19.130
+      '@types/node': 20.19.25
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
   jest-worker@30.2.0:
     dependencies:
-      '@types/node': 18.19.130
+      '@types/node': 20.19.25
       '@ungap/structured-clone': 1.3.0
       jest-util: 30.2.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
     optional: true
 
-  jest@29.7.0(@types/node@18.19.129)(babel-plugin-macros@3.1.0):
+  jest@29.7.0(@types/node@20.19.25)(babel-plugin-macros@3.1.0):
     dependencies:
       '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@18.19.129)(babel-plugin-macros@3.1.0)
+      jest-cli: 29.7.0(@types/node@20.19.25)(babel-plugin-macros@3.1.0)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -23348,9 +23214,9 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@2.12.1(@types/node@18.15.3)(typescript@5.9.2):
+  msw@2.12.1(@types/node@20.19.25)(typescript@5.9.2):
     dependencies:
-      '@inquirer/confirm': 5.1.21(@types/node@18.15.3)
+      '@inquirer/confirm': 5.1.21(@types/node@20.19.25)
       '@mswjs/interceptors': 0.40.0
       '@open-draft/deferred-promise': 2.2.0
       '@types/statuses': 2.0.6
@@ -23374,61 +23240,9 @@ snapshots:
       - '@types/node'
     optional: true
 
-  msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3):
+  msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3):
     dependencies:
-      '@inquirer/confirm': 5.1.21(@types/node@18.15.3)
-      '@mswjs/interceptors': 0.40.0
-      '@open-draft/deferred-promise': 2.2.0
-      '@types/statuses': 2.0.6
-      cookie: 1.0.2
-      graphql: 16.12.0
-      headers-polyfill: 4.0.3
-      is-node-process: 1.2.0
-      outvariant: 1.4.3
-      path-to-regexp: 6.3.0
-      picocolors: 1.1.1
-      rettime: 0.7.0
-      statuses: 2.0.2
-      strict-event-emitter: 0.5.1
-      tough-cookie: 6.0.0
-      type-fest: 4.41.0
-      until-async: 3.0.2
-      yargs: 17.7.2
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@types/node'
-    optional: true
-
-  msw@2.12.1(@types/node@22.19.0)(typescript@5.9.3):
-    dependencies:
-      '@inquirer/confirm': 5.1.21(@types/node@22.19.0)
-      '@mswjs/interceptors': 0.40.0
-      '@open-draft/deferred-promise': 2.2.0
-      '@types/statuses': 2.0.6
-      cookie: 1.0.2
-      graphql: 16.12.0
-      headers-polyfill: 4.0.3
-      is-node-process: 1.2.0
-      outvariant: 1.4.3
-      path-to-regexp: 6.3.0
-      picocolors: 1.1.1
-      rettime: 0.7.0
-      statuses: 2.0.2
-      strict-event-emitter: 0.5.1
-      tough-cookie: 6.0.0
-      type-fest: 4.41.0
-      until-async: 3.0.2
-      yargs: 17.7.2
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@types/node'
-    optional: true
-
-  msw@2.12.1(@types/node@24.10.0)(typescript@5.9.3):
-    dependencies:
-      '@inquirer/confirm': 5.1.21(@types/node@24.10.0)
+      '@inquirer/confirm': 5.1.21(@types/node@20.19.25)
       '@mswjs/interceptors': 0.40.0
       '@open-draft/deferred-promise': 2.2.0
       '@types/statuses': 2.0.6
@@ -25160,12 +24974,12 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest@29.4.5(@babel/core@7.28.4)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.4))(jest-util@30.2.0)(jest@29.7.0(@types/node@18.19.129)(babel-plugin-macros@3.1.0))(typescript@5.9.3):
+  ts-jest@29.4.5(@babel/core@7.28.4)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.4))(jest-util@30.2.0)(jest@29.7.0(@types/node@20.19.25)(babel-plugin-macros@3.1.0))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.8
-      jest: 29.7.0(@types/node@18.19.129)(babel-plugin-macros@3.1.0)
+      jest: 29.7.0(@types/node@20.19.25)(babel-plugin-macros@3.1.0)
       json5: 2.2.2
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -25344,12 +25158,7 @@ snapshots:
       buffer: 5.7.1
       through: 2.3.8
 
-  undici-types@5.26.5: {}
-
   undici-types@6.21.0: {}
-
-  undici-types@7.16.0:
-    optional: true
 
   undici@6.21.3: {}
 
@@ -25498,7 +25307,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@7.2.2(@types/node@18.15.3)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3):
+  vite@7.2.2(@types/node@20.19.25)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
@@ -25507,49 +25316,17 @@ snapshots:
       rollup: 4.53.2
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 18.15.3
+      '@types/node': 20.19.25
       fsevents: 2.3.3
       sass: 1.94.0
       terser: 5.44.1
       tsx: 4.20.6
       yaml: 2.3.3
 
-  vite@7.2.2(@types/node@22.19.0)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3):
-    dependencies:
-      esbuild: 0.25.12
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.53.2
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 22.19.0
-      fsevents: 2.3.3
-      sass: 1.94.0
-      terser: 5.44.1
-      tsx: 4.20.6
-      yaml: 2.3.3
-
-  vite@7.2.2(@types/node@24.10.0)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3):
-    dependencies:
-      esbuild: 0.25.12
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.53.2
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 24.10.0
-      fsevents: 2.3.3
-      sass: 1.94.0
-      terser: 5.44.1
-      tsx: 4.20.6
-      yaml: 2.3.3
-
-  vitest@4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.2))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3):
+  vitest@4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.2))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3):
     dependencies:
       '@vitest/expect': 4.0.8
-      '@vitest/mocker': 4.0.8(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.2))(vite@7.2.2(@types/node@18.15.3)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3))
+      '@vitest/mocker': 4.0.8(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.2))(vite@7.2.2(@types/node@20.19.25)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3))
       '@vitest/pretty-format': 4.0.8
       '@vitest/runner': 4.0.8
       '@vitest/snapshot': 4.0.8
@@ -25566,11 +25343,11 @@ snapshots:
       tinyexec: 0.3.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.2.2(@types/node@18.15.3)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+      vite: 7.2.2(@types/node@20.19.25)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
-      '@types/node': 18.15.3
+      '@types/node': 20.19.25
       jsdom: 27.1.0
     transitivePeerDependencies:
       - jiti
@@ -25586,10 +25363,10 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3):
+  vitest@4.0.8(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@27.1.0)(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3):
     dependencies:
       '@vitest/expect': 4.0.8
-      '@vitest/mocker': 4.0.8(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(vite@7.2.2(@types/node@18.15.3)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3))
+      '@vitest/mocker': 4.0.8(msw@2.12.1(@types/node@20.19.25)(typescript@5.9.3))(vite@7.2.2(@types/node@20.19.25)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3))
       '@vitest/pretty-format': 4.0.8
       '@vitest/runner': 4.0.8
       '@vitest/snapshot': 4.0.8
@@ -25606,91 +25383,11 @@ snapshots:
       tinyexec: 0.3.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.2.2(@types/node@18.15.3)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+      vite: 7.2.2(@types/node@20.19.25)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
-      '@types/node': 18.15.3
-      jsdom: 27.1.0
-    transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
-  vitest@4.0.8(@types/debug@4.1.12)(@types/node@22.19.0)(jsdom@27.1.0)(msw@2.12.1(@types/node@22.19.0)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3):
-    dependencies:
-      '@vitest/expect': 4.0.8
-      '@vitest/mocker': 4.0.8(msw@2.12.1(@types/node@22.19.0)(typescript@5.9.3))(vite@7.2.2(@types/node@22.19.0)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3))
-      '@vitest/pretty-format': 4.0.8
-      '@vitest/runner': 4.0.8
-      '@vitest/snapshot': 4.0.8
-      '@vitest/spy': 4.0.8
-      '@vitest/utils': 4.0.8
-      debug: 4.4.3
-      es-module-lexer: 1.7.0
-      expect-type: 1.2.2
-      magic-string: 0.30.21
-      pathe: 2.0.3
-      picomatch: 4.0.3
-      std-env: 3.10.0
-      tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.15
-      tinyrainbow: 3.0.3
-      vite: 7.2.2(@types/node@22.19.0)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/debug': 4.1.12
-      '@types/node': 22.19.0
-      jsdom: 27.1.0
-    transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
-  vitest@4.0.8(@types/debug@4.1.12)(@types/node@24.10.0)(jsdom@27.1.0)(msw@2.12.1(@types/node@24.10.0)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3):
-    dependencies:
-      '@vitest/expect': 4.0.8
-      '@vitest/mocker': 4.0.8(msw@2.12.1(@types/node@24.10.0)(typescript@5.9.3))(vite@7.2.2(@types/node@24.10.0)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3))
-      '@vitest/pretty-format': 4.0.8
-      '@vitest/runner': 4.0.8
-      '@vitest/snapshot': 4.0.8
-      '@vitest/spy': 4.0.8
-      '@vitest/utils': 4.0.8
-      debug: 4.4.3
-      es-module-lexer: 1.7.0
-      expect-type: 1.2.2
-      magic-string: 0.30.21
-      pathe: 2.0.3
-      picomatch: 4.0.3
-      std-env: 3.10.0
-      tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.15
-      tinyrainbow: 3.0.3
-      vite: 7.2.2(@types/node@24.10.0)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/debug': 4.1.12
-      '@types/node': 24.10.0
+      '@types/node': 20.19.25
       jsdom: 27.1.0
     transitivePeerDependencies:
       - jiti

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,7 +20,7 @@ overrides:
   es-toolkit: ^1.39.10
   ts-essentials: ^10.1.1
   form-data: ^4.0.4
-  '@types/node@': ^20.19.0
+  '@types/node': ^20.19.0
 
 importers:
 


### PR DESCRIPTION
## Description
Linear ticket: Closes N/A
<!-- Fixes peer dependency errors after vite update and TypeScript compilation errors with @types/node@20+ -->

This PR resolves peer dependency warnings and TypeScript compilation errors that occurred after upgrading vite. The issue was caused by vitest 4.0.8 and vite 7.2.2 requiring @types/node@^20.19.0 or higher, while the repo was using @types/node@18.15.3.

## Changes Made
- Added `@types/node: ^20.19.0` to pnpm overrides in root package.json to enforce consistent Node types across the monorepo
- Updated `packages/snippets/core/package.json` to use `@types/node@^20.19.25` (was `18.15.3`)
- Fixed `TtyAwareLogger.ts` to use `ReturnType<typeof setInterval>` instead of `NodeJS.Timer` (the Timer type was removed/changed in @types/node@20+)
- Updated pnpm-lock.yaml to reflect the new @types/node version throughout the dependency tree

## Testing
- [x] Manual testing completed - compiled locally with `pnpm compile --filter=@fern-api/cli` and `pnpm check`
- [x] CI passed all checks (compile, lint, test, test-ete)

## Review Checklist
**Critical change**: The `NodeJS.Timer` → `ReturnType<typeof setInterval>` change in `TtyAwareLogger.ts:15` is the only code change. This is the correct fix for @types/node@20+ compatibility, where the Timer type was replaced with Timeout. Using `ReturnType<typeof setInterval>` is the recommended cross-platform approach.

**Verification**: Searched the entire codebase for `NodeJS.Timer` and `\bTimer\b` - only one usage found in TtyAwareLogger.ts (now fixed). The C# codegen file that appeared in search results is just a string literal, not a type usage.

---

**Link to Devin run**: https://app.devin.ai/sessions/8efcd4cf223944219ec65474e7a24f8e  
**Requested by**: David Konigsberg (@davidkonigsberg)