### PR TITLE
fix(cli): dont inline enums by default

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertSchemas.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertSchemas.ts
@@ -57,9 +57,11 @@ function isInlinable(
     switch (resolvedSchema.type) {
         case "boolean":
         case "number":
-        case "string":
         case "integer":
             return true;
+        case "string":
+            // Don't inline string schemas that are actually enums
+            return resolvedSchema.enum == null;
         case "array":
             return isInlinable(resolvedSchema.items, context);
         case "object":

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/enum-array-references.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/enum-array-references.json
@@ -1,0 +1,673 @@
+{
+  "title": "Enum Array Reference Test API",
+  "servers": [],
+  "websocketServers": [],
+  "tags": {
+    "tagsById": {}
+  },
+  "hasEndpointsMarkedInternal": false,
+  "endpoints": [
+    {
+      "summary": "Get filters with array of enum references",
+      "audiences": [],
+      "tags": [],
+      "pathParameters": [],
+      "queryParameters": [
+        {
+          "description": "Filter by quantity units",
+          "name": "quantityUnitFilter",
+          "schema": {
+            "generatedName": "GetFiltersRequestQuantityUnitFilter",
+            "value": {
+              "value": {
+                "generatedName": "GetFiltersRequestQuantityUnitFilterItem",
+                "schema": "QuantityUnit",
+                "source": {
+                  "file": "../openapi.yml",
+                  "type": "openapi"
+                },
+                "type": "reference"
+              },
+              "generatedName": "GetFiltersRequestQuantityUnitFilter",
+              "groupName": [],
+              "type": "array"
+            },
+            "groupName": [],
+            "type": "optional"
+          },
+          "source": {
+            "file": "../openapi.yml",
+            "type": "openapi"
+          }
+        },
+        {
+          "description": "Filter by status",
+          "name": "statusFilter",
+          "schema": {
+            "generatedName": "GetFiltersRequestStatusFilter",
+            "value": {
+              "value": {
+                "generatedName": "GetFiltersRequestStatusFilterItem",
+                "schema": "OrderStatus",
+                "source": {
+                  "file": "../openapi.yml",
+                  "type": "openapi"
+                },
+                "type": "reference"
+              },
+              "generatedName": "GetFiltersRequestStatusFilter",
+              "groupName": [],
+              "type": "array"
+            },
+            "groupName": [],
+            "type": "optional"
+          },
+          "source": {
+            "file": "../openapi.yml",
+            "type": "openapi"
+          }
+        }
+      ],
+      "headers": [],
+      "generatedRequestName": "GetFiltersRequest",
+      "response": {
+        "description": "Successful response",
+        "schema": {
+          "allOf": [],
+          "properties": [
+            {
+              "conflict": {},
+              "generatedName": "getFiltersResponseData",
+              "key": "data",
+              "schema": {
+                "generatedName": "GetFiltersResponseData",
+                "value": {
+                  "value": {
+                    "generatedName": "GetFiltersResponseDataItem",
+                    "schema": "Product",
+                    "source": {
+                      "file": "../openapi.yml",
+                      "type": "openapi"
+                    },
+                    "type": "reference"
+                  },
+                  "generatedName": "GetFiltersResponseData",
+                  "groupName": [],
+                  "type": "array"
+                },
+                "groupName": [],
+                "type": "optional"
+              },
+              "audiences": []
+            }
+          ],
+          "allOfPropertyConflicts": [],
+          "generatedName": "GetFiltersResponse",
+          "groupName": [],
+          "additionalProperties": false,
+          "source": {
+            "file": "../openapi.yml",
+            "type": "openapi"
+          },
+          "type": "object"
+        },
+        "fullExamples": [],
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "statusCode": 200,
+        "type": "json"
+      },
+      "errors": {},
+      "servers": [],
+      "authed": false,
+      "security": [],
+      "method": "GET",
+      "path": "/filters",
+      "examples": [
+        {
+          "pathParameters": [],
+          "queryParameters": [],
+          "headers": [],
+          "response": {
+            "value": {
+              "properties": {
+                "data": {
+                  "value": [
+                    {
+                      "properties": {
+                        "id": {
+                          "value": {
+                            "value": "id",
+                            "type": "string"
+                          },
+                          "type": "primitive"
+                        },
+                        "name": {
+                          "value": {
+                            "value": "name",
+                            "type": "string"
+                          },
+                          "type": "primitive"
+                        },
+                        "category": {
+                          "value": "ELECTRONICS",
+                          "type": "enum"
+                        },
+                        "quantityUnit": {
+                          "value": "QUANTITY_UNIT_UNSPECIFIED",
+                          "type": "enum"
+                        },
+                        "status": {
+                          "value": "PENDING",
+                          "type": "enum"
+                        },
+                        "allowedUnits": {
+                          "value": [
+                            {
+                              "value": "QUANTITY_UNIT_UNSPECIFIED",
+                              "type": "enum"
+                            }
+                          ],
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  ],
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            },
+            "type": "withoutStreaming"
+          },
+          "codeSamples": [],
+          "type": "full"
+        }
+      ],
+      "source": {
+        "file": "../openapi.yml",
+        "type": "openapi"
+      }
+    },
+    {
+      "summary": "Create product with enum references",
+      "audiences": [],
+      "tags": [],
+      "pathParameters": [],
+      "queryParameters": [],
+      "headers": [],
+      "generatedRequestName": "PostProductsRequest",
+      "request": {
+        "schema": {
+          "allOf": [],
+          "properties": [
+            {
+              "conflict": {},
+              "generatedName": "postProductsRequestName",
+              "key": "name",
+              "schema": {
+                "generatedName": "PostProductsRequestName",
+                "value": {
+                  "schema": {
+                    "type": "string"
+                  },
+                  "generatedName": "PostProductsRequestName",
+                  "groupName": [],
+                  "type": "primitive"
+                },
+                "groupName": [],
+                "type": "optional"
+              },
+              "audiences": []
+            },
+            {
+              "conflict": {},
+              "generatedName": "postProductsRequestCategory",
+              "key": "category",
+              "schema": {
+                "generatedName": "PostProductsRequestCategory",
+                "value": {
+                  "generatedName": "PostProductsRequestCategory",
+                  "schema": "ProductCategory",
+                  "source": {
+                    "file": "../openapi.yml",
+                    "type": "openapi"
+                  },
+                  "type": "reference"
+                },
+                "type": "optional"
+              },
+              "audiences": [],
+              "readonly": false,
+              "writeonly": false
+            },
+            {
+              "conflict": {},
+              "generatedName": "postProductsRequestAllowedUnits",
+              "key": "allowedUnits",
+              "schema": {
+                "generatedName": "PostProductsRequestAllowedUnits",
+                "value": {
+                  "value": {
+                    "generatedName": "PostProductsRequestAllowedUnitsItem",
+                    "schema": "QuantityUnit",
+                    "source": {
+                      "file": "../openapi.yml",
+                      "type": "openapi"
+                    },
+                    "type": "reference"
+                  },
+                  "generatedName": "PostProductsRequestAllowedUnits",
+                  "groupName": [],
+                  "type": "array"
+                },
+                "groupName": [],
+                "type": "optional"
+              },
+              "audiences": []
+            },
+            {
+              "conflict": {},
+              "generatedName": "postProductsRequestValidStatuses",
+              "key": "validStatuses",
+              "schema": {
+                "generatedName": "PostProductsRequestValidStatuses",
+                "value": {
+                  "value": {
+                    "generatedName": "PostProductsRequestValidStatusesItem",
+                    "schema": "OrderStatus",
+                    "source": {
+                      "file": "../openapi.yml",
+                      "type": "openapi"
+                    },
+                    "type": "reference"
+                  },
+                  "generatedName": "PostProductsRequestValidStatuses",
+                  "groupName": [],
+                  "type": "array"
+                },
+                "groupName": [],
+                "type": "optional"
+              },
+              "audiences": []
+            }
+          ],
+          "allOfPropertyConflicts": [],
+          "generatedName": "PostProductsRequest",
+          "groupName": [],
+          "additionalProperties": false,
+          "source": {
+            "file": "../openapi.yml",
+            "type": "openapi"
+          },
+          "type": "object"
+        },
+        "contentType": "application/json",
+        "fullExamples": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "json"
+      },
+      "response": {
+        "description": "Product created",
+        "schema": {
+          "generatedName": "PostProductsResponse",
+          "schema": "Product",
+          "source": {
+            "file": "../openapi.yml",
+            "type": "openapi"
+          },
+          "type": "reference"
+        },
+        "fullExamples": [],
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "statusCode": 201,
+        "type": "json"
+      },
+      "errors": {},
+      "servers": [],
+      "authed": false,
+      "security": [],
+      "method": "POST",
+      "path": "/products",
+      "examples": [
+        {
+          "pathParameters": [],
+          "queryParameters": [],
+          "headers": [],
+          "request": {
+            "properties": {},
+            "type": "object"
+          },
+          "response": {
+            "value": {
+              "properties": {
+                "id": {
+                  "value": {
+                    "value": "id",
+                    "type": "string"
+                  },
+                  "type": "primitive"
+                },
+                "name": {
+                  "value": {
+                    "value": "name",
+                    "type": "string"
+                  },
+                  "type": "primitive"
+                },
+                "category": {
+                  "value": "ELECTRONICS",
+                  "type": "enum"
+                },
+                "quantityUnit": {
+                  "value": "QUANTITY_UNIT_UNSPECIFIED",
+                  "type": "enum"
+                },
+                "status": {
+                  "value": "PENDING",
+                  "type": "enum"
+                },
+                "allowedUnits": {
+                  "value": [
+                    {
+                      "value": "QUANTITY_UNIT_UNSPECIFIED",
+                      "type": "enum"
+                    }
+                  ],
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            },
+            "type": "withoutStreaming"
+          },
+          "codeSamples": [],
+          "type": "full"
+        }
+      ],
+      "source": {
+        "file": "../openapi.yml",
+        "type": "openapi"
+      }
+    }
+  ],
+  "webhooks": [],
+  "channels": {},
+  "groupedSchemas": {
+    "rootSchemas": {
+      "QuantityUnit": {
+        "description": "Units for measuring quantity",
+        "generatedName": "QuantityUnit",
+        "values": [
+          {
+            "generatedName": "QUANTITY_UNIT_UNSPECIFIED",
+            "value": "QUANTITY_UNIT_UNSPECIFIED",
+            "casing": {}
+          },
+          {
+            "generatedName": "QUANTITY_UNIT_COUNT",
+            "value": "QUANTITY_UNIT_COUNT",
+            "casing": {}
+          },
+          {
+            "generatedName": "QUANTITY_UNIT_GALLONS",
+            "value": "QUANTITY_UNIT_GALLONS",
+            "casing": {}
+          },
+          {
+            "generatedName": "QUANTITY_UNIT_POD",
+            "value": "QUANTITY_UNIT_POD",
+            "casing": {}
+          },
+          {
+            "generatedName": "QUANTITY_UNIT_PALLET",
+            "value": "QUANTITY_UNIT_PALLET",
+            "casing": {}
+          },
+          {
+            "generatedName": "QUANTITY_UNIT_SET",
+            "value": "QUANTITY_UNIT_SET",
+            "casing": {}
+          }
+        ],
+        "groupName": [],
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "enum"
+      },
+      "OrderStatus": {
+        "description": "Status of an order",
+        "generatedName": "OrderStatus",
+        "values": [
+          {
+            "generatedName": "PENDING",
+            "value": "PENDING",
+            "casing": {}
+          },
+          {
+            "generatedName": "PROCESSING",
+            "value": "PROCESSING",
+            "casing": {}
+          },
+          {
+            "generatedName": "SHIPPED",
+            "value": "SHIPPED",
+            "casing": {}
+          },
+          {
+            "generatedName": "DELIVERED",
+            "value": "DELIVERED",
+            "casing": {}
+          },
+          {
+            "generatedName": "CANCELLED",
+            "value": "CANCELLED",
+            "casing": {}
+          }
+        ],
+        "groupName": [],
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "enum"
+      },
+      "ProductCategory": {
+        "description": "Category of a product",
+        "generatedName": "ProductCategory",
+        "values": [
+          {
+            "generatedName": "ELECTRONICS",
+            "value": "ELECTRONICS",
+            "casing": {}
+          },
+          {
+            "generatedName": "CLOTHING",
+            "value": "CLOTHING",
+            "casing": {}
+          },
+          {
+            "generatedName": "HOME_GARDEN",
+            "value": "HOME_GARDEN",
+            "casing": {}
+          },
+          {
+            "generatedName": "BOOKS",
+            "value": "BOOKS",
+            "casing": {}
+          },
+          {
+            "generatedName": "TOYS",
+            "value": "TOYS",
+            "casing": {}
+          }
+        ],
+        "groupName": [],
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "enum"
+      },
+      "Product": {
+        "allOf": [],
+        "properties": [
+          {
+            "conflict": {},
+            "generatedName": "productId",
+            "key": "id",
+            "schema": {
+              "generatedName": "ProductId",
+              "value": {
+                "schema": {
+                  "type": "string"
+                },
+                "generatedName": "ProductId",
+                "groupName": [],
+                "type": "primitive"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "audiences": []
+          },
+          {
+            "conflict": {},
+            "generatedName": "productName",
+            "key": "name",
+            "schema": {
+              "generatedName": "ProductName",
+              "value": {
+                "schema": {
+                  "type": "string"
+                },
+                "generatedName": "ProductName",
+                "groupName": [],
+                "type": "primitive"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "audiences": []
+          },
+          {
+            "conflict": {},
+            "generatedName": "productCategory",
+            "key": "category",
+            "schema": {
+              "generatedName": "ProductCategory",
+              "value": {
+                "generatedName": "ProductCategory",
+                "schema": "ProductCategory",
+                "source": {
+                  "file": "../openapi.yml",
+                  "type": "openapi"
+                },
+                "type": "reference"
+              },
+              "type": "optional"
+            },
+            "audiences": [],
+            "readonly": false,
+            "writeonly": false
+          },
+          {
+            "conflict": {},
+            "generatedName": "productQuantityUnit",
+            "key": "quantityUnit",
+            "schema": {
+              "generatedName": "ProductQuantityUnit",
+              "value": {
+                "generatedName": "ProductQuantityUnit",
+                "schema": "QuantityUnit",
+                "source": {
+                  "file": "../openapi.yml",
+                  "type": "openapi"
+                },
+                "type": "reference"
+              },
+              "type": "optional"
+            },
+            "audiences": [],
+            "readonly": false,
+            "writeonly": false
+          },
+          {
+            "conflict": {},
+            "generatedName": "productStatus",
+            "key": "status",
+            "schema": {
+              "generatedName": "ProductStatus",
+              "value": {
+                "generatedName": "ProductStatus",
+                "schema": "OrderStatus",
+                "source": {
+                  "file": "../openapi.yml",
+                  "type": "openapi"
+                },
+                "type": "reference"
+              },
+              "type": "optional"
+            },
+            "audiences": [],
+            "readonly": false,
+            "writeonly": false
+          },
+          {
+            "conflict": {},
+            "generatedName": "productAllowedUnits",
+            "key": "allowedUnits",
+            "schema": {
+              "generatedName": "ProductAllowedUnits",
+              "value": {
+                "value": {
+                  "generatedName": "ProductAllowedUnitsItem",
+                  "schema": "QuantityUnit",
+                  "source": {
+                    "file": "../openapi.yml",
+                    "type": "openapi"
+                  },
+                  "type": "reference"
+                },
+                "generatedName": "ProductAllowedUnits",
+                "groupName": [],
+                "type": "array"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "audiences": []
+          }
+        ],
+        "allOfPropertyConflicts": [],
+        "generatedName": "Product",
+        "groupName": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "object"
+      }
+    },
+    "namespacedSchemas": {}
+  },
+  "variables": {},
+  "nonRequestReferencedSchemas": {},
+  "securitySchemes": {},
+  "globalHeaders": [],
+  "idempotencyHeaders": [],
+  "groups": {}
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/enum-array-references.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/enum-array-references.json
@@ -1,0 +1,321 @@
+{
+  "absoluteFilePath": "/DUMMY_PATH",
+  "importedDefinitions": {},
+  "namedDefinitionFiles": {
+    "__package__.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {
+        "service": {
+          "auth": false,
+          "base-path": "",
+          "endpoints": {
+            "createProductWithEnumReferences": {
+              "auth": undefined,
+              "display-name": "Create product with enum references",
+              "docs": undefined,
+              "examples": [
+                {
+                  "request": {},
+                  "response": {
+                    "body": {
+                      "allowedUnits": [
+                        "QUANTITY_UNIT_UNSPECIFIED",
+                      ],
+                      "category": "ELECTRONICS",
+                      "id": "id",
+                      "name": "name",
+                      "quantityUnit": "QUANTITY_UNIT_UNSPECIFIED",
+                      "status": "PENDING",
+                    },
+                  },
+                },
+              ],
+              "method": "POST",
+              "pagination": undefined,
+              "path": "/products",
+              "request": {
+                "body": {
+                  "properties": {
+                    "allowedUnits": "optional<list<QuantityUnit>>",
+                    "category": "optional<ProductCategory>",
+                    "name": "optional<string>",
+                    "validStatuses": "optional<list<OrderStatus>>",
+                  },
+                },
+                "content-type": "application/json",
+                "headers": undefined,
+                "name": "PostProductsRequest",
+                "path-parameters": undefined,
+                "query-parameters": undefined,
+              },
+              "response": {
+                "docs": "Product created",
+                "status-code": 201,
+                "type": "Product",
+              },
+              "source": {
+                "openapi": "../openapi.yml",
+              },
+            },
+            "getFiltersWithArrayOfEnumReferences": {
+              "auth": undefined,
+              "display-name": "Get filters with array of enum references",
+              "docs": undefined,
+              "examples": [
+                {
+                  "response": {
+                    "body": {
+                      "data": [
+                        {
+                          "allowedUnits": [
+                            "QUANTITY_UNIT_UNSPECIFIED",
+                          ],
+                          "category": "ELECTRONICS",
+                          "id": "id",
+                          "name": "name",
+                          "quantityUnit": "QUANTITY_UNIT_UNSPECIFIED",
+                          "status": "PENDING",
+                        },
+                      ],
+                    },
+                  },
+                },
+              ],
+              "method": "GET",
+              "pagination": undefined,
+              "path": "/filters",
+              "request": {
+                "name": "GetFiltersRequest",
+                "query-parameters": {
+                  "quantityUnitFilter": {
+                    "allow-multiple": true,
+                    "docs": "Filter by quantity units",
+                    "type": "optional<QuantityUnit>",
+                  },
+                  "statusFilter": {
+                    "allow-multiple": true,
+                    "docs": "Filter by status",
+                    "type": "optional<OrderStatus>",
+                  },
+                },
+              },
+              "response": {
+                "docs": "Successful response",
+                "status-code": 200,
+                "type": "GetFiltersResponse",
+              },
+              "source": {
+                "openapi": "../openapi.yml",
+              },
+            },
+          },
+          "source": {
+            "openapi": "../openapi.yml",
+          },
+        },
+        "types": {
+          "GetFiltersResponse": {
+            "docs": undefined,
+            "inline": undefined,
+            "properties": {
+              "data": "optional<list<Product>>",
+            },
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+          "OrderStatus": {
+            "docs": "Status of an order",
+            "enum": [
+              "PENDING",
+              "PROCESSING",
+              "SHIPPED",
+              "DELIVERED",
+              "CANCELLED",
+            ],
+            "inline": undefined,
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+          "Product": {
+            "docs": undefined,
+            "inline": undefined,
+            "properties": {
+              "allowedUnits": "optional<list<QuantityUnit>>",
+              "category": "optional<ProductCategory>",
+              "id": "optional<string>",
+              "name": "optional<string>",
+              "quantityUnit": "optional<QuantityUnit>",
+              "status": "optional<OrderStatus>",
+            },
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+          "ProductCategory": {
+            "docs": "Category of a product",
+            "enum": [
+              "ELECTRONICS",
+              "CLOTHING",
+              "HOME_GARDEN",
+              "BOOKS",
+              "TOYS",
+            ],
+            "inline": undefined,
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+          "QuantityUnit": {
+            "docs": "Units for measuring quantity",
+            "enum": [
+              "QUANTITY_UNIT_UNSPECIFIED",
+              "QUANTITY_UNIT_COUNT",
+              "QUANTITY_UNIT_GALLONS",
+              "QUANTITY_UNIT_POD",
+              "QUANTITY_UNIT_PALLET",
+              "QUANTITY_UNIT_SET",
+            ],
+            "inline": undefined,
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+        },
+      },
+      "rawContents": "types:
+  GetFiltersResponse:
+    properties:
+      data: optional<list<Product>>
+    source:
+      openapi: ../openapi.yml
+  QuantityUnit:
+    enum:
+      - QUANTITY_UNIT_UNSPECIFIED
+      - QUANTITY_UNIT_COUNT
+      - QUANTITY_UNIT_GALLONS
+      - QUANTITY_UNIT_POD
+      - QUANTITY_UNIT_PALLET
+      - QUANTITY_UNIT_SET
+    docs: Units for measuring quantity
+    source:
+      openapi: ../openapi.yml
+  OrderStatus:
+    enum:
+      - PENDING
+      - PROCESSING
+      - SHIPPED
+      - DELIVERED
+      - CANCELLED
+    docs: Status of an order
+    source:
+      openapi: ../openapi.yml
+  ProductCategory:
+    enum:
+      - ELECTRONICS
+      - CLOTHING
+      - HOME_GARDEN
+      - BOOKS
+      - TOYS
+    docs: Category of a product
+    source:
+      openapi: ../openapi.yml
+  Product:
+    properties:
+      id: optional<string>
+      name: optional<string>
+      category: optional<ProductCategory>
+      quantityUnit: optional<QuantityUnit>
+      status: optional<OrderStatus>
+      allowedUnits: optional<list<QuantityUnit>>
+    source:
+      openapi: ../openapi.yml
+service:
+  auth: false
+  base-path: ''
+  endpoints:
+    getFiltersWithArrayOfEnumReferences:
+      path: /filters
+      method: GET
+      source:
+        openapi: ../openapi.yml
+      display-name: Get filters with array of enum references
+      request:
+        name: GetFiltersRequest
+        query-parameters:
+          quantityUnitFilter:
+            type: optional<QuantityUnit>
+            allow-multiple: true
+            docs: Filter by quantity units
+          statusFilter:
+            type: optional<OrderStatus>
+            allow-multiple: true
+            docs: Filter by status
+      response:
+        docs: Successful response
+        type: GetFiltersResponse
+        status-code: 200
+      examples:
+        - response:
+            body:
+              data:
+                - id: id
+                  name: name
+                  category: ELECTRONICS
+                  quantityUnit: QUANTITY_UNIT_UNSPECIFIED
+                  status: PENDING
+                  allowedUnits:
+                    - QUANTITY_UNIT_UNSPECIFIED
+    createProductWithEnumReferences:
+      path: /products
+      method: POST
+      source:
+        openapi: ../openapi.yml
+      display-name: Create product with enum references
+      request:
+        name: PostProductsRequest
+        body:
+          properties:
+            name: optional<string>
+            category: optional<ProductCategory>
+            allowedUnits: optional<list<QuantityUnit>>
+            validStatuses: optional<list<OrderStatus>>
+        content-type: application/json
+      response:
+        docs: Product created
+        type: Product
+        status-code: 201
+      examples:
+        - request: {}
+          response:
+            body:
+              id: id
+              name: name
+              category: ELECTRONICS
+              quantityUnit: QUANTITY_UNIT_UNSPECIFIED
+              status: PENDING
+              allowedUnits:
+                - QUANTITY_UNIT_UNSPECIFIED
+  source:
+    openapi: ../openapi.yml
+",
+    },
+  },
+  "packageMarkers": {},
+  "rootApiFile": {
+    "contents": {
+      "display-name": "Enum Array Reference Test API",
+      "error-discrimination": {
+        "strategy": "status-code",
+      },
+      "name": "api",
+    },
+    "defaultUrl": undefined,
+    "rawContents": "name: api
+error-discrimination:
+  strategy: status-code
+display-name: Enum Array Reference Test API
+",
+  },
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/enum-array-references/fern/fern.config.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/enum-array-references/fern/fern.config.json
@@ -1,0 +1,4 @@
+{
+  "organization": "fern",
+  "version": "*"
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/enum-array-references/fern/generators.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/enum-array-references/fern/generators.yml
@@ -1,0 +1,3 @@
+api:
+  specs:
+    - openapi: ../openapi.yml

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/enum-array-references/openapi.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/enum-array-references/openapi.yml
@@ -1,0 +1,117 @@
+openapi: 3.0.0
+info:
+  title: Enum Array Reference Test API
+  version: 1.0.0
+paths:
+  /filters:
+    get:
+      summary: Get filters with array of enum references
+      parameters:
+        - name: quantityUnitFilter
+          in: query
+          description: Filter by quantity units
+          required: false
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/QuantityUnit"
+        - name: statusFilter
+          in: query
+          description: Filter by status
+          required: false
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/OrderStatus"
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Product"
+  /products:
+    post:
+      summary: Create product with enum references
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                category:
+                  $ref: "#/components/schemas/ProductCategory"
+                allowedUnits:
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/QuantityUnit"
+                validStatuses:
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/OrderStatus"
+      responses:
+        "201":
+          description: Product created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Product"
+
+components:
+  schemas:
+    QuantityUnit:
+      type: string
+      enum:
+        - QUANTITY_UNIT_UNSPECIFIED
+        - QUANTITY_UNIT_COUNT
+        - QUANTITY_UNIT_GALLONS
+        - QUANTITY_UNIT_POD
+        - QUANTITY_UNIT_PALLET
+        - QUANTITY_UNIT_SET
+      description: Units for measuring quantity
+
+    OrderStatus:
+      type: string
+      enum:
+        - PENDING
+        - PROCESSING
+        - SHIPPED
+        - DELIVERED
+        - CANCELLED
+      description: Status of an order
+
+    ProductCategory:
+      type: string
+      enum:
+        - ELECTRONICS
+        - CLOTHING
+        - HOME_GARDEN
+        - BOOKS
+        - TOYS
+      description: Category of a product
+
+    Product:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        category:
+          $ref: "#/components/schemas/ProductCategory"
+        quantityUnit:
+          $ref: "#/components/schemas/QuantityUnit"
+        status:
+          $ref: "#/components/schemas/OrderStatus"
+        allowedUnits:
+          type: array
+          items:
+            $ref: "#/components/schemas/QuantityUnit"

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Fix OpenAPI enum references being inlined instead of preserved as references. Enum schemas (type: string with enum property) are no longer treated as inlinable primitives, ensuring that $ref to enum schemas maintain their reference structure in the generated IR.
+      type: fix
+  irVersion: 61
+  createdAt: "2025-11-19"
+  version: 1.11.2
+
+- changelogEntry:
+    - summary: |
         Fix AutoVersioning to exclude Fern branding from commit messages and PR titles/descriptions when whitelabel config is present.
       type: fix
   irVersion: 61


### PR DESCRIPTION
A referenced enum schema should be treated as one. 