### PR TITLE
feat(python): Run ruff linter on wire tests generated by python-v2

### DIFF
--- a/generators/python-v2/base/package.json
+++ b/generators/python-v2/base/package.json
@@ -34,6 +34,7 @@
     "@fern-api/base-generator": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
     "@fern-api/fs-utils": "workspace:*",
+    "@fern-api/logging-execa": "workspace:*",
     "@fern-api/python-ast": "workspace:*",
     "@fern-api/python-browser-compatible-base": "workspace:*",
     "@fern-fern/ir-sdk": "^61.7.0",

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 4.39.1
+  changelogEntry:
+    - summary: Various fixes and improvements to wire tests.
+      type: fix
+  createdAt: "2025-11-25"
+  irVersion: 61
+
 - version: 4.39.0
   changelogEntry:
     - summary: Add environment_class_name config option to customize the environment class name. Default remains {ClientName}Environment.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1215,6 +1215,9 @@ importers:
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../../packages/commons/fs-utils
+      '@fern-api/logging-execa':
+        specifier: workspace:*
+        version: link:../../../packages/commons/logging-execa
       '@fern-api/python-ast':
         specifier: workspace:*
         version: link:../ast

--- a/seed/python-sdk/exhaustive/no-custom-config/tests/wire/conftest.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/tests/wire/conftest.py
@@ -3,6 +3,7 @@ Pytest configuration for wire tests.
 
 This module manages the WireMock container lifecycle for integration tests.
 """
+
 import os
 import subprocess
 from typing import Any, Dict, Optional
@@ -30,10 +31,7 @@ def wiremock_container():
     print("\nStarting WireMock container...")
     try:
         subprocess.run(
-            ["docker", "compose", "-f", compose_file, "up", "-d", "--wait"],
-            check=True,
-            capture_output=True,
-            text=True
+            ["docker", "compose", "-f", compose_file, "up", "-d", "--wait"], check=True, capture_output=True, text=True
         )
         print("WireMock container is ready")
     except subprocess.CalledProcessError as e:
@@ -45,11 +43,7 @@ def wiremock_container():
 
     # Cleanup: stop and remove the container
     print("\nStopping WireMock container...")
-    subprocess.run(
-        ["docker", "compose", "-f", compose_file, "down", "-v"],
-        check=False,
-        capture_output=True
-    )
+    subprocess.run(["docker", "compose", "-f", compose_file, "down", "-v"], check=False, capture_output=True)
 
 
 def verify_request_count(
@@ -64,7 +58,7 @@ def verify_request_count(
     request_body: Dict[str, Any] = {
         "method": method,
         "urlPath": url_path,
-        "headers": {"X-Test-Id": {"equalTo": test_id}}
+        "headers": {"X-Test-Id": {"equalTo": test_id}},
     }
     if query_params:
         query_parameters = {k: {"equalTo": v} for k, v in query_params.items()}

--- a/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_container.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_container.py
@@ -1,15 +1,13 @@
-from seed import SeedExhaustive
 from conftest import verify_request_count
 
-import pytest
-
+from seed import SeedExhaustive
 
 
 def test_endpoints_container_get_and_return_list_of_primitives() -> None:
     """Test getAndReturnListOfPrimitives endpoint with WireMock"""
     test_id = "endpoints.container.get_and_return_list_of_primitives.0"
     client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
-    result = client.endpoints.container.get_and_return_list_of_primitives(request=["string","string"])
+    result = client.endpoints.container.get_and_return_list_of_primitives(request=["string", "string"])
     verify_request_count(test_id, "POST", "/container/list-of-primitives", None, 1)
 
 
@@ -17,7 +15,9 @@ def test_endpoints_container_get_and_return_list_of_objects() -> None:
     """Test getAndReturnListOfObjects endpoint with WireMock"""
     test_id = "endpoints.container.get_and_return_list_of_objects.0"
     client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
-    result = client.endpoints.container.get_and_return_list_of_objects(request=[{"string":"string"},{"string":"string"}])
+    result = client.endpoints.container.get_and_return_list_of_objects(
+        request=[{"string": "string"}, {"string": "string"}]
+    )
     verify_request_count(test_id, "POST", "/container/list-of-objects", None, 1)
 
 
@@ -33,7 +33,7 @@ def test_endpoints_container_get_and_return_set_of_objects() -> None:
     """Test getAndReturnSetOfObjects endpoint with WireMock"""
     test_id = "endpoints.container.get_and_return_set_of_objects.0"
     client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
-    result = client.endpoints.container.get_and_return_set_of_objects(request=[{"string":"string"}])
+    result = client.endpoints.container.get_and_return_set_of_objects(request=[{"string": "string"}])
     verify_request_count(test_id, "POST", "/container/set-of-objects", None, 1)
 
 
@@ -41,7 +41,7 @@ def test_endpoints_container_get_and_return_map_prim_to_prim() -> None:
     """Test getAndReturnMapPrimToPrim endpoint with WireMock"""
     test_id = "endpoints.container.get_and_return_map_prim_to_prim.0"
     client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
-    result = client.endpoints.container.get_and_return_map_prim_to_prim(request={"string":"string"})
+    result = client.endpoints.container.get_and_return_map_prim_to_prim(request={"string": "string"})
     verify_request_count(test_id, "POST", "/container/map-prim-to-prim", None, 1)
 
 
@@ -49,7 +49,7 @@ def test_endpoints_container_get_and_return_map_of_prim_to_object() -> None:
     """Test getAndReturnMapOfPrimToObject endpoint with WireMock"""
     test_id = "endpoints.container.get_and_return_map_of_prim_to_object.0"
     client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
-    result = client.endpoints.container.get_and_return_map_of_prim_to_object(request={"string":{"string":"string"}})
+    result = client.endpoints.container.get_and_return_map_of_prim_to_object(request={"string": {"string": "string"}})
     verify_request_count(test_id, "POST", "/container/map-prim-to-object", None, 1)
 
 
@@ -57,6 +57,5 @@ def test_endpoints_container_get_and_return_optional() -> None:
     """Test getAndReturnOptional endpoint with WireMock"""
     test_id = "endpoints.container.get_and_return_optional.0"
     client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
-    result = client.endpoints.container.get_and_return_optional(request={"string":"string"})
+    result = client.endpoints.container.get_and_return_optional(request={"string": "string"})
     verify_request_count(test_id, "POST", "/container/opt-objects", None, 1)
-

--- a/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_contentType.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_contentType.py
@@ -1,15 +1,27 @@
-from seed import SeedExhaustive
 from conftest import verify_request_count
 
-import pytest
-
+from seed import SeedExhaustive
 
 
 def test_endpoints_contentType_post_json_patch_content_type() -> None:
     """Test postJsonPatchContentType endpoint with WireMock"""
     test_id = "endpoints.content_type.post_json_patch_content_type.0"
     client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
-    result = client.endpoints.content_type.post_json_patch_content_type(string="string", integer=1, long_=1000000, double=1.1, bool_=True, datetime="2024-01-15T09:30:00Z", date="2023-01-15", uuid_="d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32", base_64="SGVsbG8gd29ybGQh", list_=["list","list"], set_=["set"], map_={"1":"map"}, bigint="1000000")
+    result = client.endpoints.content_type.post_json_patch_content_type(
+        string="string",
+        integer=1,
+        long_=1000000,
+        double=1.1,
+        bool_=True,
+        datetime="2024-01-15T09:30:00Z",
+        date="2023-01-15",
+        uuid_="d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
+        base_64="SGVsbG8gd29ybGQh",
+        list_=["list", "list"],
+        set_=["set"],
+        map_={"1": "map"},
+        bigint="1000000",
+    )
     verify_request_count(test_id, "POST", "/foo/bar", None, 1)
 
 
@@ -17,6 +29,19 @@ def test_endpoints_contentType_post_json_patch_content_with_charset_type() -> No
     """Test postJsonPatchContentWithCharsetType endpoint with WireMock"""
     test_id = "endpoints.content_type.post_json_patch_content_with_charset_type.0"
     client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
-    result = client.endpoints.content_type.post_json_patch_content_with_charset_type(string="string", integer=1, long_=1000000, double=1.1, bool_=True, datetime="2024-01-15T09:30:00Z", date="2023-01-15", uuid_="d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32", base_64="SGVsbG8gd29ybGQh", list_=["list","list"], set_=["set"], map_={"1":"map"}, bigint="1000000")
+    result = client.endpoints.content_type.post_json_patch_content_with_charset_type(
+        string="string",
+        integer=1,
+        long_=1000000,
+        double=1.1,
+        bool_=True,
+        datetime="2024-01-15T09:30:00Z",
+        date="2023-01-15",
+        uuid_="d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
+        base_64="SGVsbG8gd29ybGQh",
+        list_=["list", "list"],
+        set_=["set"],
+        map_={"1": "map"},
+        bigint="1000000",
+    )
     verify_request_count(test_id, "POST", "/foo/baz", None, 1)
-

--- a/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_enum.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_enum.py
@@ -1,8 +1,6 @@
-from seed import SeedExhaustive
 from conftest import verify_request_count
 
-import pytest
-
+from seed import SeedExhaustive
 
 
 def test_endpoints_enum_get_and_return_enum() -> None:
@@ -11,4 +9,3 @@ def test_endpoints_enum_get_and_return_enum() -> None:
     client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
     result = client.endpoints.enum.get_and_return_enum(request="SUNNY")
     verify_request_count(test_id, "POST", "/enum", None, 1)
-

--- a/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_httpMethods.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_httpMethods.py
@@ -1,8 +1,6 @@
-from seed import SeedExhaustive
 from conftest import verify_request_count
 
-import pytest
-
+from seed import SeedExhaustive
 
 
 def test_endpoints_httpMethods_test_get() -> None:
@@ -33,7 +31,22 @@ def test_endpoints_httpMethods_test_patch() -> None:
     """Test testPatch endpoint with WireMock"""
     test_id = "endpoints.http_methods.test_patch.0"
     client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
-    result = client.endpoints.http_methods.test_patch("id", string="string", integer=1, long_=1000000, double=1.1, bool_=True, datetime="2024-01-15T09:30:00Z", date="2023-01-15", uuid_="d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32", base_64="SGVsbG8gd29ybGQh", list_=["list","list"], set_=["set"], map_={"1":"map"}, bigint="1000000")
+    result = client.endpoints.http_methods.test_patch(
+        "id",
+        string="string",
+        integer=1,
+        long_=1000000,
+        double=1.1,
+        bool_=True,
+        datetime="2024-01-15T09:30:00Z",
+        date="2023-01-15",
+        uuid_="d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
+        base_64="SGVsbG8gd29ybGQh",
+        list_=["list", "list"],
+        set_=["set"],
+        map_={"1": "map"},
+        bigint="1000000",
+    )
     verify_request_count(test_id, "PATCH", "/http-methods/id", None, 1)
 
 
@@ -43,4 +56,3 @@ def test_endpoints_httpMethods_test_delete() -> None:
     client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
     result = client.endpoints.http_methods.test_delete("id")
     verify_request_count(test_id, "DELETE", "/http-methods/id", None, 1)
-

--- a/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_object.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_object.py
@@ -1,15 +1,27 @@
-from seed import SeedExhaustive
 from conftest import verify_request_count
 
-import pytest
-
+from seed import SeedExhaustive
 
 
 def test_endpoints_object_get_and_return_with_optional_field() -> None:
     """Test getAndReturnWithOptionalField endpoint with WireMock"""
     test_id = "endpoints.object.get_and_return_with_optional_field.0"
     client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
-    result = client.endpoints.object.get_and_return_with_optional_field(string="string", integer=1, long_=1000000, double=1.1, bool_=True, datetime="2024-01-15T09:30:00Z", date="2023-01-15", uuid_="d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32", base_64="SGVsbG8gd29ybGQh", list_=["list","list"], set_=["set"], map_={"1":"map"}, bigint="1000000")
+    result = client.endpoints.object.get_and_return_with_optional_field(
+        string="string",
+        integer=1,
+        long_=1000000,
+        double=1.1,
+        bool_=True,
+        datetime="2024-01-15T09:30:00Z",
+        date="2023-01-15",
+        uuid_="d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
+        base_64="SGVsbG8gd29ybGQh",
+        list_=["list", "list"],
+        set_=["set"],
+        map_={"1": "map"},
+        bigint="1000000",
+    )
     verify_request_count(test_id, "POST", "/object/get-and-return-with-optional-field", None, 1)
 
 
@@ -25,7 +37,7 @@ def test_endpoints_object_get_and_return_with_map_of_map() -> None:
     """Test getAndReturnWithMapOfMap endpoint with WireMock"""
     test_id = "endpoints.object.get_and_return_with_map_of_map.0"
     client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
-    result = client.endpoints.object.get_and_return_with_map_of_map(map_={"map":{"map":"map"}})
+    result = client.endpoints.object.get_and_return_with_map_of_map(map_={"map": {"map": "map"}})
     verify_request_count(test_id, "POST", "/object/get-and-return-with-map-of-map", None, 1)
 
 
@@ -33,7 +45,24 @@ def test_endpoints_object_get_and_return_nested_with_optional_field() -> None:
     """Test getAndReturnNestedWithOptionalField endpoint with WireMock"""
     test_id = "endpoints.object.get_and_return_nested_with_optional_field.0"
     client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
-    result = client.endpoints.object.get_and_return_nested_with_optional_field(string="string", nested_object={"string":"string","integer":1,"long":1000000,"double":1.1,"bool":True,"datetime":"2024-01-15T09:30:00Z","date":"2023-01-15","uuid":"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32","base64":"SGVsbG8gd29ybGQh","list":["list","list"],"set":["set"],"map":{"1":"map"},"bigint":"1000000"})
+    result = client.endpoints.object.get_and_return_nested_with_optional_field(
+        string="string",
+        nested_object={
+            "string": "string",
+            "integer": 1,
+            "long": 1000000,
+            "double": 1.1,
+            "bool": True,
+            "datetime": "2024-01-15T09:30:00Z",
+            "date": "2023-01-15",
+            "uuid": "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
+            "base64": "SGVsbG8gd29ybGQh",
+            "list": ["list", "list"],
+            "set": ["set"],
+            "map": {"1": "map"},
+            "bigint": "1000000",
+        },
+    )
     verify_request_count(test_id, "POST", "/object/get-and-return-nested-with-optional-field", None, 1)
 
 
@@ -41,7 +70,25 @@ def test_endpoints_object_get_and_return_nested_with_required_field() -> None:
     """Test getAndReturnNestedWithRequiredField endpoint with WireMock"""
     test_id = "endpoints.object.get_and_return_nested_with_required_field.0"
     client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
-    result = client.endpoints.object.get_and_return_nested_with_required_field("string", string="string", nested_object={"string":"string","integer":1,"long":1000000,"double":1.1,"bool":True,"datetime":"2024-01-15T09:30:00Z","date":"2023-01-15","uuid":"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32","base64":"SGVsbG8gd29ybGQh","list":["list","list"],"set":["set"],"map":{"1":"map"},"bigint":"1000000"})
+    result = client.endpoints.object.get_and_return_nested_with_required_field(
+        "string",
+        string="string",
+        nested_object={
+            "string": "string",
+            "integer": 1,
+            "long": 1000000,
+            "double": 1.1,
+            "bool": True,
+            "datetime": "2024-01-15T09:30:00Z",
+            "date": "2023-01-15",
+            "uuid": "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
+            "base64": "SGVsbG8gd29ybGQh",
+            "list": ["list", "list"],
+            "set": ["set"],
+            "map": {"1": "map"},
+            "bigint": "1000000",
+        },
+    )
     verify_request_count(test_id, "POST", "/object/get-and-return-nested-with-required-field/string", None, 1)
 
 
@@ -49,6 +96,44 @@ def test_endpoints_object_get_and_return_nested_with_required_field_as_list() ->
     """Test getAndReturnNestedWithRequiredFieldAsList endpoint with WireMock"""
     test_id = "endpoints.object.get_and_return_nested_with_required_field_as_list.0"
     client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
-    result = client.endpoints.object.get_and_return_nested_with_required_field_as_list(request=[{"string":"string","NestedObject":{"string":"string","integer":1,"long":1000000,"double":1.1,"bool":True,"datetime":"2024-01-15T09:30:00Z","date":"2023-01-15","uuid":"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32","base64":"SGVsbG8gd29ybGQh","list":["list","list"],"set":["set"],"map":{"1":"map"},"bigint":"1000000"}},{"string":"string","NestedObject":{"string":"string","integer":1,"long":1000000,"double":1.1,"bool":True,"datetime":"2024-01-15T09:30:00Z","date":"2023-01-15","uuid":"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32","base64":"SGVsbG8gd29ybGQh","list":["list","list"],"set":["set"],"map":{"1":"map"},"bigint":"1000000"}}])
+    result = client.endpoints.object.get_and_return_nested_with_required_field_as_list(
+        request=[
+            {
+                "string": "string",
+                "NestedObject": {
+                    "string": "string",
+                    "integer": 1,
+                    "long": 1000000,
+                    "double": 1.1,
+                    "bool": True,
+                    "datetime": "2024-01-15T09:30:00Z",
+                    "date": "2023-01-15",
+                    "uuid": "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
+                    "base64": "SGVsbG8gd29ybGQh",
+                    "list": ["list", "list"],
+                    "set": ["set"],
+                    "map": {"1": "map"},
+                    "bigint": "1000000",
+                },
+            },
+            {
+                "string": "string",
+                "NestedObject": {
+                    "string": "string",
+                    "integer": 1,
+                    "long": 1000000,
+                    "double": 1.1,
+                    "bool": True,
+                    "datetime": "2024-01-15T09:30:00Z",
+                    "date": "2023-01-15",
+                    "uuid": "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
+                    "base64": "SGVsbG8gd29ybGQh",
+                    "list": ["list", "list"],
+                    "set": ["set"],
+                    "map": {"1": "map"},
+                    "bigint": "1000000",
+                },
+            },
+        ]
+    )
     verify_request_count(test_id, "POST", "/object/get-and-return-nested-with-required-field-list", None, 1)
-

--- a/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_params.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_params.py
@@ -1,8 +1,6 @@
-from seed import SeedExhaustive
 from conftest import verify_request_count
 
-import pytest
-
+from seed import SeedExhaustive
 
 
 def test_endpoints_params_get_with_path() -> None:
@@ -67,4 +65,3 @@ def test_endpoints_params_modify_with_inline_path() -> None:
     client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
     result = client.endpoints.params.modify_with_inline_path("param", request="string")
     verify_request_count(test_id, "PUT", "/params/path/param", None, 1)
-

--- a/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_primitive.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_primitive.py
@@ -1,8 +1,6 @@
-from seed import SeedExhaustive
 from conftest import verify_request_count
 
-import pytest
-
+from seed import SeedExhaustive
 
 
 def test_endpoints_primitive_get_and_return_string() -> None:
@@ -75,4 +73,3 @@ def test_endpoints_primitive_get_and_return_base_64() -> None:
     client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
     result = client.endpoints.primitive.get_and_return_base_64(request="SGVsbG8gd29ybGQh")
     verify_request_count(test_id, "POST", "/primitive/base64", None, 1)
-

--- a/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_put.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_put.py
@@ -1,8 +1,6 @@
-from seed import SeedExhaustive
 from conftest import verify_request_count
 
-import pytest
-
+from seed import SeedExhaustive
 
 
 def test_endpoints_put_add() -> None:
@@ -11,4 +9,3 @@ def test_endpoints_put_add() -> None:
     client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
     result = client.endpoints.put.add("id")
     verify_request_count(test_id, "PUT", "/id", None, 1)
-

--- a/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_union.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_union.py
@@ -1,14 +1,11 @@
-from seed import SeedExhaustive
 from conftest import verify_request_count
 
-import pytest
-
+from seed import SeedExhaustive
 
 
 def test_endpoints_union_get_and_return_union() -> None:
     """Test getAndReturnUnion endpoint with WireMock"""
     test_id = "endpoints.union.get_and_return_union.0"
     client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
-    result = client.endpoints.union.get_and_return_union(request={"animal":"dog","name":"name","likesToWoof":True})
+    result = client.endpoints.union.get_and_return_union(request={"animal": "dog", "name": "name", "likesToWoof": True})
     verify_request_count(test_id, "POST", "/union", None, 1)
-

--- a/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_urls.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_urls.py
@@ -1,8 +1,6 @@
-from seed import SeedExhaustive
 from conftest import verify_request_count
 
-import pytest
-
+from seed import SeedExhaustive
 
 
 def test_endpoints_urls_with_mixed_case() -> None:
@@ -35,4 +33,3 @@ def test_endpoints_urls_with_underscores() -> None:
     client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
     result = client.endpoints.urls.with_underscores()
     verify_request_count(test_id, "GET", "/urls/with_underscores", None, 1)
-

--- a/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_inlinedRequests.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_inlinedRequests.py
@@ -1,14 +1,29 @@
-from seed import SeedExhaustive
 from conftest import verify_request_count
 
-import pytest
-
+from seed import SeedExhaustive
 
 
 def test_inlinedRequests_post_with_object_bodyand_response() -> None:
     """Test postWithObjectBodyandResponse endpoint with WireMock"""
     test_id = "inlined_requests.post_with_object_bodyand_response.0"
     client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
-    result = client.inlined_requests.post_with_object_bodyand_response(string="string", integer=1, nested_object={"string":"string","integer":1,"long":1000000,"double":1.1,"bool":True,"datetime":"2024-01-15T09:30:00Z","date":"2023-01-15","uuid":"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32","base64":"SGVsbG8gd29ybGQh","list":["list","list"],"set":["set"],"map":{"1":"map"},"bigint":"1000000"})
+    result = client.inlined_requests.post_with_object_bodyand_response(
+        string="string",
+        integer=1,
+        nested_object={
+            "string": "string",
+            "integer": 1,
+            "long": 1000000,
+            "double": 1.1,
+            "bool": True,
+            "datetime": "2024-01-15T09:30:00Z",
+            "date": "2023-01-15",
+            "uuid": "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
+            "base64": "SGVsbG8gd29ybGQh",
+            "list": ["list", "list"],
+            "set": ["set"],
+            "map": {"1": "map"},
+            "bigint": "1000000",
+        },
+    )
     verify_request_count(test_id, "POST", "/req-bodies/object", None, 1)
-

--- a/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_noAuth.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_noAuth.py
@@ -1,14 +1,11 @@
-from seed import SeedExhaustive
 from conftest import verify_request_count
 
-import pytest
-
+from seed import SeedExhaustive
 
 
 def test_noAuth_post_with_no_auth() -> None:
     """Test postWithNoAuth endpoint with WireMock"""
     test_id = "no_auth.post_with_no_auth.0"
     client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
-    result = client.no_auth.post_with_no_auth(request={"key":"value"})
+    result = client.no_auth.post_with_no_auth(request={"key": "value"})
     verify_request_count(test_id, "POST", "/no-auth", None, 1)
-

--- a/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_noReqBody.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_noReqBody.py
@@ -1,8 +1,6 @@
-from seed import SeedExhaustive
 from conftest import verify_request_count
 
-import pytest
-
+from seed import SeedExhaustive
 
 
 def test_noReqBody_get_with_no_request_body() -> None:
@@ -19,4 +17,3 @@ def test_noReqBody_post_with_no_request_body() -> None:
     client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
     result = client.no_req_body.post_with_no_request_body()
     verify_request_count(test_id, "POST", "/no-req-body", None, 1)
-

--- a/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_reqWithHeaders.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_reqWithHeaders.py
@@ -1,14 +1,13 @@
-from seed import SeedExhaustive
 from conftest import verify_request_count
 
-import pytest
-
+from seed import SeedExhaustive
 
 
 def test_reqWithHeaders_get_with_custom_header() -> None:
     """Test getWithCustomHeader endpoint with WireMock"""
     test_id = "req_with_headers.get_with_custom_header.0"
     client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
-    result = client.req_with_headers.get_with_custom_header(x_test_service_header="X-TEST-SERVICE-HEADER", x_test_endpoint_header="X-TEST-ENDPOINT-HEADER", request="string")
+    result = client.req_with_headers.get_with_custom_header(
+        x_test_service_header="X-TEST-SERVICE-HEADER", x_test_endpoint_header="X-TEST-ENDPOINT-HEADER", request="string"
+    )
     verify_request_count(test_id, "POST", "/test-headers/custom-header", None, 1)
-


### PR DESCRIPTION
## Description
Refs: Slack thread from @tjb9dc

Adds ruff linting to the Python v2 generator, matching the behavior of the Python v1 generator. This ensures generated Python code (including wire tests) is properly linted and formatted.

## Changes Made
- Added `@fern-api/logging-execa` dependency to `generators/python-v2/base`
- Implemented `runRuffLinting()` method in `PythonProject.ts` that runs:
  - `ruff check --fix --no-cache --ignore E741` (auto-fix linting issues)
  - `ruff format --no-cache` (format code)
- Linting runs after all source files are written to disk

## Human Review Checklist
- [ ] Verify that running ruff on all generated files (not just wire tests) is the intended behavior - the implementation lints all source files in the output directory
- [ ] Confirm the ruff flags (`--ignore E741`) match the Python v1 generator's behavior

## Testing
- [x] Verified TypeScript compilation passes
- [x] Verified lint checks pass
- [ ] Manual testing with wire test generation (requires Docker environment)

---
Link to Devin run: https://app.devin.ai/sessions/ce039bff4c874134ac10c3db190c4a93
Requested by: thomas@buildwithfern.com (@tjb9dc)