### PR TITLE
fix(cli): support multi-line code srcs

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,11 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- changelogEntry:
+    - summary: |
+        Support `<Code />` components with props formatted on multiple lines.
+      type: fix
+  irVersion: 61
+  createdAt: "2025-11-21"
+  version: 2.2.3
 
 - changelogEntry:
     - summary: |
@@ -6,14 +13,6 @@
       type: feat
   irVersion: 61
   createdAt: "2025-11-20"
-  version: 2.2.2
-
-- changelogEntry:
-    - summary: |
-        Support `<Code />` components with props formatted on multiple lines.
-      type: fix
-  irVersion: 61
-  createdAt: "2025-11-21"
   version: 2.2.2
 
 - changelogEntry:

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Support `<Code />` components with props formatted on multiple lines.
+      type: fix
+  irVersion: 61
+  createdAt: "2025-11-21"
+  version: 2.2.2
+
+- changelogEntry:
+    - summary: |
         Add clarified output for unchanged generator versions (i.e., generators already on the latest version) to `fern generator upgrade`.
       type: fix
   irVersion: 61

--- a/packages/cli/docs-markdown-utils/src/__test__/replaceReferencedCode.test.ts
+++ b/packages/cli/docs-markdown-utils/src/__test__/replaceReferencedCode.test.ts
@@ -362,7 +362,7 @@ describe("replaceReferencedCode", () => {
 
         `);
     });
-    
+
     it("should handle weird formatting", async () => {
         const markdown = `
             <Code title={"Hello 1"}
@@ -398,7 +398,7 @@ describe("replaceReferencedCode", () => {
 
         `);
     });
-    
+
     it("should handle more weird formatting", async () => {
         const markdown = `
             <Code title={"Hello 1"} maxLines={20}

--- a/packages/cli/docs-markdown-utils/src/__test__/replaceReferencedCode.test.ts
+++ b/packages/cli/docs-markdown-utils/src/__test__/replaceReferencedCode.test.ts
@@ -362,6 +362,71 @@ describe("replaceReferencedCode", () => {
 
         `);
     });
+    
+    it("should handle weird formatting", async () => {
+        const markdown = `
+            <Code title={"Hello 1"}
+                src="./example.js"
+            />
+
+            <Code title={"Hello 2"} src="./example.js"
+            />
+        `;
+
+        const result = await replaceReferencedCode({
+            markdown,
+            absolutePathToFernFolder,
+            absolutePathToMarkdownFile,
+            context,
+            fileLoader: async (filepath) => {
+                if (filepath === AbsoluteFilePath.of("/path/to/fern/pages/example.js")) {
+                    return "test content";
+                }
+                throw new Error(`Unexpected filepath: ${filepath}`);
+            }
+        });
+
+        expect(result).toBe(`
+            \`\`\`js title={"Hello 1"}
+            test content
+            \`\`\`
+
+
+            \`\`\`js title={"Hello 2"}
+            test content
+            \`\`\`
+
+        `);
+    });
+    
+    it("should handle more weird formatting", async () => {
+        const markdown = `
+            <Code title={"Hello 1"} maxLines={20}
+                src="./example.js"
+                highlight={40}
+            />
+        `;
+
+        const result = await replaceReferencedCode({
+            markdown,
+            absolutePathToFernFolder,
+            absolutePathToMarkdownFile,
+            context,
+            fileLoader: async (filepath) => {
+                if (filepath === AbsoluteFilePath.of("/path/to/fern/pages/example.js")) {
+                    return "test content";
+                }
+                throw new Error(`Unexpected filepath: ${filepath}`);
+            }
+        });
+
+        expect(result).toBe(`
+            \`\`\`js title={"Hello 1"} maxLines={20} highlight={40}
+            test content
+            \`\`\`
+
+        `);
+    });
 
     it("should not replace CodeBlock components", async () => {
         const markdown = `

--- a/packages/cli/docs-markdown-utils/src/replaceReferencedCode.ts
+++ b/packages/cli/docs-markdown-utils/src/replaceReferencedCode.ts
@@ -27,11 +27,11 @@ export async function replaceReferencedCode({
     context: TaskContext;
     fileLoader?: (filepath: AbsoluteFilePath) => Promise<string>;
 }): Promise<string> {
-    if (!markdown.includes("<Code ")) {
+    if (!markdown.includes("<Code")) {
         return markdown;
     }
 
-    const regex = /([ \t]*)<Code(?:\s+[^>]*?)?\s+src={?['"]([^'"]+)['"](?! \+)}?((?:\s+[^>]*)?)\/>/g;
+    const regex = /([ \t]*)<Code(?![a-zA-Z])[\s\S]*?src={?['"]([^'"]+)['"](?! \+)}?([\s\S]*?)\/>/g;
 
     let newMarkdown = markdown;
 


### PR DESCRIPTION
before, the regex was too specific, and we checked for `<Code ` with a space to trigger the codepath
