### PR TITLE
fix(go): ensure wiremock tests run in ci

### DIFF
--- a/generators/go/internal/writer/workflows/ci.yml
+++ b/generators/go/internal/writer/workflows/ci.yml
@@ -23,5 +23,13 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@v4
 
+      - name: Setup wiremock server
+        run: |
+          if [ -f wiremock/docker-compose.test.yml ]; then docker compose -f wiremock/docker-compose.test.yml down && docker compose -f wiremock/docker-compose.test.yml up -d; fi
+
       - name: Test
         run: go test ./...
+
+      - name: Teardown wiremock server
+        run: |
+          if [ -f wiremock/docker-compose.test.yml ]; then docker compose -f wiremock/docker-compose.test.yml down; fi

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,4 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+
+- version: 1.16.2
+  changelogEntry:
+    - summary: |
+        Ensure wire tests run in CI correctly with docker compose strategy.
+      type: feat
+  createdAt: "2025-11-18"
+  irVersion: 60
+
 - version: 1.16.1
   changelogEntry:
     - summary: |

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -4,7 +4,7 @@
   changelogEntry:
     - summary: |
         Ensure wire tests run in CI correctly with docker compose strategy.
-      type: feat
+      type: fix
   createdAt: "2025-11-18"
   irVersion: 60
 

--- a/seed/go-sdk/imdb/with-wiremock-tests/.github/workflows/ci.yml
+++ b/seed/go-sdk/imdb/with-wiremock-tests/.github/workflows/ci.yml
@@ -23,5 +23,13 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@v4
 
+      - name: Setup wiremock server
+        run: |
+          if [ -f wiremock/docker-compose.test.yml ]; then docker compose -f wiremock/docker-compose.test.yml down && docker compose -f wiremock/docker-compose.test.yml up -d; fi
+
       - name: Test
         run: go test ./...
+
+      - name: Teardown wiremock server
+        run: |
+          if [ -f wiremock/docker-compose.test.yml ]; then docker compose -f wiremock/docker-compose.test.yml down; fi


### PR DESCRIPTION
## Summary

We merged in a change to go wire tests to use a centralized mock server initialized with docker compose and ensured that it is setup correctly in local seed tests but never verified that it worked for end SDK users in CI.