### PR TITLE
fix(docs): fix changelog upstream

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -155,7 +155,7 @@
 
 - changelogEntry:
     - summary: |
-        Show AI example generation progress in the spinner line. When generating AI examples, the spinner displays `generating AI examples for {API name} - X/Y`` to track progress without creating terminal noise.
+        Show AI example generation progress in the spinner line. When generating AI examples, the spinner displays `generating AI examples for {API name} - X/Y` to track progress without creating terminal noise.
       type: feat
   irVersion: 61
   createdAt: "2025-11-14"


### PR DESCRIPTION
## Description
Docs were not publishing because of a changelog typo

## Changes Made
fixed typo

## Testing
Already deployed fix in docs repo directly