### PR TITLE
chore(rust): add circular reference detection and Box<T> wrapping for recursive types

### DIFF
--- a/generators/rust/base/src/utils/cycleDetector.ts
+++ b/generators/rust/base/src/utils/cycleDetector.ts
@@ -1,0 +1,255 @@
+import { IntermediateRepresentation, TypeDeclaration, TypeId, TypeReference } from "@fern-fern/ir-sdk/api";
+
+/**
+ * Detects illegal recursive type cycles in the IR that cannot be represented in Rust.
+ *
+ * An illegal cycle occurs when types reference each other through REQUIRED properties
+ * without any finite base case (no Option, Vec, HashMap, etc. to break the cycle).
+ *
+ * Example of illegal cycle:
+ * ```rust
+ * struct A { b: B }
+ * struct B { a: A }  // Error: no finite base case
+ * ```
+ *
+ * Example of legal cycle:
+ * ```rust
+ * struct A { b: Option<B> }  // OK: Option provides finite base case (None)
+ * struct B { a: A }
+ * ```
+ */
+export class RustCycleDetector {
+    public constructor(private readonly ir: IntermediateRepresentation) {}
+
+    /**
+     * Detects illegal cycles and throws an error if any are found.
+     * Should be called during generator initialization.
+     */
+    public detectIllegalCycles(): void {
+        const dependencyGraph = this.buildRequiredDependencyGraph();
+        const visited = new Set<TypeId>();
+        const visiting = new Set<TypeId>();
+        const stack: TypeId[] = [];
+
+        const typeIds = Object.keys(this.ir.types);
+
+        for (const typeId of typeIds) {
+            if (!visited.has(typeId)) {
+                const cycle = this.dfsFindCycle(typeId, dependencyGraph, visited, visiting, stack);
+                if (cycle != null) {
+                    const message = this.formatCycleError(cycle);
+                    throw new Error(message);
+                }
+            }
+        }
+    }
+
+    /**
+     * Builds a graph where there is a directed edge A -> B iff every value of A
+     * must (transitively) contain a value of B. In practice, this means:
+     *
+     * - Edges through required properties whose type is a non-container,
+     *   non-nullable, non-optional named type (after alias resolution)
+     * - Edges through object/union inheritance (`extends`)
+     *
+     * Edges through containers (Vec, HashMap, HashSet) and Option/Nullable wrappers
+     * are intentionally ignored, because those provide a finite base case:
+     * - Option<T> can be None
+     * - Vec<T> can be empty []
+     * - HashMap<K, V> can be empty {}
+     *
+     * This makes such cycles representable in Rust and valid.
+     */
+    private buildRequiredDependencyGraph(): Map<TypeId, TypeId[]> {
+        const graph = new Map<TypeId, TypeId[]>();
+
+        for (const [typeId, typeDeclaration] of Object.entries(this.ir.types)) {
+            const deps = this.getRequiredDependenciesForType(typeDeclaration);
+            graph.set(typeId, deps);
+        }
+
+        return graph;
+    }
+
+    /**
+     * Gets the set of types that this type MUST contain (i.e., no finite base case).
+     */
+    private getRequiredDependenciesForType(typeDeclaration: TypeDeclaration): TypeId[] {
+        const dependencies = new Set<TypeId>();
+
+        typeDeclaration.shape._visit({
+            alias: (aliasShape) => {
+                // Aliases inherit the requirements of their aliased type
+                const dep = this.getRequiredNamedDependencyForType(aliasShape.aliasOf);
+                if (dep != null) {
+                    dependencies.add(dep);
+                }
+            },
+            enum: () => {
+                // Enums have no recursive structure
+            },
+            object: (objectShape) => {
+                // Inheritance is always required (no way to have "no parent")
+                for (const parent of objectShape.extends) {
+                    dependencies.add(parent.typeId);
+                }
+
+                // Check all properties to see if they create required dependencies
+                const allProperties = [...(objectShape.extendedProperties ?? []), ...objectShape.properties];
+                for (const property of allProperties) {
+                    const dep = this.getRequiredNamedDependencyForType(property.valueType);
+                    if (dep != null) {
+                        dependencies.add(dep);
+                    }
+                }
+            },
+            union: (unionShape) => {
+                // Union inheritance is always required
+                for (const parent of unionShape.extends) {
+                    dependencies.add(parent.typeId);
+                }
+
+                // Base properties are present for every union variant, so they're required
+                for (const baseProperty of unionShape.baseProperties) {
+                    const dep = this.getRequiredNamedDependencyForType(baseProperty.valueType);
+                    if (dep != null) {
+                        dependencies.add(dep);
+                    }
+                }
+
+                // Individual union variants provide alternatives, not requirements.
+                // If at least one variant doesn't create a cycle, the type has a finite base case.
+                // So we intentionally ignore variant-specific properties here.
+            },
+            undiscriminatedUnion: () => {
+                // Members of an undiscriminated union are alternatives, not requirements.
+                // At least one member will not create a cycle, providing a finite base case.
+            },
+            _other: () => {
+                // Future-proof for new shapes
+            }
+        });
+
+        return Array.from(dependencies);
+    }
+
+    /**
+     * Checks if a type reference creates a required dependency (i.e., must always contain the target type).
+     * Returns the target type ID only if:
+     * - The type is a named type (after alias resolution)
+     * - It's NOT wrapped in Option or Nullable
+     * - It's NOT inside a container (Vec, HashMap, HashSet)
+     */
+    private getRequiredNamedDependencyForType(typeReference: TypeReference): TypeId | null {
+        const unaliased = this.resolveAlias(typeReference);
+
+        // Only named types can create dependencies
+        if (unaliased.type === "named") {
+            return unaliased.typeId;
+        }
+
+        // Container types provide finite base cases, so they don't create required dependencies
+        if (unaliased.type === "container") {
+            return unaliased.container._visit<TypeId | null>({
+                // Option and Nullable provide finite base cases (None, null)
+                optional: () => null,
+                nullable: () => null,
+                // Collections provide finite base cases (empty collection)
+                list: () => null,
+                map: () => null,
+                set: () => null,
+                literal: () => null,
+                _other: () => null
+            });
+        }
+
+        return null;
+    }
+
+    /**
+     * Resolves type aliases to their underlying type.
+     * Handles alias chains: A -> B -> C resolves to C.
+     */
+    private resolveAlias(typeReference: TypeReference): TypeReference {
+        const visitedAliases = new Set<TypeId>();
+
+        const unwrapAlias = (ref: TypeReference): TypeReference => {
+            if (ref.type === "named") {
+                const typeDeclaration = this.ir.types[ref.typeId];
+                if (
+                    typeDeclaration != null &&
+                    typeDeclaration.shape.type === "alias" &&
+                    !visitedAliases.has(ref.typeId)
+                ) {
+                    visitedAliases.add(ref.typeId);
+                    return unwrapAlias(typeDeclaration.shape.aliasOf);
+                }
+            }
+            return ref;
+        };
+
+        return unwrapAlias(typeReference);
+    }
+
+    /**
+     * Performs depth-first search to find cycles in the required dependency graph.
+     * Uses the "visiting" set to detect back-edges (cycles).
+     */
+    private dfsFindCycle(
+        typeId: TypeId,
+        graph: Map<TypeId, TypeId[]>,
+        visited: Set<TypeId>,
+        visiting: Set<TypeId>,
+        stack: TypeId[]
+    ): TypeId[] | undefined {
+        visiting.add(typeId);
+        stack.push(typeId);
+
+        const neighbors = graph.get(typeId) ?? [];
+        for (const neighbor of neighbors) {
+            if (visited.has(neighbor)) {
+                continue;
+            }
+            if (visiting.has(neighbor)) {
+                // Found a back-edge (cycle)! Extract the cycle from the stack
+                const startIndex = stack.indexOf(neighbor);
+                if (startIndex !== -1) {
+                    return stack.slice(startIndex).concat(neighbor);
+                }
+                continue;
+            }
+            const cycle = this.dfsFindCycle(neighbor, graph, visited, visiting, stack);
+            if (cycle != null) {
+                return cycle;
+            }
+        }
+
+        stack.pop();
+        visiting.delete(typeId);
+        visited.add(typeId);
+        return undefined;
+    }
+
+    /**
+     * Formats a user-friendly error message showing the cycle path.
+     */
+    private formatCycleError(cycle: TypeId[]): string {
+        const prettyPath = cycle
+            .map((typeId) => {
+                const typeDeclaration = this.ir.types[typeId];
+                const typeName =
+                    typeDeclaration?.name?.name?.originalName ??
+                    typeDeclaration?.name?.name?.pascalCase?.unsafeName ??
+                    typeId;
+                return typeName;
+            })
+            .join(" -> ");
+
+        return [
+            "Illegal recursive type cycle detected in Rust generator.",
+            `The following types reference each other via required properties: ${prettyPath}.`,
+            "Such a cycle cannot be represented in Rust because it has no finite base case.",
+            "To fix this, wrap at least one of the properties in Option<T>, Vec<T>, or another container type."
+        ].join(" ");
+    }
+}

