### PR TITLE
fix(cli): remove spammy warning for unresolved OpenAPI sources in dependencies

### DIFF
--- a/packages/cli/cli-source-resolver/src/SourceResolverImpl.ts
+++ b/packages/cli/cli-source-resolver/src/SourceResolverImpl.ts
@@ -28,10 +28,10 @@ export class SourceResolverImpl implements SourceResolver {
         if (resolvedType == null) {
             if (isRawProtobufSourceSchema(source)) {
                 this.context.logger.warn(`Cannot resolve source ${source.proto} from file ${relativeFilepath}`);
-            } else {
-                // Do not throw if OpenAPI since the source is not actually required.
-                this.context.logger.warn(`Cannot resolve source ${source.openapi} from file ${relativeFilepath}`);
             }
+            // Do not warn if OpenAPI since the source is not actually required.
+            // This commonly happens with dependencies where the source file is in
+            // the dependency's directory, not the main workspace.
         }
         return resolvedType;
     }

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Remove spammy "Cannot resolve source" warnings for OpenAPI sources in unioned API configurations with dependencies.
+      type: fix
+  irVersion: 61
+  createdAt: "2025-11-25"
+  version: 2.5.2
+
+- changelogEntry:
+    - summary: |
         Add validation for instance URLs to ensure they are valid.
       type: fix
   irVersion: 61


### PR DESCRIPTION
## Description
Refs https://github.com/twitchard/annoying-fern-warnings

Fixes a usability issue where users with unioned API configurations that use dependencies get spammy "Cannot resolve source" warnings for OpenAPI sources.

Fixes https://github.com/fern-api/fern/issues/10834

Link to Devin run: https://app.devin.ai/sessions/974c968291584966bc6115f46dc0233f
Requested by: thomas@buildwithfern.com (@tjb9dc)