### PR TITLE
fix(python): escape multiline strings in wire test generator

### DIFF
--- a/generators/python-v2/sdk/src/wire-tests/WireTestGenerator.ts
+++ b/generators/python-v2/sdk/src/wire-tests/WireTestGenerator.ts
@@ -510,9 +510,22 @@ export class WireTestGenerator {
         });
     }
 
+    /**
+     * Escapes a string for use in Python code.
+     * Handles newlines, tabs, carriage returns, backslashes, and quotes.
+     */
+    private escapeStringForPython(value: string): string {
+        return value
+            .replace(/\\/g, "\\\\") // Escape backslashes first
+            .replace(/\n/g, "\\n") // Escape newlines
+            .replace(/\r/g, "\\r") // Escape carriage returns
+            .replace(/\t/g, "\\t") // Escape tabs
+            .replace(/"/g, '\\"'); // Escape double quotes
+    }
+
     private formatValue(value: unknown): string {
         if (typeof value === "string") {
-            return `"${value}"`;
+            return `"${this.escapeStringForPython(value)}"`;
         }
         if (typeof value === "number") {
             return String(value);
@@ -540,7 +553,7 @@ export class WireTestGenerator {
             return value ? "True" : "False";
         }
         if (typeof value === "string") {
-            return `"${value}"`;
+            return `"${this.escapeStringForPython(value)}"`;
         }
         if (typeof value === "number") {
             return String(value);
@@ -550,7 +563,9 @@ export class WireTestGenerator {
             return `[${items.join(",")}]`;
         }
         if (typeof value === "object") {
-            const entries = Object.entries(value).map(([key, val]) => `"${key}":${this.jsonToPython(val)}`);
+            const entries = Object.entries(value).map(
+                ([key, val]) => `"${this.escapeStringForPython(key)}":${this.jsonToPython(val)}`
+            );
             return `{${entries.join(",")}}`;
         }
         return JSON.stringify(value);
@@ -571,7 +586,7 @@ export class WireTestGenerator {
 
         for (const [key, value] of Object.entries(queryParams)) {
             if (value != null) {
-                entries.push(`"${key}": "${String(value)}"`);
+                entries.push(`"${this.escapeStringForPython(key)}": "${this.escapeStringForPython(String(value))}"`);
             }
         }
 


### PR DESCRIPTION
## Description

Fixes a bug in the Python wire test generator where multiline string parameters were not properly escaped, causing invalid Python syntax in generated test files.

Reference issue: [payroc-python-sdk PR #9](https://github.com/fern-demo/payroc-python-sdk/pull/9/commits/be325b3489c6b76e164208635220dbed4c98e22c) - shows the manual fix that was required

## Changes Made

- Added `escapeStringForPython` helper method that properly escapes special characters:
  - Backslashes (`\` → `\\`)
  - Newlines (`\n`)
  - Carriage returns (`\r`)
  - Tabs (`\t`)
  - Double quotes (`"` → `\"`)
- Updated `formatValue` to use the escape helper for string values
- Updated `jsonToPython` to use the escape helper for string values and object keys
- Updated `buildQueryParamsCode` to use the escape helper for query parameter keys and values
- [ ] Updated README.md generator (if applicable) - N/A

## Testing

- [x] Lint checks pass (`pnpm run check`)
- [ ] Unit tests added/updated
- [ ] Manual testing completed

## Human Review Checklist

- [ ] Verify escape sequence order is correct (backslashes must be escaped first)
- [ ] Consider if additional escape sequences are needed (e.g., `\0`, `\b`, `\f`)
- [ ] Confirm this is the correct code path for the payroc wire test issue

---
Requested by: thomas@buildwithfern.com (@tjb9dc)
Devin Session: https://app.devin.ai/sessions/0a09c424043d4d868d7ae477f89145b8