### PR TITLE
chore(cli): improve update of navigation in local dev

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -4,7 +4,7 @@
         Update local development refresh behavior when updating the `sidebar-title` override, or a `slug` override of a page. The preview should now navigate to the new slug instead of showing a 404.
       type: fix
   irVersion: 61
-  createdAt: "2025-11-21"
+  createdAt: "2025-11-23"
   version: 2.4.1
 
 - changelogEntry:

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Update local development refresh behavior when updating the `sidebar-title` override, or a `slug` override of a page. The preview should now navigate to the new slug instead of showing a 404.
+      type: fix
+  irVersion: 61
+  createdAt: "2025-11-21"
+  version: 2.4.1
+
+- changelogEntry:
+    - summary: |
         Revert "fix(openapi): handle situations where discriminated unions reference unknown variants"
       type: chore
   irVersion: 61


### PR DESCRIPTION
adds support for:
- updating the `sidebar-title` from local dev
- navigating to the new page if you update a slug in local dev
