### PR TITLE
fix(java): fix missing `@JsonIgnore` on certain `OptionalNullable<>` instances

### DIFF
--- a/generators/java/generator-utils/src/main/java/com/fern/java/generators/object/EnrichedObjectProperty.java
+++ b/generators/java/generator-utils/src/main/java/com/fern/java/generators/object/EnrichedObjectProperty.java
@@ -137,12 +137,23 @@ public interface EnrichedObjectProperty {
         }
         // Headers have empty wireKey to avoid JSON serialization
         boolean hasWireKey = wireKey().isPresent() && !wireKey().get().isEmpty();
-        if (hasWireKey && !nullable() && !aliasOfNullable()) {
+        if (hasWireKey && !nullable() && !aliasOfNullable() && !isOptionalNullableField()) {
             getterBuilder.addAnnotation(AnnotationSpec.builder(JsonProperty.class)
                     .addMember("value", "$S", wireKey().get())
                     .build());
         } else {
-            getterBuilder.addAnnotation(AnnotationSpec.builder(JsonIgnore.class).build());
+            // Check if this is an OptionalNullable field - if so, add @JsonInclude + @JsonProperty
+            if (hasWireKey && isOptionalNullableField()) {
+                getterBuilder.addAnnotation(AnnotationSpec.builder(JsonInclude.class)
+                        .addMember("value", "$T.Include.CUSTOM", JsonInclude.class)
+                        .addMember("valueFilter", "$T.class", nullableNonemptyFilterClassName())
+                        .build());
+                getterBuilder.addAnnotation(AnnotationSpec.builder(JsonProperty.class)
+                        .addMember("value", "$S", wireKey().get())
+                        .build());
+            } else {
+                getterBuilder.addAnnotation(AnnotationSpec.builder(JsonIgnore.class).build());
+            }
         }
         if (fromInterface() && !inline()) {
             getterBuilder.addAnnotation(ClassName.get("", "java.lang.Override"));

--- a/generators/java/generator-utils/src/main/java/com/fern/java/generators/object/EnrichedObjectProperty.java
+++ b/generators/java/generator-utils/src/main/java/com/fern/java/generators/object/EnrichedObjectProperty.java
@@ -152,7 +152,8 @@ public interface EnrichedObjectProperty {
                         .addMember("value", "$S", wireKey().get())
                         .build());
             } else {
-                getterBuilder.addAnnotation(AnnotationSpec.builder(JsonIgnore.class).build());
+                getterBuilder.addAnnotation(
+                        AnnotationSpec.builder(JsonIgnore.class).build());
             }
         }
         if (fromInterface() && !inline()) {

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,3 +1,11 @@
+- version: 3.18.4
+  changelogEntry:
+    - summary: |
+        Fix missing @JsonInclude header on certain instances of OptionalNullable<>.
+      type: fix
+  createdAt: "2025-11-20"
+  irVersion: 61
+
 - version: 3.18.3
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description
As per the title.

## Changes Made
Small change to `EnrichedObjectProperty.java`.

## Testing
Lets Auth0 tests pass.
