### PR TITLE
fix(csharp, go, java, python, swift, typescript): Remove using generator-cli to push to GitHub for self-hosted SDKs

### DIFF
--- a/generators/csharp/sdk/src/SdkGeneratorCli.ts
+++ b/generators/csharp/sdk/src/SdkGeneratorCli.ts
@@ -76,9 +76,6 @@ export class SdkGeneratorCLI extends AbstractCsharpGeneratorCli {
 
     protected async writeForGithub(context: SdkGeneratorContext): Promise<void> {
         await this.generate(context);
-        if (context.isSelfHosted()) {
-            await this.generateGitHub({ context });
-        }
     }
 
     protected async writeForDownload(context: SdkGeneratorContext): Promise<void> {

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.9.3
+  changelogEntry:
+    - summary: |
+        Remove using generator-cli to push to GitHub for self-hosted SDKs; this is now handled in the local workspace runner.
+      type: fix
+  createdAt: "2025-11-21"
+  irVersion: 61
+
 - version: 2.9.2
   changelogEntry:
     - type: chore

--- a/generators/go-v2/sdk/src/SdkGeneratorCli.ts
+++ b/generators/go-v2/sdk/src/SdkGeneratorCli.ts
@@ -49,9 +49,6 @@ export class SdkGeneratorCLI extends AbstractGoGeneratorCli<SdkCustomConfigSchem
 
     protected async writeForGithub(context: SdkGeneratorContext): Promise<void> {
         await this.generate(context);
-        if (context.isSelfHosted()) {
-            await this.generateGitHub({ context });
-        }
     }
 
     protected async writeForDownload(context: SdkGeneratorContext): Promise<void> {

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.17.1
+  changelogEntry:
+    - summary: |
+        Remove using generator-cli to push to GitHub for self-hosted SDKs; this is now handled in the local workspace runner.
+      type: fix
+  createdAt: "2025-11-21"
+  irVersion: 60
+
 - version: 1.17.0
   changelogEntry:
     - summary: |

--- a/generators/java-v2/sdk/src/SdkGeneratorCli.ts
+++ b/generators/java-v2/sdk/src/SdkGeneratorCli.ts
@@ -39,9 +39,6 @@ export class SdkGeneratorCLI extends AbstractJavaGeneratorCli<SdkCustomConfigSch
 
     protected async writeForGithub(context: SdkGeneratorContext): Promise<void> {
         await this.generate(context);
-        if (context.isSelfHosted()) {
-            await this.generateGitHub({ context });
-        }
     }
 
     protected async writeForDownload(context: SdkGeneratorContext): Promise<void> {

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,3 +1,11 @@
+- version: 3.18.5
+  changelogEntry:
+    - summary: |
+        Remove using generator-cli to push to GitHub for self-hosted SDKs; this is now handled in the local workspace runner.
+      type: fix
+  createdAt: "2025-11-21"
+  irVersion: 61
+
 - version: 3.18.4
   changelogEntry:
     - summary: |

--- a/generators/python-v2/sdk/src/SdkGeneratorCli.ts
+++ b/generators/python-v2/sdk/src/SdkGeneratorCli.ts
@@ -37,9 +37,6 @@ export class SdkGeneratorCli extends AbstractPythonGeneratorCli<SdkCustomConfigS
 
     protected async writeForGithub(context: SdkGeneratorContext): Promise<void> {
         await this.generate(context);
-        if (context.isSelfHosted()) {
-            await this.generateGitHub({ context });
-        }
     }
 
     protected async writeForDownload(context: SdkGeneratorContext): Promise<void> {

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 4.38.4
+  changelogEntry:
+    - summary: |
+        Remove using generator-cli to push to GitHub for self-hosted SDKs; this is now handled in the local workspace runner.
+      type: fix
+  createdAt: "2025-11-21"
+  irVersion: 61
+
 - version: 4.38.3-rc0
   changelogEntry:
     - summary: Add support for custom pagination

--- a/generators/swift/sdk/src/SdkGeneratorCli.ts
+++ b/generators/swift/sdk/src/SdkGeneratorCli.ts
@@ -60,9 +60,6 @@ export class SdkGeneratorCLI extends AbstractSwiftGeneratorCli<SdkCustomConfigSc
 
     protected async writeForGithub(context: SdkGeneratorContext): Promise<void> {
         await this.generate(context);
-        if (context.isSelfHosted()) {
-            await context.generatorAgent.pushToGitHubProgrammatic({ context });
-        }
     }
 
     protected async writeForDownload(context: SdkGeneratorContext): Promise<void> {

--- a/generators/swift/sdk/versions.yml
+++ b/generators/swift/sdk/versions.yml
@@ -1,4 +1,11 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 0.25.1
+  changelogEntry:
+    - summary: |
+        Remove using generator-cli to push to GitHub for self-hosted SDKs; this is now handled in the local workspace runner.
+      type: fix
+  createdAt: "2025-11-21"
+  irVersion: 61
 
 - version: 0.25.0
   changelogEntry:

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.33.1
+  changelogEntry:
+    - summary: |
+        Remove using generator-cli to push to GitHub for self-hosted SDKs; this is now handled in the local workspace runner.
+      type: fix
+  createdAt: "2025-11-21"
+  irVersion: 61
+
 - version: 3.33.0
   changelogEntry:
     - summary: |

--- a/generators/typescript/utils/abstract-generator-cli/src/AbstractGeneratorCli.ts
+++ b/generators/typescript/utils/abstract-generator-cli/src/AbstractGeneratorCli.ts
@@ -173,16 +173,6 @@ export abstract class AbstractGeneratorCli<CustomConfig> {
                         zipFilename: OUTPUT_ZIP_FILENAME,
                         unzipOutput: options?.unzipOutput
                     });
-                    if (ir.selfHosted) {
-                        const tmpDir = await tmp.dir();
-                        await typescriptProject.copyProjectTo({
-                            destinationPath: AbsoluteFilePath.of(tmpDir.path),
-                            zipFilename: OUTPUT_ZIP_FILENAME,
-                            unzipOutput: true,
-                            logger
-                        });
-                        await this.pushToGitHub(ir, tmpDir.path, logger);
-                    }
                 },
                 downloadFiles: async () => {
                     await typescriptProject.installDependencies(logger);


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of the changes made in this PR -->

This change removes the generator-cli responsibility for pushing self-hosted SDKs to GitHub repositories. The GitHub push functionality is now centralized in the local workspace runner, eliminating duplicate push operations and improving the reliability of the self-hosted SDK workflow.

Previously, both the generator-cli and the workspace runner would attempt to push changes when generating self-hosted SDKs, leading to potential conflicts and redundant operations. This change streamlines the process by having only the workspace runner handle GitHub operations.

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- **SDK Generators**: Remove `generateGitHub()` call in `writeForGithub()` method for self-hosted mode
- **Version Updates**: Bump versions across all affected generators (C# 2.9.3, Go v1 1.17.1, Java v2 3.18.5, Python v2 4.38.4, Swift 0.25.1, TypeScript 3.33.1)

