### PR TITLE
fix(java): support custom OAuth properties including headers in token supplier

### DIFF
--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,3 +1,11 @@
+- version: 3.16.1
+  changelogEntry:
+    - summary: |
+        Fix OAuth client credentials token supplier to support custom properties and headers. OAuth token endpoints can now include custom headers (e.g., x-api-key) and custom body properties (e.g., entity_id) in addition to standard OAuth fields (client_id, client_secret, scopes). This enables authentication with non-standard OAuth implementations that require additional parameters.
+      type: fix
+  createdAt: "2025-11-18"
+  irVersion: 61
+
 - version: 3.16.0
   changelogEntry:
     - summary: |

--- a/seed/java-sdk/oauth-client-credentials-custom/src/main/java/com/seed/oauthClientCredentials/AsyncSeedOauthClientCredentialsClientBuilder.java
+++ b/seed/java-sdk/oauth-client-credentials-custom/src/main/java/com/seed/oauthClientCredentials/AsyncSeedOauthClientCredentialsClientBuilder.java
@@ -23,6 +23,14 @@ public class AsyncSeedOauthClientCredentialsClientBuilder {
 
     private String clientSecret = null;
 
+    private String entityId = null;
+
+    private String audience = null;
+
+    private String grantType = null;
+
+    private String scope = null;
+
     private Environment environment;
 
     private OkHttpClient httpClient;
@@ -40,6 +48,38 @@ public class AsyncSeedOauthClientCredentialsClientBuilder {
      */
     public AsyncSeedOauthClientCredentialsClientBuilder clientSecret(String clientSecret) {
         this.clientSecret = clientSecret;
+        return this;
+    }
+
+    /**
+     * Sets entityId
+     */
+    public AsyncSeedOauthClientCredentialsClientBuilder entityId(String entityId) {
+        this.entityId = entityId;
+        return this;
+    }
+
+    /**
+     * Sets audience
+     */
+    public AsyncSeedOauthClientCredentialsClientBuilder audience(String audience) {
+        this.audience = audience;
+        return this;
+    }
+
+    /**
+     * Sets grantType
+     */
+    public AsyncSeedOauthClientCredentialsClientBuilder grantType(String grantType) {
+        this.grantType = grantType;
+        return this;
+    }
+
+    /**
+     * Sets scope
+     */
+    public AsyncSeedOauthClientCredentialsClientBuilder scope(String scope) {
+        this.scope = scope;
         return this;
     }
 
@@ -129,8 +169,14 @@ public class AsyncSeedOauthClientCredentialsClientBuilder {
             ClientOptions.Builder authClientOptionsBuilder =
                     ClientOptions.builder().environment(this.environment);
             AuthClient authClient = new AuthClient(authClientOptionsBuilder.build());
-            OAuthTokenSupplier oAuthTokenSupplier =
-                    new OAuthTokenSupplier(this.clientId, this.clientSecret, authClient);
+            OAuthTokenSupplier oAuthTokenSupplier = new OAuthTokenSupplier(
+                    this.clientId,
+                    this.clientSecret,
+                    this.entityId,
+                    this.audience,
+                    this.grantType,
+                    this.scope,
+                    authClient);
             builder.addHeader("Authorization", oAuthTokenSupplier);
         }
     }

--- a/seed/java-sdk/oauth-client-credentials-custom/src/main/java/com/seed/oauthClientCredentials/SeedOauthClientCredentialsClientBuilder.java
+++ b/seed/java-sdk/oauth-client-credentials-custom/src/main/java/com/seed/oauthClientCredentials/SeedOauthClientCredentialsClientBuilder.java
@@ -23,6 +23,14 @@ public class SeedOauthClientCredentialsClientBuilder {
 
     private String clientSecret = null;
 
+    private String entityId = null;
+
+    private String audience = null;
+
+    private String grantType = null;
+
+    private String scope = null;
+
     private Environment environment;
 
     private OkHttpClient httpClient;
@@ -40,6 +48,38 @@ public class SeedOauthClientCredentialsClientBuilder {
      */
     public SeedOauthClientCredentialsClientBuilder clientSecret(String clientSecret) {
         this.clientSecret = clientSecret;
+        return this;
+    }
+
+    /**
+     * Sets entityId
+     */
+    public SeedOauthClientCredentialsClientBuilder entityId(String entityId) {
+        this.entityId = entityId;
+        return this;
+    }
+
+    /**
+     * Sets audience
+     */
+    public SeedOauthClientCredentialsClientBuilder audience(String audience) {
+        this.audience = audience;
+        return this;
+    }
+
+    /**
+     * Sets grantType
+     */
+    public SeedOauthClientCredentialsClientBuilder grantType(String grantType) {
+        this.grantType = grantType;
+        return this;
+    }
+
+    /**
+     * Sets scope
+     */
+    public SeedOauthClientCredentialsClientBuilder scope(String scope) {
+        this.scope = scope;
         return this;
     }
 
@@ -129,8 +169,14 @@ public class SeedOauthClientCredentialsClientBuilder {
             ClientOptions.Builder authClientOptionsBuilder =
                     ClientOptions.builder().environment(this.environment);
             AuthClient authClient = new AuthClient(authClientOptionsBuilder.build());
-            OAuthTokenSupplier oAuthTokenSupplier =
-                    new OAuthTokenSupplier(this.clientId, this.clientSecret, authClient);
+            OAuthTokenSupplier oAuthTokenSupplier = new OAuthTokenSupplier(
+                    this.clientId,
+                    this.clientSecret,
+                    this.entityId,
+                    this.audience,
+                    this.grantType,
+                    this.scope,
+                    authClient);
             builder.addHeader("Authorization", oAuthTokenSupplier);
         }
     }

--- a/seed/java-sdk/oauth-client-credentials-custom/src/main/java/com/seed/oauthClientCredentials/core/OAuthTokenSupplier.java
+++ b/seed/java-sdk/oauth-client-credentials-custom/src/main/java/com/seed/oauthClientCredentials/core/OAuthTokenSupplier.java
@@ -17,22 +17,47 @@ public final class OAuthTokenSupplier implements Supplier<String> {
 
     private final String clientSecret;
 
+    private final String entityId;
+
+    private final String audience;
+
+    private final String grantType;
+
+    private final String scope;
+
     private final AuthClient authClient;
 
     private String accessToken;
 
     private Instant expiresAt;
 
-    public OAuthTokenSupplier(String clientId, String clientSecret, AuthClient authClient) {
+    public OAuthTokenSupplier(
+            String clientId,
+            String clientSecret,
+            String entityId,
+            String audience,
+            String grantType,
+            String scope,
+            AuthClient authClient) {
         this.clientId = clientId;
         this.clientSecret = clientSecret;
+        this.entityId = entityId;
+        this.audience = audience;
+        this.grantType = grantType;
+        this.scope = scope;
         this.authClient = authClient;
         this.expiresAt = Instant.now();
     }
 
     public TokenResponse fetchToken() {
-        GetTokenRequest getTokenRequest =
-                GetTokenRequest.builder().cid(clientId).csr(clientSecret).build();
+        GetTokenRequest getTokenRequest = GetTokenRequest.builder()
+                .entityId(entityId)
+                .audience(audience)
+                .grantType(grantType)
+                .scope(scope)
+                .cid(clientId)
+                .csr(clientSecret)
+                .build();
         return authClient.getTokenWithClientCredentials(getTokenRequest);
     }
 


### PR DESCRIPTION
## Description
Linear ticket: Closes [FER-7751: \[Java\]Support custom OAuth properties including headers in token supplier](https://linear.app/buildwithfern/issue/FER-7751/javasupport-custom-oauth-properties-including-headers-in-token)
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
<!-- Provide a clear and concise description of the changes made in this PR -->

Fixes OAuth token generation for endpoints with custom properties (headers or body parameters) beyond standard client_id/client_secret. Previously, the Java generator only looked at customProperties from the OAuth IR config, which was often null. Custom headers like x-api-key were ignored, causing compilation failures when the staged builder required them.

### Changes:
  - Extract header parameters from OAuth token endpoint and include in OAuthTokenSupplier fields/constructor
  - Update builder chain order to put custom properties (headers) before clientId/clientSecret to match staged builder requirements
  - Add header extraction to AbstractRootClientGenerator for client initialization

Fixes compilation of SDKs like Payroc where OAuth uses custom headers, and fixes oauth-client-credentials-custom seed test that was previously in allowedFailures. 

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated - oauth-client-credentials-custom now passes 
- [x] Manual testing completed - Payroc now works 