--- a/generators/rust/base/src/utils/index.ts
+++ b/generators/rust/base/src/utils/index.ts
@@ -1,6 +1,8 @@
 import { camelCase, snakeCase } from "lodash-es";
 import { RUST_KEYWORDS, RUST_RESERVED_TYPES } from "../constants";
 
+export { RustCycleDetector } from "./cycleDetector";
+
 export function convertToSnakeCase(str: string): string {
     return snakeCase(str);
 }

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -3,7 +3,7 @@
 - version: 0.13.2
   createdAt: "2025-11-25"
   changelogEntry:
-    - type: feat
+    - type: chore
       summary: |
         add circular reference detection and Box<T> wrapping for recursive types
   irVersion: 61

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -5,7 +5,7 @@
   changelogEntry:
     - type: chore
       summary: |
-        add circular reference detection and Box<T> wrapping for recursive types
+        add circular reference detection and Box wrapping for recursive types
   irVersion: 61
 
 - version: 0.13.1

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
-- version: 0.13.1
+- version: 0.13.2
   createdAt: "2025-11-25"
   changelogEntry:
     - type: feat

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
 - version: 0.13.1
+  createdAt: "2025-11-25"
+  changelogEntry:
+    - type: feat
+      summary: |
+        add circular reference detection and Box<T> wrapping for recursive types
+  irVersion: 61
+
+- version: 0.13.1
   createdAt: "2025-11-24"
   changelogEntry:
     - type: chore

--- a/seed/rust-model/seed.yml
+++ b/seed/rust-model/seed.yml
@@ -48,12 +48,4 @@ fixtures:
   types:
     - customConfig:
         generateBuilders: true
