### PR TITLE
chore(deps): update js-yaml

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4767,7 +4767,7 @@ importers:
         version: 4.0.2
       '@types/yargs':
         specifier: ^17.0.28
-        version: 17.0.34
+        version: 17.0.35
       ansi-escapes:
         specifier: ^5.0.0
         version: 5.0.0
@@ -7892,7 +7892,7 @@ importers:
         version: 22.19.0
       '@types/yargs':
         specifier: ^17.0.32
-        version: 17.0.34
+        version: 17.0.35
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -7955,7 +7955,7 @@ importers:
         version: 18.15.3
       '@types/yargs':
         specifier: ^17.0.32
-        version: 17.0.34
+        version: 17.0.35
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -8043,7 +8043,7 @@ importers:
         version: 7.7.1
       '@types/yargs':
         specifier: ^17.0.28
-        version: 17.0.34
+        version: 17.0.35
       ajv:
         specifier: 8.17.1
         version: 8.17.1
@@ -11046,9 +11046,6 @@ packages:
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
 
-  '@types/yargs@17.0.34':
-    resolution: {integrity: sha512-KExbHVa92aJpw9WDQvzBaGVE2/Pz+pLZQloT2hjL8IqsZnV62rlPOYvNnLmf/L2dyllfVUOVBj64M0z/46eR2A==}
-
   '@types/yargs@17.0.35':
     resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
 
@@ -13338,8 +13335,8 @@ packages:
     peerDependencies:
       js-yaml: ^4.0.0
 
-  js-yaml@3.14.1:
-    resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
+  js-yaml@3.14.2:
+    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
     hasBin: true
 
   js-yaml@4.1.1:
@@ -17856,7 +17853,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 3.14.1
+      js-yaml: 3.14.2
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.3': {}
@@ -18055,7 +18052,7 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
       '@types/node': 18.19.130
-      '@types/yargs': 17.0.34
+      '@types/yargs': 17.0.35
       chalk: 4.1.2
 
   '@jest/types@30.2.0':
@@ -19164,14 +19161,9 @@ snapshots:
 
   '@types/yargs-parser@21.0.3': {}
 
-  '@types/yargs@17.0.34':
-    dependencies:
-      '@types/yargs-parser': 21.0.3
-
   '@types/yargs@17.0.35':
     dependencies:
       '@types/yargs-parser': 21.0.3
-    optional: true
 
   '@types/yauzl@2.10.3':
     dependencies:
@@ -19360,7 +19352,7 @@ snapshots:
 
   '@yarnpkg/parsers@3.0.2':
     dependencies:
-      js-yaml: 3.14.1
+      js-yaml: 3.14.2
       tslib: 2.8.1
 
   '@zkochan/js-yaml@0.0.7':
@@ -20297,7 +20289,7 @@ snapshots:
       findup-sync: 5.0.0
       ignore: 5.3.2
       is-core-module: 2.16.1
-      js-yaml: 3.14.1
+      js-yaml: 3.14.2
       json5: 2.2.2
       lodash: 4.17.21
       minimatch: 7.4.6
@@ -21007,7 +20999,7 @@ snapshots:
 
   front-matter@4.0.2:
     dependencies:
-      js-yaml: 3.14.1
+      js-yaml: 3.14.2
 
   fs-constants@1.0.0: {}
 
@@ -21187,7 +21179,7 @@ snapshots:
 
   gray-matter@4.0.3:
     dependencies:
-      js-yaml: 3.14.1
+      js-yaml: 3.14.2
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -22047,7 +22039,7 @@ snapshots:
     dependencies:
       js-yaml: 4.1.1
 
-  js-yaml@3.14.1:
+  js-yaml@3.14.2:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1


### PR DESCRIPTION
## Short description of the changes made
Update js-yaml to resolve dependabot alert: https://github.com/fern-api/fern/security/dependabot/779

added js-yaml as dep, regenerated lock file, removed, regenerated.

## What was the motivation & context behind this PR?
soc2 compliance

## How has this PR been tested?
CI