### PR TITLE
fix(java): skip InputStream generation for endpoints with inline path parameters

### DIFF
--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/AbstractEndpointWriter.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/AbstractEndpointWriter.java
@@ -345,11 +345,30 @@ public abstract class AbstractEndpointWriter {
         if (maybeFileUpload.isPresent()) {
             FileUploadRequest fileUpload = maybeFileUpload.get();
 
-            // Check if endpoint has query parameters - if so, skip InputStream generation
+            // Check if endpoint has query parameters or inline path parameters - if so, skip InputStream generation
             // to avoid compilation errors from referencing non-existent request parameter
             boolean hasQueryParameters = !httpEndpoint.getQueryParameters().isEmpty();
+            boolean hasInlinePathParameters = clientGeneratorContext.getCustomConfig().inlinePathParameters()
+                    && httpEndpoint.getSdkRequest().isPresent()
+                    && httpEndpoint.getSdkRequest().get().getShape().isWrapper()
+                    && (httpEndpoint
+                                    .getSdkRequest()
+                                    .get()
+                                    .getShape()
+                                    .getWrapper()
+                                    .get()
+                                    .getIncludePathParameters()
+                                    .orElse(false)
+                            || httpEndpoint
+                                    .getSdkRequest()
+                                    .get()
+                                    .getShape()
+                                    .getWrapper()
+                                    .get()
+                                    .getOnlyPathParameters()
+                                    .orElse(false));
 
-            if (!hasQueryParameters) {
+            if (!hasQueryParameters && !hasInlinePathParameters) {
                 List<FileProperty> fileProperties = fileUpload.getProperties().stream()
                         .filter(prop -> prop.visit(new FileUploadRequestProperty.Visitor<Boolean>() {
                             @Override

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/AbstractEndpointWriter.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/AbstractEndpointWriter.java
@@ -348,25 +348,26 @@ public abstract class AbstractEndpointWriter {
             // Check if endpoint has query parameters or inline path parameters - if so, skip InputStream generation
             // to avoid compilation errors from referencing non-existent request parameter
             boolean hasQueryParameters = !httpEndpoint.getQueryParameters().isEmpty();
-            boolean hasInlinePathParameters = clientGeneratorContext.getCustomConfig().inlinePathParameters()
-                    && httpEndpoint.getSdkRequest().isPresent()
-                    && httpEndpoint.getSdkRequest().get().getShape().isWrapper()
-                    && (httpEndpoint
-                                    .getSdkRequest()
-                                    .get()
-                                    .getShape()
-                                    .getWrapper()
-                                    .get()
-                                    .getIncludePathParameters()
-                                    .orElse(false)
-                            || httpEndpoint
-                                    .getSdkRequest()
-                                    .get()
-                                    .getShape()
-                                    .getWrapper()
-                                    .get()
-                                    .getOnlyPathParameters()
-                                    .orElse(false));
+            boolean hasInlinePathParameters =
+                    clientGeneratorContext.getCustomConfig().inlinePathParameters()
+                            && httpEndpoint.getSdkRequest().isPresent()
+                            && httpEndpoint.getSdkRequest().get().getShape().isWrapper()
+                            && (httpEndpoint
+                                            .getSdkRequest()
+                                            .get()
+                                            .getShape()
+                                            .getWrapper()
+                                            .get()
+                                            .getIncludePathParameters()
+                                            .orElse(false)
+                                    || httpEndpoint
+                                            .getSdkRequest()
+                                            .get()
+                                            .getShape()
+                                            .getWrapper()
+                                            .get()
+                                            .getOnlyPathParameters()
+                                            .orElse(false));
 
             if (!hasQueryParameters && !hasInlinePathParameters) {
                 List<FileProperty> fileProperties = fileUpload.getProperties().stream()

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,3 +1,11 @@
+- version: 3.18.8
+  changelogEntry:
+    - summary: |
+        Skip InputStream overload generation for file upload endpoints with inline path parameters. This prevents compilation errors where InputStream methods would reference non-existent request parameters when path parameters are inlined.
+      type: fix
+  createdAt: "2025-11-23"
+  irVersion: 61
+
 - version: 3.18.7
   changelogEntry:
     - summary: |


### PR DESCRIPTION
When `inline-path-parameters: true` is enabled in generators.yml, file upload endpoints with path parameters (e.g., `/v2/disputes/{disputeId}/evidence-files`) were generating InputStream convenience methods that failed to compile. The generated code referenced `request.getDisputeId()` but InputStream methods don't have a `request` parameter.

This fix adds a check for inline path parameters (similar to the existing query parameter check) to skip InputStream generation when path parameters would be inlined. This prevents compilation errors in SDKs like Square that use `inline-path-parameters: true`.

Tested with Square SDK generation, compilation, and test suite - all successful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Description
Linear ticket: Closes 
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
<!-- Provide a clear and concise description of the changes made in this PR -->

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- 
- 
- [ ] Updated README.md generator (if applicable)

## Testing
<!-- Describe how you tested these changes -->
- [ ] Unit tests added/updated
- [ ] Manual testing completed