-      outputFolder: with-builders 
-
-allowedFailures:
-  - circular-references
-  - circular-references-advanced
-  - examples
-  - objects-with-imports
-  - pagination
-  - trace
+      outputFolder: with-builders

--- a/seed/rust-sdk/circular-references-advanced/Cargo.toml
+++ b/seed/rust-sdk/circular-references-advanced/Cargo.toml
@@ -11,20 +11,22 @@ documentation = "https://docs.rs/seed_api"
 doctest = false
 
 [dependencies]
+bytes = "1.0"
+chrono = { version = "0.4", features = ["serde"] }
+futures = "0.3"
+num-bigint = { version = "0.4", features = ["serde"] }
+ordered-float = { version = "4.5", features = ["serde"] }
+percent-encoding = "2.3"
+reqwest = { version = "0.12", features = ["json", "stream"], default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-reqwest = { version = "0.12", features = ["json", "stream", "multipart"] }
-reqwest-sse = "0.1"
-tokio = { version = "1.0", features = ["full"] }
-futures = "0.3"
-bytes = "1.0"
 thiserror = "1.0"
-chrono = { version = "0.4", features = ["serde"] }
+tokio = { version = "1.0", features = ["full"] }
 uuid = { version = "1.0", features = ["serde"] }
-num-bigint = { version = "0.4", features = ["serde"] }
-percent-encoding = "2.3"
-ordered-float = { version = "4.5", features = ["serde"] }
-pin-project = "1.1"
 
 [dev-dependencies]
 tokio-test = "0.4"
+
+[features]
+multipart = []
+sse = []

--- a/seed/rust-sdk/circular-references-advanced/src/api/types/ast_animal.rs
+++ b/seed/rust-sdk/circular-references-advanced/src/api/types/ast_animal.rs
@@ -3,9 +3,9 @@ pub use crate::prelude::*;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(untagged)]
 pub enum Animal {
-    Cat(Cat),
+    Cat(Box<Cat>),
 
-    Dog(Dog),
+    Dog(Box<Dog>),
 }
 
 impl Animal {
@@ -17,7 +17,7 @@ impl Animal {
         matches!(self, Self::Dog(_))
     }
 
-    pub fn as_cat(&self) -> Option<&Cat> {
+    pub fn as_cat(&self) -> Option<&Box<Cat>> {
         match self {
             Self::Cat(value) => Some(value),
             _ => None,
@@ -26,12 +26,12 @@ impl Animal {
 
     pub fn into_cat(self) -> Option<Cat> {
         match self {
-            Self::Cat(value) => Some(value),
+            Self::Cat(value) => Some(*value),
             _ => None,
         }
     }
 
-    pub fn as_dog(&self) -> Option<&Dog> {
+    pub fn as_dog(&self) -> Option<&Box<Dog>> {
         match self {
             Self::Dog(value) => Some(value),
             _ => None,
@@ -40,7 +40,7 @@ impl Animal {
 
     pub fn into_dog(self) -> Option<Dog> {
         match self {
-            Self::Dog(value) => Some(value),
+            Self::Dog(value) => Some(*value),
             _ => None,
         }
     }

--- a/seed/rust-sdk/circular-references-advanced/src/api/types/ast_branch_node.rs
+++ b/seed/rust-sdk/circular-references-advanced/src/api/types/ast_branch_node.rs
@@ -2,5 +2,5 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct BranchNode {
-    pub children: Vec<Node>,
+    pub children: Vec<Box<Node>>,
 }

--- a/seed/rust-sdk/circular-references-advanced/src/api/types/ast_cat.rs
+++ b/seed/rust-sdk/circular-references-advanced/src/api/types/ast_cat.rs
@@ -2,5 +2,5 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Cat {
-    pub fruit: Fruit,
+    pub fruit: Box<Fruit>,
 }

--- a/seed/rust-sdk/circular-references-advanced/src/api/types/ast_container_value.rs
+++ b/seed/rust-sdk/circular-references-advanced/src/api/types/ast_container_value.rs
@@ -3,7 +3,7 @@ pub use crate::prelude::*;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
 pub enum ContainerValue {
-    List { value: Vec<FieldValue> },
+    List { value: Vec<Box<FieldValue>> },
 
-    Optional { value: Option<FieldValue> },
+    Optional { value: Option<Box<FieldValue>> },
 }

--- a/seed/rust-sdk/circular-references-advanced/src/api/types/ast_dog.rs
+++ b/seed/rust-sdk/circular-references-advanced/src/api/types/ast_dog.rs
@@ -2,5 +2,5 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Dog {
-    pub fruit: Fruit,
+    pub fruit: Box<Fruit>,
 }

--- a/seed/rust-sdk/circular-references-advanced/src/api/types/ast_field_value.rs
+++ b/seed/rust-sdk/circular-references-advanced/src/api/types/ast_field_value.rs
@@ -13,5 +13,5 @@ pub enum FieldValue {
     },
 
     #[serde(rename = "container_value")]
-    ContainerValue { value: ContainerValue },
+    ContainerValue { value: Box<ContainerValue> },
 }

--- a/seed/rust-sdk/circular-references-advanced/src/api/types/ast_fig.rs
+++ b/seed/rust-sdk/circular-references-advanced/src/api/types/ast_fig.rs
@@ -2,5 +2,5 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Fig {
-    pub animal: Animal,
+    pub animal: Box<Animal>,
 }

--- a/seed/rust-sdk/circular-references-advanced/src/api/types/ast_fruit.rs
+++ b/seed/rust-sdk/circular-references-advanced/src/api/types/ast_fruit.rs
@@ -5,7 +5,7 @@ pub use crate::prelude::*;
 pub enum Fruit {
     Acai(Acai),
 
-    Fig(Fig),
+    Fig(Box<Fig>),
 }
 
 impl Fruit {
@@ -31,7 +31,7 @@ impl Fruit {
         }
     }
 
-    pub fn as_fig(&self) -> Option<&Fig> {
+    pub fn as_fig(&self) -> Option<&Box<Fig>> {
         match self {
             Self::Fig(value) => Some(value),
             _ => None,
@@ -40,7 +40,7 @@ impl Fruit {
 
     pub fn into_fig(self) -> Option<Fig> {
         match self {
-            Self::Fig(value) => Some(value),
+            Self::Fig(value) => Some(*value),
             _ => None,
         }
     }

--- a/seed/rust-sdk/circular-references-advanced/src/api/types/ast_node.rs
+++ b/seed/rust-sdk/circular-references-advanced/src/api/types/ast_node.rs
@@ -3,7 +3,7 @@ pub use crate::prelude::*;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(untagged)]
 pub enum Node {
-    BranchNode(BranchNode),
+    BranchNode(Box<BranchNode>),
 
     LeafNode(LeafNode),
 }
@@ -17,7 +17,7 @@ impl Node {
         matches!(self, Self::LeafNode(_))
     }
 
-    pub fn as_branchnode(&self) -> Option<&BranchNode> {
+    pub fn as_branchnode(&self) -> Option<&Box<BranchNode>> {
         match self {
             Self::BranchNode(value) => Some(value),
             _ => None,
@@ -26,7 +26,7 @@ impl Node {
 
     pub fn into_branchnode(self) -> Option<BranchNode> {
         match self {
-            Self::BranchNode(value) => Some(value),
+            Self::BranchNode(value) => Some(*value),
             _ => None,
         }
     }

--- a/seed/rust-sdk/circular-references-advanced/src/core/http_client.rs
+++ b/seed/rust-sdk/circular-references-advanced/src/core/http_client.rs
@@ -166,6 +166,7 @@ impl HttpClient {
     ///     None,
     /// ).await?;
     /// ```
+    #[cfg(feature = "multipart")]
     pub async fn execute_multipart_request<T>(
         &self,
         method: Method,
@@ -450,6 +451,7 @@ impl HttpClient {
     ///     println!("Received: {:?}", chunk);
     /// }
     /// ```
+    #[cfg(feature = "sse")]
     pub async fn execute_sse_request<T>(
         &self,
         method: Method,

--- a/seed/rust-sdk/circular-references-advanced/src/core/mod.rs
+++ b/seed/rust-sdk/circular-references-advanced/src/core/mod.rs
@@ -3,11 +3,13 @@
 mod http_client;
 mod query_parameter_builder;
 mod request_options;
+#[cfg(feature = "sse")]
 mod sse_stream;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
+#[cfg(feature = "sse")]
 pub use sse_stream::SseStream;
 pub use utils::join_url;

--- a/seed/rust-sdk/circular-references-advanced/src/prelude.rs
+++ b/seed/rust-sdk/circular-references-advanced/src/prelude.rs
@@ -12,10 +12,8 @@ pub use crate::error::ApiError;
 pub use crate::api::*;
 
 // Re-export commonly used external types
-pub use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
 pub use ordered_float::OrderedFloat;
 pub use serde::{Deserialize, Serialize};
 pub use serde_json::{json, Value};
 pub use std::collections::{HashMap, HashSet};
 pub use std::fmt;
-pub use uuid::Uuid;

--- a/seed/rust-sdk/circular-references/Cargo.toml
+++ b/seed/rust-sdk/circular-references/Cargo.toml
@@ -11,20 +11,22 @@ documentation = "https://docs.rs/seed_api"
 doctest = false
 
 [dependencies]
+bytes = "1.0"
+chrono = { version = "0.4", features = ["serde"] }
+futures = "0.3"
+num-bigint = { version = "0.4", features = ["serde"] }
+ordered-float = { version = "4.5", features = ["serde"] }
+percent-encoding = "2.3"
+reqwest = { version = "0.12", features = ["json", "stream"], default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-reqwest = { version = "0.12", features = ["json", "stream", "multipart"] }
-reqwest-sse = "0.1"
-tokio = { version = "1.0", features = ["full"] }
-futures = "0.3"
-bytes = "1.0"
 thiserror = "1.0"
-chrono = { version = "0.4", features = ["serde"] }
+tokio = { version = "1.0", features = ["full"] }
 uuid = { version = "1.0", features = ["serde"] }
-num-bigint = { version = "0.4", features = ["serde"] }
-percent-encoding = "2.3"
-ordered-float = { version = "4.5", features = ["serde"] }
-pin-project = "1.1"
 
 [dev-dependencies]
 tokio-test = "0.4"
+
+[features]
+multipart = []
+sse = []

--- a/seed/rust-sdk/circular-references/src/api/types/ast_container_value.rs
+++ b/seed/rust-sdk/circular-references/src/api/types/ast_container_value.rs
@@ -3,7 +3,7 @@ pub use crate::prelude::*;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
 pub enum ContainerValue {
-    List { value: Vec<FieldValue> },
+    List { value: Vec<Box<FieldValue>> },
 
-    Optional { value: Option<FieldValue> },
+    Optional { value: Option<Box<FieldValue>> },
 }

--- a/seed/rust-sdk/circular-references/src/api/types/ast_field_value.rs
+++ b/seed/rust-sdk/circular-references/src/api/types/ast_field_value.rs
@@ -13,5 +13,5 @@ pub enum FieldValue {
     },
 
     #[serde(rename = "container_value")]
-    ContainerValue { value: ContainerValue },
+    ContainerValue { value: Box<ContainerValue> },
 }

--- a/seed/rust-sdk/circular-references/src/api/types/ast_t.rs
+++ b/seed/rust-sdk/circular-references/src/api/types/ast_t.rs
@@ -2,5 +2,5 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct T {
-    pub child: TorU,
+    pub child: Box<TorU>,
 }

--- a/seed/rust-sdk/circular-references/src/api/types/ast_tor_u.rs
+++ b/seed/rust-sdk/circular-references/src/api/types/ast_tor_u.rs
@@ -3,9 +3,9 @@ pub use crate::prelude::*;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(untagged)]
 pub enum TorU {
-    T(T),
+    T(Box<T>),
 
-    U(U),
+    U(Box<U>),
 }
 
 impl TorU {
@@ -17,7 +17,7 @@ impl TorU {
         matches!(self, Self::U(_))
     }
 
-    pub fn as_t(&self) -> Option<&T> {
+    pub fn as_t(&self) -> Option<&Box<T>> {
         match self {
             Self::T(value) => Some(value),
             _ => None,
@@ -26,12 +26,12 @@ impl TorU {
 
     pub fn into_t(self) -> Option<T> {
         match self {
-            Self::T(value) => Some(value),
+            Self::T(value) => Some(*value),
             _ => None,
         }
     }
 
-    pub fn as_u(&self) -> Option<&U> {
+    pub fn as_u(&self) -> Option<&Box<U>> {
         match self {
             Self::U(value) => Some(value),
             _ => None,
@@ -40,7 +40,7 @@ impl TorU {
 
     pub fn into_u(self) -> Option<U> {
         match self {
-            Self::U(value) => Some(value),
+            Self::U(value) => Some(*value),
             _ => None,
         }
     }

--- a/seed/rust-sdk/circular-references/src/api/types/ast_u.rs
+++ b/seed/rust-sdk/circular-references/src/api/types/ast_u.rs
@@ -2,5 +2,5 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct U {
-    pub child: T,
+    pub child: Box<T>,
 }

--- a/seed/rust-sdk/circular-references/src/core/http_client.rs
+++ b/seed/rust-sdk/circular-references/src/core/http_client.rs
@@ -166,6 +166,7 @@ impl HttpClient {
     ///     None,
     /// ).await?;
     /// ```
+    #[cfg(feature = "multipart")]
     pub async fn execute_multipart_request<T>(
         &self,
         method: Method,
@@ -450,6 +451,7 @@ impl HttpClient {
     ///     println!("Received: {:?}", chunk);
     /// }
     /// ```
+    #[cfg(feature = "sse")]
     pub async fn execute_sse_request<T>(
         &self,
         method: Method,

--- a/seed/rust-sdk/circular-references/src/core/mod.rs
+++ b/seed/rust-sdk/circular-references/src/core/mod.rs
@@ -3,11 +3,13 @@
 mod http_client;
 mod query_parameter_builder;
 mod request_options;
+#[cfg(feature = "sse")]
 mod sse_stream;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
+#[cfg(feature = "sse")]
 pub use sse_stream::SseStream;
 pub use utils::join_url;

--- a/seed/rust-sdk/circular-references/src/prelude.rs
+++ b/seed/rust-sdk/circular-references/src/prelude.rs
@@ -12,10 +12,8 @@ pub use crate::error::ApiError;
 pub use crate::api::*;
 
 // Re-export commonly used external types
-pub use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
 pub use ordered_float::OrderedFloat;
 pub use serde::{Deserialize, Serialize};
 pub use serde_json::{json, Value};
 pub use std::collections::{HashMap, HashSet};
 pub use std::fmt;
-pub use uuid::Uuid;

--- a/seed/rust-sdk/examples/no-custom-config/src/api/types/types_directory.rs
+++ b/seed/rust-sdk/examples/no-custom-config/src/api/types/types_directory.rs
@@ -6,5 +6,5 @@ pub struct Directory {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub files: Option<Vec<File>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub directories: Option<Vec<Directory>>,
+    pub directories: Option<Vec<Box<Directory>>>,
 }

--- a/seed/rust-sdk/examples/no-custom-config/src/api/types/types_node.rs
+++ b/seed/rust-sdk/examples/no-custom-config/src/api/types/types_node.rs
@@ -4,7 +4,7 @@ pub use crate::prelude::*;
 pub struct Node {
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub nodes: Option<Vec<Node>>,
+    pub nodes: Option<Vec<Box<Node>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub trees: Option<Vec<Tree>>,
+    pub trees: Option<Vec<Box<Tree>>>,
 }

--- a/seed/rust-sdk/examples/no-custom-config/src/api/types/types_tree.rs
+++ b/seed/rust-sdk/examples/no-custom-config/src/api/types/types_tree.rs
@@ -3,5 +3,5 @@ pub use crate::prelude::*;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Tree {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub nodes: Option<Vec<Node>>,
+    pub nodes: Option<Vec<Box<Node>>>,
 }

--- a/seed/rust-sdk/examples/readme-config/src/api/types/types_directory.rs
+++ b/seed/rust-sdk/examples/readme-config/src/api/types/types_directory.rs
@@ -6,5 +6,5 @@ pub struct Directory {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub files: Option<Vec<File>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub directories: Option<Vec<Directory>>,
+    pub directories: Option<Vec<Box<Directory>>>,
 }

--- a/seed/rust-sdk/examples/readme-config/src/api/types/types_node.rs
+++ b/seed/rust-sdk/examples/readme-config/src/api/types/types_node.rs
@@ -4,7 +4,7 @@ pub use crate::prelude::*;
 pub struct Node {
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub nodes: Option<Vec<Node>>,
+    pub nodes: Option<Vec<Box<Node>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub trees: Option<Vec<Tree>>,
+    pub trees: Option<Vec<Box<Tree>>>,
 }

--- a/seed/rust-sdk/examples/readme-config/src/api/types/types_tree.rs
+++ b/seed/rust-sdk/examples/readme-config/src/api/types/types_tree.rs
@@ -3,5 +3,5 @@ pub use crate::prelude::*;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Tree {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub nodes: Option<Vec<Node>>,
+    pub nodes: Option<Vec<Box<Node>>>,
 }

--- a/seed/rust-sdk/objects-with-imports/Cargo.toml
+++ b/seed/rust-sdk/objects-with-imports/Cargo.toml
@@ -11,20 +11,22 @@ documentation = "https://docs.rs/seed_objects_with_imports"
 doctest = false
 
 [dependencies]
+bytes = "1.0"
+chrono = { version = "0.4", features = ["serde"] }
+futures = "0.3"
+num-bigint = { version = "0.4", features = ["serde"] }
+ordered-float = { version = "4.5", features = ["serde"] }
+percent-encoding = "2.3"
+reqwest = { version = "0.12", features = ["json", "stream"], default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-reqwest = { version = "0.12", features = ["json", "stream", "multipart"] }
-reqwest-sse = "0.1"
-tokio = { version = "1.0", features = ["full"] }
-futures = "0.3"
-bytes = "1.0"
 thiserror = "1.0"
-chrono = { version = "0.4", features = ["serde"] }
+tokio = { version = "1.0", features = ["full"] }
 uuid = { version = "1.0", features = ["serde"] }
-num-bigint = { version = "0.4", features = ["serde"] }
-percent-encoding = "2.3"
-ordered-float = { version = "4.5", features = ["serde"] }
-pin-project = "1.1"
 
 [dev-dependencies]
 tokio-test = "0.4"
+
+[features]
+multipart = []
+sse = []

--- a/seed/rust-sdk/objects-with-imports/src/api/types/file_directory_directory.rs
+++ b/seed/rust-sdk/objects-with-imports/src/api/types/file_directory_directory.rs
@@ -6,5 +6,5 @@ pub struct Directory {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub files: Option<Vec<File>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub directories: Option<Vec<Directory>>,
+    pub directories: Option<Vec<Box<Directory>>>,
 }

--- a/seed/rust-sdk/objects-with-imports/src/core/http_client.rs
+++ b/seed/rust-sdk/objects-with-imports/src/core/http_client.rs
@@ -166,6 +166,7 @@ impl HttpClient {
     ///     None,
     /// ).await?;
     /// ```
+    #[cfg(feature = "multipart")]
     pub async fn execute_multipart_request<T>(
         &self,
         method: Method,
@@ -450,6 +451,7 @@ impl HttpClient {
     ///     println!("Received: {:?}", chunk);
     /// }
     /// ```
+    #[cfg(feature = "sse")]
     pub async fn execute_sse_request<T>(
         &self,
         method: Method,

--- a/seed/rust-sdk/objects-with-imports/src/core/mod.rs
+++ b/seed/rust-sdk/objects-with-imports/src/core/mod.rs
@@ -3,11 +3,13 @@
 mod http_client;
 mod query_parameter_builder;
 mod request_options;
+#[cfg(feature = "sse")]
 mod sse_stream;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
+#[cfg(feature = "sse")]
 pub use sse_stream::SseStream;
 pub use utils::join_url;

--- a/seed/rust-sdk/objects-with-imports/src/prelude.rs
+++ b/seed/rust-sdk/objects-with-imports/src/prelude.rs
@@ -12,10 +12,8 @@ pub use crate::error::ApiError;
 pub use crate::api::*;
 
 // Re-export commonly used external types
-pub use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
 pub use ordered_float::OrderedFloat;
 pub use serde::{Deserialize, Serialize};
 pub use serde_json::{json, Value};
 pub use std::collections::{HashMap, HashSet};
 pub use std::fmt;
-pub use uuid::Uuid;

--- a/seed/rust-sdk/pagination/Cargo.toml
+++ b/seed/rust-sdk/pagination/Cargo.toml
@@ -11,20 +11,22 @@ documentation = "https://docs.rs/seed_pagination"
 doctest = false
 
 [dependencies]
+bytes = "1.0"
+chrono = { version = "0.4", features = ["serde"] }
+futures = "0.3"
+num-bigint = { version = "0.4", features = ["serde"] }
+ordered-float = { version = "4.5", features = ["serde"] }
+percent-encoding = "2.3"
+reqwest = { version = "0.12", features = ["json", "stream"], default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-reqwest = { version = "0.12", features = ["json", "stream", "multipart"] }
-reqwest-sse = "0.1"
-tokio = { version = "1.0", features = ["full"] }
-futures = "0.3"
-bytes = "1.0"
 thiserror = "1.0"
-chrono = { version = "0.4", features = ["serde"] }
+tokio = { version = "1.0", features = ["full"] }
 uuid = { version = "1.0", features = ["serde"] }
-num-bigint = { version = "0.4", features = ["serde"] }
-percent-encoding = "2.3"
-ordered-float = { version = "4.5", features = ["serde"] }
-pin-project = "1.1"
 
 [dev-dependencies]
 tokio-test = "0.4"
+
+[features]
+multipart = []
+sse = []

--- a/seed/rust-sdk/pagination/src/api/types/complex_multiple_filter_search_request.rs
+++ b/seed/rust-sdk/pagination/src/api/types/complex_multiple_filter_search_request.rs
@@ -5,5 +5,5 @@ pub struct MultipleFilterSearchRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub operator: Option<MultipleFilterSearchRequestOperator>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub value: Option<MultipleFilterSearchRequestValue>,
+    pub value: Option<Box<MultipleFilterSearchRequestValue>>,
 }

--- a/seed/rust-sdk/pagination/src/core/http_client.rs
+++ b/seed/rust-sdk/pagination/src/core/http_client.rs
@@ -166,6 +166,7 @@ impl HttpClient {
     ///     None,
     /// ).await?;
     /// ```
+    #[cfg(feature = "multipart")]
     pub async fn execute_multipart_request<T>(
         &self,
         method: Method,
@@ -450,6 +451,7 @@ impl HttpClient {
     ///     println!("Received: {:?}", chunk);
     /// }
     /// ```
+    #[cfg(feature = "sse")]
     pub async fn execute_sse_request<T>(
         &self,
         method: Method,

--- a/seed/rust-sdk/pagination/src/core/mod.rs
+++ b/seed/rust-sdk/pagination/src/core/mod.rs
@@ -3,11 +3,13 @@
 mod http_client;
 mod query_parameter_builder;
 mod request_options;
+#[cfg(feature = "sse")]
 mod sse_stream;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
+#[cfg(feature = "sse")]
 pub use sse_stream::SseStream;
 pub use utils::join_url;

--- a/seed/rust-sdk/pagination/src/prelude.rs
+++ b/seed/rust-sdk/pagination/src/prelude.rs
@@ -12,7 +12,6 @@ pub use crate::error::ApiError;
 pub use crate::api::*;
 
 // Re-export commonly used external types
-pub use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
 pub use ordered_float::OrderedFloat;
 pub use serde::{Deserialize, Serialize};
 pub use serde_json::{json, Value};

--- a/seed/rust-sdk/seed.yml
+++ b/seed/rust-sdk/seed.yml
@@ -116,10 +116,3 @@ fixtures:
           timeouts:
             - GET /movie/{movieId}
       outputFolder: readme-config
-
-allowedFailures:
-  - circular-references
-  - circular-references-advanced
-  - objects-with-imports
-  - pagination
-  - trace

--- a/seed/rust-sdk/trace/Cargo.toml
+++ b/seed/rust-sdk/trace/Cargo.toml
@@ -11,20 +11,22 @@ documentation = "https://docs.rs/seed_trace"
 doctest = false
 
 [dependencies]
+bytes = "1.0"
+chrono = { version = "0.4", features = ["serde"] }
+futures = "0.3"
+num-bigint = { version = "0.4", features = ["serde"] }
+ordered-float = { version = "4.5", features = ["serde"] }
+percent-encoding = "2.3"
+reqwest = { version = "0.12", features = ["json", "stream"], default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-reqwest = { version = "0.12", features = ["json", "stream", "multipart"] }
-reqwest-sse = "0.1"
-tokio = { version = "1.0", features = ["full"] }
-futures = "0.3"
-bytes = "1.0"
 thiserror = "1.0"
-chrono = { version = "0.4", features = ["serde"] }
+tokio = { version = "1.0", features = ["full"] }
 uuid = { version = "1.0", features = ["serde"] }
-num-bigint = { version = "0.4", features = ["serde"] }
-percent-encoding = "2.3"
-ordered-float = { version = "4.5", features = ["serde"] }
-pin-project = "1.1"
 
 [dev-dependencies]
 tokio-test = "0.4"
+
+[features]
+multipart = []
+sse = []

--- a/seed/rust-sdk/trace/src/api/types/commons_debug_key_value_pairs.rs
+++ b/seed/rust-sdk/trace/src/api/types/commons_debug_key_value_pairs.rs
@@ -2,6 +2,6 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct DebugKeyValuePairs {
-    pub key: DebugVariableValue,
-    pub value: DebugVariableValue,
+    pub key: Box<DebugVariableValue>,
+    pub value: Box<DebugVariableValue>,
 }

--- a/seed/rust-sdk/trace/src/api/types/commons_debug_map_value.rs
+++ b/seed/rust-sdk/trace/src/api/types/commons_debug_map_value.rs
@@ -3,5 +3,5 @@ pub use crate::prelude::*;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct DebugMapValue {
     #[serde(rename = "keyValuePairs")]
-    pub key_value_pairs: Vec<DebugKeyValuePairs>,
+    pub key_value_pairs: Vec<Box<DebugKeyValuePairs>>,
 }

--- a/seed/rust-sdk/trace/src/api/types/commons_debug_variable_value.rs
+++ b/seed/rust-sdk/trace/src/api/types/commons_debug_variable_value.rs
@@ -25,11 +25,11 @@ pub enum DebugVariableValue {
 
     MapValue {
         #[serde(flatten)]
-        data: DebugMapValue,
+        data: Box<DebugMapValue>,
     },
 
     ListValue {
-        value: Vec<DebugVariableValue>,
+        value: Vec<Box<DebugVariableValue>>,
     },
 
     BinaryTreeNodeValue {

--- a/seed/rust-sdk/trace/src/api/types/commons_key_value_pair.rs
+++ b/seed/rust-sdk/trace/src/api/types/commons_key_value_pair.rs
@@ -2,6 +2,6 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct KeyValuePair {
-    pub key: VariableValue,
-    pub value: VariableValue,
+    pub key: Box<VariableValue>,
+    pub value: Box<VariableValue>,
 }

--- a/seed/rust-sdk/trace/src/api/types/commons_list_type.rs
+++ b/seed/rust-sdk/trace/src/api/types/commons_list_type.rs
@@ -3,7 +3,7 @@ pub use crate::prelude::*;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ListType {
     #[serde(rename = "valueType")]
-    pub value_type: VariableType,
+    pub value_type: Box<VariableType>,
     /// Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false.
     #[serde(rename = "isFixedLength")]
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/seed/rust-sdk/trace/src/api/types/commons_map_type.rs
+++ b/seed/rust-sdk/trace/src/api/types/commons_map_type.rs
@@ -3,7 +3,7 @@ pub use crate::prelude::*;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct MapType {
     #[serde(rename = "keyType")]
-    pub key_type: VariableType,
+    pub key_type: Box<VariableType>,
     #[serde(rename = "valueType")]
-    pub value_type: VariableType,
+    pub value_type: Box<VariableType>,
 }

--- a/seed/rust-sdk/trace/src/api/types/commons_map_value.rs
+++ b/seed/rust-sdk/trace/src/api/types/commons_map_value.rs
@@ -3,5 +3,5 @@ pub use crate::prelude::*;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct MapValue {
     #[serde(rename = "keyValuePairs")]
-    pub key_value_pairs: Vec<KeyValuePair>,
+    pub key_value_pairs: Vec<Box<KeyValuePair>>,
 }

--- a/seed/rust-sdk/trace/src/api/types/commons_variable_type.rs
+++ b/seed/rust-sdk/trace/src/api/types/commons_variable_type.rs
@@ -15,12 +15,12 @@ pub enum VariableType {
 
     ListType {
         #[serde(flatten)]
-        data: ListType,
+        data: Box<ListType>,
     },
 
     MapType {
         #[serde(flatten)]
-        data: MapType,
+        data: Box<MapType>,
     },
 
     BinaryTreeType,

--- a/seed/rust-sdk/trace/src/api/types/commons_variable_value.rs
+++ b/seed/rust-sdk/trace/src/api/types/commons_variable_value.rs
@@ -25,11 +25,11 @@ pub enum VariableValue {
 
     MapValue {
         #[serde(flatten)]
-        data: MapValue,
+        data: Box<MapValue>,
     },
 
     ListValue {
-        value: Vec<VariableValue>,
+        value: Vec<Box<VariableValue>>,
     },
 
     BinaryTreeValue {

--- a/seed/rust-sdk/trace/src/core/http_client.rs
+++ b/seed/rust-sdk/trace/src/core/http_client.rs
@@ -166,6 +166,7 @@ impl HttpClient {
     ///     None,
     /// ).await?;
     /// ```
+    #[cfg(feature = "multipart")]
     pub async fn execute_multipart_request<T>(
         &self,
         method: Method,
@@ -450,6 +451,7 @@ impl HttpClient {
     ///     println!("Received: {:?}", chunk);
     /// }
     /// ```
+    #[cfg(feature = "sse")]
     pub async fn execute_sse_request<T>(
         &self,
         method: Method,

--- a/seed/rust-sdk/trace/src/core/mod.rs
+++ b/seed/rust-sdk/trace/src/core/mod.rs
@@ -3,11 +3,13 @@
 mod http_client;
 mod query_parameter_builder;
 mod request_options;
+#[cfg(feature = "sse")]
 mod sse_stream;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
+#[cfg(feature = "sse")]
 pub use sse_stream::SseStream;
 pub use utils::join_url;


### PR DESCRIPTION
## Description
Linear ticket: Closes [FER-7724](https://linear.app/buildwithfern/issue/FER-7724/rust-sdk-circular-reference-seed-failure)

Fixes seed failures caused by illegal circular type references in Rust SDK generation. Adds cycle detection to catch invalid recursive types early and enhances recursive type utilities to properly handle unions and undiscriminated unions.

## Changes Made
- Created `RustCycleDetector` to detect illegal recursive cycles that cannot be represented in Rust
- Integrated cycle detection into `AbstractRustGeneratorContext` initialisation (fails fast on invalid schemas)
- Added visited set tracking in `irUsesType()` to prevent infinite recursion on circular types
- Enhanced `recursiveTypeUtils.ts` to handle all type shapes:
  - Discriminated unions (check all variants and base properties)
  - Undiscriminated unions (check all members)
  - Alias types (check aliased type)
- Updated seed fixtures with circular references to use `Box<T>` wrapping
- Updated `allowedFailures` in rust-model seed.yml

## Testing
- [x] Unit tests added/updated
- [x] Manual testing completed
