### PR TITLE
fix(python): use correct endpoint naming logic in wire test generator

### DIFF
--- a/generators/python-v2/sdk/src/wire-tests/WireTestGenerator.ts
+++ b/generators/python-v2/sdk/src/wire-tests/WireTestGenerator.ts
@@ -14,6 +14,12 @@ import { SdkGeneratorContext } from "../SdkGeneratorContext";
 import { WireTestSetupGenerator } from "./WireTestSetupGenerator";
 
 /**
+ * Reserved method names that are allowed to use their unsafe (original) names.
+ * This matches the Python generator's ALLOWED_RESERVED_METHOD_NAMES.
+ */
+const ALLOWED_RESERVED_METHOD_NAMES = ["list", "set"];
+
+/**
  * Generates WireMock-based integration tests for Python SDK.
  *
  * This is a skeleton implementation that sets up the infrastructure for wire tests
@@ -299,7 +305,7 @@ export class WireTestGenerator {
     // =============================================================================
 
     private generateApiCall(endpoint: HttpEndpoint, example: dynamic.EndpointExample, service: HttpService): string {
-        const methodName = endpoint.name.snakeCase.safeName;
+        const methodName = this.getEndpointName(endpoint);
 
         // Build path parameters
         const pathParams = this.buildPathParameters(endpoint, example);
@@ -589,6 +595,18 @@ export class WireTestGenerator {
     private getTestFunctionName(serviceName: string, endpoint: HttpEndpoint): string {
         const endpointName = endpoint.name.snakeCase.safeName;
         return `test_${serviceName}_${endpointName}`;
+    }
+
+    /**
+     * Gets the endpoint method name, matching the Python generator's get_endpoint_name logic.
+     * If the endpoint's original name (lowercased) is in ALLOWED_RESERVED_METHOD_NAMES,
+     * use the unsafe name; otherwise use the safe name.
+     */
+    private getEndpointName(endpoint: HttpEndpoint): string {
+        if (ALLOWED_RESERVED_METHOD_NAMES.includes(endpoint.name.originalName.toLowerCase())) {
+            return endpoint.name.snakeCase.unsafeName;
+        }
+        return endpoint.name.snakeCase.safeName;
     }
 
     private getClientModulePath(): string[] {


### PR DESCRIPTION
## Description

Refs: Slack thread from @tjb9dc

Fixes the Python wire test generator to use the correct endpoint naming logic. The issue was that `WireTestGenerator.ts` was always using `safeName` for endpoint method names, but it should match the Python generator's `get_endpoint_name` logic which uses `unsafeName` for certain reserved method names like "list" and "set".

## Changes Made

- Added `ALLOWED_RESERVED_METHOD_NAMES` constant matching the Python generator's list (`["list", "set"]`)
- Added `getEndpointName()` helper method that replicates the Python generator's naming logic
- Updated `generateApiCall()` to use the new helper instead of always using `safeName`

The fix ensures wire tests generate the correct method names that match what the actual Python SDK generates.

## Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed (lint checks pass)

## Human Review Checklist

- [ ] Verify the logic matches [endpoint_function_generator.py L2099-2102](https://github.com/fern-api/fern/blob/main/generators/python/src/fern_python/generators/sdk/client_generator/endpoint_function_generator.py#L2099-L2102)
- [ ] Check if other places in `WireTestGenerator.ts` use endpoint names that might need the same fix

---

Requested by: thomas@buildwithfern.com (@tjb9dc)
Devin Session: https://app.devin.ai/sessions/0fc93eaff44d4d1f8fbd6b1b8e1ba4ec