### PR TITLE
fix(java): skip InputStream generation for endpoints with inline path parameters

### DIFF
--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/AbstractEndpointWriter.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/AbstractEndpointWriter.java
@@ -345,11 +345,30 @@ public abstract class AbstractEndpointWriter {
         if (maybeFileUpload.isPresent()) {
             FileUploadRequest fileUpload = maybeFileUpload.get();
 
-            // Check if endpoint has query parameters - if so, skip InputStream generation
+            // Check if endpoint has query parameters or inline path parameters - if so, skip InputStream generation
             // to avoid compilation errors from referencing non-existent request parameter
             boolean hasQueryParameters = !httpEndpoint.getQueryParameters().isEmpty();
+            boolean hasInlinePathParameters = clientGeneratorContext.getCustomConfig().inlinePathParameters()
+                    && httpEndpoint.getSdkRequest().isPresent()
+                    && httpEndpoint.getSdkRequest().get().getShape().isWrapper()
+                    && (httpEndpoint
+                                    .getSdkRequest()
+                                    .get()
+                                    .getShape()
+                                    .getWrapper()
+                                    .get()
+                                    .getIncludePathParameters()
+                                    .orElse(false)
+                            || httpEndpoint
+                                    .getSdkRequest()
+                                    .get()
+                                    .getShape()
+                                    .getWrapper()
+                                    .get()
+                                    .getOnlyPathParameters()
+                                    .orElse(false));
 
-            if (!hasQueryParameters) {
+            if (!hasQueryParameters && !hasInlinePathParameters) {
                 List<FileProperty> fileProperties = fileUpload.getProperties().stream()
                         .filter(prop -> prop.visit(new FileUploadRequestProperty.Visitor<Boolean>() {
                             @Override


### PR DESCRIPTION
Fixes compilation errors when inline-path-parameters is enabled for file upload endpoints with path parameters.