### PR TITLE
chore(rust): double optionals like `optional<nullable<T>>` support in query params

### DIFF
--- a/generators/rust/sdk/src/generators/SubClientGenerator.ts
+++ b/generators/rust/sdk/src/generators/SubClientGenerator.ts
@@ -1025,8 +1025,54 @@ export class SubClientGenerator {
             named: () => "serialize", // User-defined types need serialization
             container: (container) => {
                 return container._visit({
-                    optional: (innerType) => this.getQueryBuilderMethodForType(innerType),
-                    nullable: (innerType) => this.getQueryBuilderMethodForType(innerType),
+                    optional: (innerType) => {
+                        // Check if the inner type is also optional/nullable (double optional)
+                        // Double optionals like Option<Option<T>> need serialize() method
+                        const isDoubleOptional = TypeReference._visit(innerType, {
+                            container: (innerContainer) =>
+                                innerContainer._visit({
+                                    optional: () => true,
+                                    nullable: () => true,
+                                    list: () => false,
+                                    map: () => false,
+                                    set: () => false,
+                                    literal: () => false,
+                                    _other: () => false
+                                }),
+                            primitive: () => false,
+                            named: () => false,
+                            unknown: () => false,
+                            _other: () => false
+                        });
+                        if (isDoubleOptional) {
+                            return "serialize";
+                        }
+                        return this.getQueryBuilderMethodForType(innerType);
+                    },
+                    nullable: (innerType) => {
+                        // Check if the inner type is also optional/nullable (double optional)
+                        // Double optionals like Option<Option<T>> need serialize() method
+                        const isDoubleOptional = TypeReference._visit(innerType, {
+                            container: (innerContainer) =>
+                                innerContainer._visit({
+                                    optional: () => true,
+                                    nullable: () => true,
+                                    list: () => false,
+                                    map: () => false,
+                                    set: () => false,
+                                    literal: () => false,
+                                    _other: () => false
+                                }),
+                            primitive: () => false,
+                            named: () => false,
+                            unknown: () => false,
+                            _other: () => false
+                        });
+                        if (isDoubleOptional) {
+                            return "serialize";
+                        }
+                        return this.getQueryBuilderMethodForType(innerType);
+                    },
                     map: () => "serialize",
                     set: () => "serialize",
                     list: () => "serialize",
@@ -1070,8 +1116,54 @@ export class SubClientGenerator {
             container: (container) => {
                 // Drill down into optional/nullable to get the underlying type
                 return container._visit({
-                    optional: (innerType) => this.getQueryBuilderMethodForType(innerType),
-                    nullable: (innerType) => this.getQueryBuilderMethodForType(innerType),
+                    optional: (innerType) => {
+                        // Check if the inner type is also optional/nullable (double optional)
+                        // Double optionals like Option<Option<T>> need serialize() method
+                        const isDoubleOptional = TypeReference._visit(innerType, {
+                            container: (innerContainer) =>
+                                innerContainer._visit({
+                                    optional: () => true,
+                                    nullable: () => true,
+                                    list: () => false,
+                                    map: () => false,
+                                    set: () => false,
+                                    literal: () => false,
+                                    _other: () => false
+                                }),
+                            primitive: () => false,
+                            named: () => false,
+                            unknown: () => false,
+                            _other: () => false
+                        });
+                        if (isDoubleOptional) {
+                            return "serialize";
+                        }
+                        return this.getQueryBuilderMethodForType(innerType);
+                    },
+                    nullable: (innerType) => {
+                        // Check if the inner type is also optional/nullable (double optional)
+                        // Double optionals like Option<Option<T>> need serialize() method
+                        const isDoubleOptional = TypeReference._visit(innerType, {
+                            container: (innerContainer) =>
+                                innerContainer._visit({
+                                    optional: () => true,
+                                    nullable: () => true,
+                                    list: () => false,
+                                    map: () => false,
+                                    set: () => false,
+                                    literal: () => false,
+                                    _other: () => false
+                                }),
+                            primitive: () => false,
+                            named: () => false,
+                            unknown: () => false,
+                            _other: () => false
+                        });
+                        if (isDoubleOptional) {
+                            return "serialize";
+                        }
+                        return this.getQueryBuilderMethodForType(innerType);
+                    },
                     map: () => "serialize",
                     set: () => "serialize",
                     list: () => "serialize",

--- a/seed/rust-sdk/nullable-optional/src/api/resources/nullable_optional/nullable_optional.rs
+++ b/seed/rust-sdk/nullable-optional/src/api/resources/nullable_optional/nullable_optional.rs
@@ -112,7 +112,7 @@ impl NullableOptionalClient2 {
                     .int("limit", request.limit.clone())
                     .int("offset", request.offset.clone())
                     .bool("includeDeleted", request.include_deleted.clone())
-                    .string("sortBy", request.sort_by.clone())
+                    .serialize("sortBy", request.sort_by.clone())
                     .build(),
                 options,
             )
@@ -142,7 +142,7 @@ impl NullableOptionalClient2 {
                     .structured_query("query", request.query.clone())
                     .string("department", request.department.clone())
                     .string("role", request.role.clone())
-                    .bool("isActive", request.is_active.clone())
+                    .serialize("isActive", request.is_active.clone())
                     .build(),
                 options,
             )

--- a/seed/rust-sdk/nullable-request-body/src/api/resources/test_group/test_group.rs
+++ b/seed/rust-sdk/nullable-request-body/src/api/resources/test_group/test_group.rs
@@ -35,7 +35,7 @@ impl TestGroupClient {
                 Some(serde_json::to_value(&request.body).unwrap_or_default()),
                 QueryBuilder::new()
                     .serialize("query_param_object", request.query_param_object.clone())
-                    .int("query_param_integer", request.query_param_integer.clone())
+                    .serialize("query_param_integer", request.query_param_integer.clone())
                     .build(),
                 options,
             )

--- a/seed/rust-sdk/nullable/src/api/resources/nullable/nullable.rs
+++ b/seed/rust-sdk/nullable/src/api/resources/nullable/nullable.rs
@@ -27,8 +27,8 @@ impl NullableClient2 {
                     .string_array("usernames", request.usernames.clone())
                     .string("avatar", request.avatar.clone())
                     .bool_array("activated", request.activated.clone())
-                    .string_array("tags", request.tags.clone())
-                    .bool("extra", request.extra.clone())
+                    .serialize_array("tags", request.tags.clone())
+                    .serialize("extra", request.extra.clone())
                     .build(),
                 options,
             )


### PR DESCRIPTION
## Description
Linear ticket: [FER-7762](https://linear.app/buildwithfern/issue/FER-7762/rust-sdk-support-for-optionalnullablet)


Fixed a type mismatch issue in the Rust SDK generator where double-optional query parameters (e.g.` Option<Option<T>>`) were incorrectly using type-specific QueryBuilder.

basically equivalent to 
- IR definition --> `extra: optional<nullable<boolean>>`
- rust --> `extra: Option<Option<bool>>` 
- typescript --> ` extra?: boolean | null;`


## Changes Made
- Added double-optional type detection in `SubClientGenerator.ts` in two locations:
  - `getQueryBuilderMethod()` inline visitor for regular query parameters
  - `getQueryBuilderMethodForType()` helper function for allow-multiple parameters