### PR TITLE
fix(java): correct OptionalNullable handling with collapse-optional-nullable flag

### DIFF
--- a/generators/java/generator-utils/src/main/java/com/fern/java/PoetTypeNameMapper.java
+++ b/generators/java/generator-utils/src/main/java/com/fern/java/PoetTypeNameMapper.java
@@ -275,8 +275,10 @@ public final class PoetTypeNameMapper {
                 ClassName optionalNullableClassName = poetClassNameFactory.getOptionalNullableClassName();
 
                 // Check if inner type is optional container - collapse nullable<optional<T>> to OptionalNullable<T>
-                if (typeReference.isContainer() && typeReference.getContainer().get().isOptional()) {
-                    TypeReference innerType = typeReference.getContainer().get().getOptional().get();
+                if (typeReference.isContainer()
+                        && typeReference.getContainer().get().isOptional()) {
+                    TypeReference innerType =
+                            typeReference.getContainer().get().getOptional().get();
                     TypeName innerTypeName = innerType.visit(primitiveDisAllowedTypeReferenceConverter);
                     return ParameterizedTypeName.get(optionalNullableClassName, innerTypeName);
                 }

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/AbstractEndpointWriter.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/AbstractEndpointWriter.java
@@ -290,6 +290,11 @@ public abstract class AbstractEndpointWriter {
                     .get(0);
             if (typeNameIsOptional(bodyParameterSpec.type)) {
                 paramNamesWoBody.add("Optional.empty()");
+            } else if (bodyParameterSpec.type instanceof ParameterizedTypeName) {
+                // Handle parameterized types with type witness syntax
+                // E.g., OptionalNullable<SomeType> becomes OptionalNullable.<SomeType>builder().build()
+                // We use $1T to refer to rawType and $2T to refer to the type argument
+                paramNamesWoBody.add("$1T.<$2T>builder().build()");
             } else {
                 paramNamesWoBody.add("$T.builder().build()");
             }

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/AbstractEndpointWriter.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/AbstractEndpointWriter.java
@@ -292,9 +292,9 @@ public abstract class AbstractEndpointWriter {
                 paramNamesWoBody.add("Optional.empty()");
             } else if (bodyParameterSpec.type instanceof ParameterizedTypeName) {
                 // Handle parameterized types with type witness syntax
-                // E.g., OptionalNullable<SomeType> becomes OptionalNullable.<SomeType>builder().build()
+                // E.g., OptionalNullable<SomeType> becomes OptionalNullable.<SomeType>absent()
                 // We use $1T to refer to rawType and $2T to refer to the type argument
-                paramNamesWoBody.add("$1T.<$2T>builder().build()");
+                paramNamesWoBody.add("$1T.<$2T>absent()");
             } else {
                 paramNamesWoBody.add("$T.builder().build()");
             }

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/AsyncHttpResponseParserGenerator.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/AsyncHttpResponseParserGenerator.java
@@ -70,9 +70,18 @@ public final class AsyncHttpResponseParserGenerator extends AbstractHttpResponse
             MethodSpec endpointWithRequestOptions,
             List<String> paramNamesWoBody,
             ParameterSpec bodyParameterSpec) {
-        endpointWithoutRequestBuilder.addStatement(
-                "return " + endpointWithRequestOptions.name + "(" + String.join(",", paramNamesWoBody) + ")",
-                bodyParameterSpec.type);
+        // Handle parameterized types (e.g., OptionalNullable<T>) which need type witness syntax
+        if (bodyParameterSpec.type instanceof ParameterizedTypeName) {
+            ParameterizedTypeName paramType = (ParameterizedTypeName) bodyParameterSpec.type;
+            endpointWithoutRequestBuilder.addStatement(
+                    "return " + endpointWithRequestOptions.name + "(" + String.join(",", paramNamesWoBody) + ")",
+                    paramType.rawType,
+                    paramType.typeArguments.get(0));
+        } else {
+            endpointWithoutRequestBuilder.addStatement(
+                    "return " + endpointWithRequestOptions.name + "(" + String.join(",", paramNamesWoBody) + ")",
+                    bodyParameterSpec.type);
+        }
     }
 
     @Override

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/SyncHttpResponseParserGenerator.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/SyncHttpResponseParserGenerator.java
@@ -11,6 +11,7 @@ import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.FieldSpec;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.ParameterSpec;
+import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -60,9 +61,18 @@ public final class SyncHttpResponseParserGenerator extends AbstractHttpResponseP
             MethodSpec endpointWithRequestOptions,
             List<String> paramNamesWoBody,
             ParameterSpec bodyParameterSpec) {
-        endpointWithoutRequestBuilder.addStatement(
-                "return " + endpointWithRequestOptions.name + "(" + String.join(",", paramNamesWoBody) + ")",
-                bodyParameterSpec.type);
+        // Handle parameterized types (e.g., OptionalNullable<T>) which need type witness syntax
+        if (bodyParameterSpec.type instanceof ParameterizedTypeName) {
+            ParameterizedTypeName paramType = (ParameterizedTypeName) bodyParameterSpec.type;
+            endpointWithoutRequestBuilder.addStatement(
+                    "return " + endpointWithRequestOptions.name + "(" + String.join(",", paramNamesWoBody) + ")",
+                    paramType.rawType,
+                    paramType.typeArguments.get(0));
+        } else {
+            endpointWithoutRequestBuilder.addStatement(
+                    "return " + endpointWithRequestOptions.name + "(" + String.join(",", paramNamesWoBody) + ")",
+                    bodyParameterSpec.type);
+        }
     }
 
     @Override

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,3 +1,11 @@
+- version: 3.18.3
+  changelogEntry:
+    - summary: |
+        Fix OptionalNullable compilation errors when collapse-optional-nullable is enabled. Corrected type witness syntax to generate `OptionalNullable.<Type>absent()` and prevented double-wrapping of OptionalNullable types.
+      type: fix
+  createdAt: "2025-11-20"
+  irVersion: 61
+
 - version: 3.18.2
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description
Linear ticket: Closes [FER-7773: \[Java\] OptionalNullable fixes with wrapping](https://linear.app/buildwithfern/issue/FER-7773/java-optionalnullable-fixes-with-wrapping)
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
<!-- Provide a clear and concise description of the changes made in this PR -->

Fixes two compilation errors when both respect-nullable-schemas and collapse-optional-nullable are enabled in Java SDK generation with certain endpoints:

## Changes Made 
Invalid type witness syntax
  - Generated: OptionalNullable<Type>.absent()
  - Fixed: OptionalNullable.<Type>absent()
  - Implementation: Use indexed type parameters ($1T, $2T) with JavaPoet

Double-wrapping of OptionalNullable types
  - Generated: OptionalNullable<OptionalNullable<T>> (type erasure errors)
  - Fixed: OptionalNullable<T>
  - Implementation: Defensive checks in visitOptional() and visitNullable() to detect and prevent re-wrapping when inner type is already OptionalNullable

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated
- [x] Manual testing completed- ✅ with auth0 no more compilation errors and generation suceeds when both flags are true 
