### PR TITLE
feat(python): refactor wire test client construction to use get_client helper

### DIFF
--- a/generators/python-v2/sdk/src/wire-tests/WireTestGenerator.ts
+++ b/generators/python-v2/sdk/src/wire-tests/WireTestGenerator.ts
@@ -164,9 +164,9 @@ export class WireTestGenerator {
         // Create an empty code block
         const node = python.codeBlock("");
 
-        // Import get_client and verify_request_count from conftest (pytest makes conftest importable)
-        node.addReference(python.reference({ name: "get_client", modulePath: ["conftest"] }));
-        node.addReference(python.reference({ name: "verify_request_count", modulePath: ["conftest"] }));
+        // Import get_client and verify_request_count from .conftest (relative import within tests/wire package)
+        node.addReference(python.reference({ name: "get_client", modulePath: [".conftest"] }));
+        node.addReference(python.reference({ name: "verify_request_count", modulePath: [".conftest"] }));
 
         return node;
     }

--- a/generators/python-v2/sdk/src/wire-tests/WireTestGenerator.ts
+++ b/generators/python-v2/sdk/src/wire-tests/WireTestGenerator.ts
@@ -164,13 +164,8 @@ export class WireTestGenerator {
         // Create an empty code block
         const node = python.codeBlock("");
 
-        // Manually add references for "from X import Y" style imports
-        // Note: simple "import X" statements are added as raw code blocks separately
-        const clientModulePath = this.getClientModulePath();
-        const clientName = this.getClientClassName();
-        node.addReference(python.reference({ name: clientName, modulePath: clientModulePath }));
-
-        // Import verify_request_count from conftest (pytest makes conftest importable)
+        // Import get_client and verify_request_count from conftest (pytest makes conftest importable)
+        node.addReference(python.reference({ name: "get_client", modulePath: ["conftest"] }));
         node.addReference(python.reference({ name: "verify_request_count", modulePath: ["conftest"] }));
 
         return node;
@@ -191,7 +186,6 @@ export class WireTestGenerator {
             const testName = this.getTestFunctionName(serviceName, endpoint);
             const basePath = this.buildBasePath(endpoint);
             const queryParamsCode = this.buildQueryParamsCode(endpoint);
-            const clientName = this.getClientClassName();
 
             // Build deterministic test ID based on fully qualified path
             const testId = this.buildDeterministicTestId(service, endpoint, exampleIndex);
@@ -201,12 +195,9 @@ export class WireTestGenerator {
             // Use deterministic test ID for concurrency safety
             statements.push(python.codeBlock(`test_id = "${testId}"`));
 
-            // Create client with test ID header for request tracking
-            statements.push(
-                python.codeBlock(
-                    `client = ${clientName}(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})`
-                )
-            );
+            // Create client using the get_client helper from conftest.py
+            // This ensures all required auth parameters are supplied with fake values
+            statements.push(python.codeBlock(`client = get_client(test_id)`));
 
             // Generate the API call
             const apiCall = this.generateApiCall(endpoint, example, service);

--- a/generators/python-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
+++ b/generators/python-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
@@ -1,7 +1,7 @@
 import { File } from "@fern-api/base-generator";
 import { RelativeFilePath } from "@fern-api/fs-utils";
 import { WireMock } from "@fern-api/mock-utils";
-import { IntermediateRepresentation } from "@fern-fern/ir-sdk/api";
+import { AuthScheme, IntermediateRepresentation } from "@fern-fern/ir-sdk/api";
 import { SdkGeneratorContext } from "../SdkGeneratorContext";
 
 /**
@@ -94,6 +94,10 @@ export class WireTestSetupGenerator {
      * Builds the content for the conftest.py file
      */
     private buildConftestContent(): string {
+        const clientClassName = this.getClientClassName();
+        const clientImport = this.getClientImport();
+        const clientConstructorParams = this.buildClientConstructorParams();
+
         return `"""
 Pytest configuration for wire tests.
 
@@ -105,6 +109,8 @@ from typing import Any, Dict, Optional
 
 import pytest
 import requests
+
+${clientImport}
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -148,6 +154,23 @@ def wiremock_container():
     )
 
 
+def get_client(test_id: str) -> ${clientClassName}:
+    """
+    Creates a configured client instance for wire tests.
+    
+    Args:
+        test_id: Unique identifier for the test, used for request tracking.
+        
+    Returns:
+        A configured client instance with all required auth parameters.
+    """
+    return ${clientClassName}(
+        base_url="http://localhost:8080",
+        headers={"X-Test-Id": test_id},
+${clientConstructorParams}
+    )
+
+
 def verify_request_count(
     test_id: str,
     method: str,
@@ -171,5 +194,104 @@ def verify_request_count(
     requests_found = len(result.get("requests", []))
     assert requests_found == expected, f"Expected {expected} requests, found {requests_found}"
 `;
+    }
+
+    /**
+     * Gets the client class name based on organization and workspace name.
+     */
+    private getClientClassName(): string {
+        const orgName = this.context.config.organization;
+        const workspaceName = this.context.config.workspaceName;
+
+        const toPascalCase = (str: string) => {
+            return str
+                .split(/[-_]/)
+                .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+                .join("");
+        };
+
+        return toPascalCase(orgName) + toPascalCase(workspaceName);
+    }
+
+    /**
+     * Gets the import statement for the client class.
+     */
+    private getClientImport(): string {
+        const orgName = this.context.config.organization;
+        const clientClassName = this.getClientClassName();
+        return `from ${orgName} import ${clientClassName}`;
+    }
+
+    /**
+     * Builds the client constructor parameters based on the IR's auth schemes.
+     * Returns a string of keyword arguments with fake values for all required auth parameters.
+     */
+    private buildClientConstructorParams(): string {
+        const params: string[] = [];
+
+        // Process auth schemes from the IR
+        if (this.ir.auth && this.ir.auth.schemes) {
+            for (const scheme of this.ir.auth.schemes) {
+                const schemeParams = this.getAuthSchemeParams(scheme);
+                params.push(...schemeParams);
+            }
+        }
+
+        // Process global headers that might require values
+        if (this.ir.headers) {
+            for (const header of this.ir.headers) {
+                const paramName = header.name.name.snakeCase.safeName;
+                // Only add if not already added by auth schemes
+                if (!params.some((p) => p.startsWith(`        ${paramName}=`))) {
+                    params.push(`        ${paramName}="test_${paramName}",`);
+                }
+            }
+        }
+
+        return params.join("\n");
+    }
+
+    /**
+     * Gets the constructor parameters for a specific auth scheme.
+     */
+    private getAuthSchemeParams(scheme: AuthScheme): string[] {
+        const params: string[] = [];
+
+        switch (scheme.type) {
+            case "bearer":
+                // Bearer auth uses a token parameter
+                params.push(`        ${scheme.token.snakeCase.safeName}="test_token",`);
+                break;
+
+            case "basic":
+                // Basic auth uses username and password parameters
+                params.push(`        ${scheme.username.snakeCase.safeName}="test_username",`);
+                params.push(`        ${scheme.password.snakeCase.safeName}="test_password",`);
+                break;
+
+            case "header":
+                // Header auth uses a custom header parameter
+                params.push(
+                    `        ${scheme.name.name.snakeCase.safeName}="test_${scheme.name.name.snakeCase.safeName}",`
+                );
+                break;
+
+            case "oauth":
+                // OAuth typically uses client credentials
+                if (scheme.configuration) {
+                    // For client credentials OAuth, we need client_id and client_secret
+                    // The actual parameter names depend on the OAuth configuration
+                    params.push(`        _token_getter_override=lambda: "test_token",`);
+                }
+                break;
+
+            case "inferred":
+                // Inferred auth - handle based on the inferred type
+                // For now, we'll add a generic token parameter
+                params.push(`        _token_getter_override=lambda: "test_token",`);
+                break;
+        }
+
+        return params;
     }
 }

--- a/generators/python-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
+++ b/generators/python-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
@@ -25,6 +25,7 @@ export class WireTestSetupGenerator {
         this.generateWireMockConfigFile();
         this.generateDockerComposeFile();
         this.generateConftestFile();
+        this.generateInitFile();
     }
 
     public static getWiremockConfigContent(ir: IntermediateRepresentation) {
@@ -88,6 +89,15 @@ export class WireTestSetupGenerator {
 
         this.context.project.addRawFiles(conftestFile);
         this.context.logger.debug("Generated conftest.py for WireMock container lifecycle management");
+    }
+
+    /**
+     * Generates an __init__.py file to make tests/wire a proper Python package
+     */
+    private generateInitFile(): void {
+        const initFile = new File("__init__.py", RelativeFilePath.of("./tests/wire"), "");
+        this.context.project.addRawFiles(initFile);
+        this.context.logger.debug("Generated __init__.py for tests/wire package");
     }
 
     /**
@@ -219,7 +229,7 @@ def verify_request_count(
     private getClientImport(): string {
         const orgName = this.context.config.organization;
         const clientClassName = this.getClientClassName();
-        return `from ${orgName} import ${clientClassName}`;
+        return `from ${orgName}.client import ${clientClassName}`;
     }
 
     /**

--- a/seed/python-sdk/exhaustive/no-custom-config/tests/wire/conftest.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/tests/wire/conftest.py
@@ -11,6 +11,8 @@ from typing import Any, Dict, Optional
 import pytest
 import requests
 
+from seed import SeedExhaustive
+
 
 @pytest.fixture(scope="session", autouse=True)
 def wiremock_container():
@@ -44,6 +46,23 @@ def wiremock_container():
     # Cleanup: stop and remove the container
     print("\nStopping WireMock container...")
     subprocess.run(["docker", "compose", "-f", compose_file, "down", "-v"], check=False, capture_output=True)
+
+
+def get_client(test_id: str) -> SeedExhaustive:
+    """
+    Creates a configured client instance for wire tests.
+
+    Args:
+        test_id: Unique identifier for the test, used for request tracking.
+
+    Returns:
+        A configured client instance with all required auth parameters.
+    """
+    return SeedExhaustive(
+        base_url="http://localhost:8080",
+        headers={"X-Test-Id": test_id},
+        token="test_token",
+    )
 
 
 def verify_request_count(

--- a/seed/python-sdk/exhaustive/no-custom-config/tests/wire/conftest.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/tests/wire/conftest.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, Optional
 import pytest
 import requests
 
-from seed import SeedExhaustive
+from seed.client import SeedExhaustive
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_container.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_container.py
@@ -1,12 +1,10 @@
-from conftest import verify_request_count
-
-from seed import SeedExhaustive
+from conftest import get_client, verify_request_count
 
 
 def test_endpoints_container_get_and_return_list_of_primitives() -> None:
     """Test getAndReturnListOfPrimitives endpoint with WireMock"""
     test_id = "endpoints.container.get_and_return_list_of_primitives.0"
-    client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
+    client = get_client(test_id)
     result = client.endpoints.container.get_and_return_list_of_primitives(request=["string", "string"])
     verify_request_count(test_id, "POST", "/container/list-of-primitives", None, 1)
 
@@ -14,7 +12,7 @@ def test_endpoints_container_get_and_return_list_of_primitives() -> None:
 def test_endpoints_container_get_and_return_list_of_objects() -> None:
     """Test getAndReturnListOfObjects endpoint with WireMock"""
     test_id = "endpoints.container.get_and_return_list_of_objects.0"
-    client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
+    client = get_client(test_id)
     result = client.endpoints.container.get_and_return_list_of_objects(
         request=[{"string": "string"}, {"string": "string"}]
     )
@@ -24,7 +22,7 @@ def test_endpoints_container_get_and_return_list_of_objects() -> None:
 def test_endpoints_container_get_and_return_set_of_primitives() -> None:
     """Test getAndReturnSetOfPrimitives endpoint with WireMock"""
     test_id = "endpoints.container.get_and_return_set_of_primitives.0"
-    client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
+    client = get_client(test_id)
     result = client.endpoints.container.get_and_return_set_of_primitives(request=["string"])
     verify_request_count(test_id, "POST", "/container/set-of-primitives", None, 1)
 
@@ -32,7 +30,7 @@ def test_endpoints_container_get_and_return_set_of_primitives() -> None:
 def test_endpoints_container_get_and_return_set_of_objects() -> None:
     """Test getAndReturnSetOfObjects endpoint with WireMock"""
     test_id = "endpoints.container.get_and_return_set_of_objects.0"
-    client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
+    client = get_client(test_id)
     result = client.endpoints.container.get_and_return_set_of_objects(request=[{"string": "string"}])
     verify_request_count(test_id, "POST", "/container/set-of-objects", None, 1)
 
@@ -40,7 +38,7 @@ def test_endpoints_container_get_and_return_set_of_objects() -> None:
 def test_endpoints_container_get_and_return_map_prim_to_prim() -> None:
     """Test getAndReturnMapPrimToPrim endpoint with WireMock"""
     test_id = "endpoints.container.get_and_return_map_prim_to_prim.0"
-    client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
+    client = get_client(test_id)
     result = client.endpoints.container.get_and_return_map_prim_to_prim(request={"string": "string"})
     verify_request_count(test_id, "POST", "/container/map-prim-to-prim", None, 1)
 
@@ -48,7 +46,7 @@ def test_endpoints_container_get_and_return_map_prim_to_prim() -> None:
 def test_endpoints_container_get_and_return_map_of_prim_to_object() -> None:
     """Test getAndReturnMapOfPrimToObject endpoint with WireMock"""
     test_id = "endpoints.container.get_and_return_map_of_prim_to_object.0"
-    client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
+    client = get_client(test_id)
     result = client.endpoints.container.get_and_return_map_of_prim_to_object(request={"string": {"string": "string"}})
     verify_request_count(test_id, "POST", "/container/map-prim-to-object", None, 1)
 
@@ -56,6 +54,6 @@ def test_endpoints_container_get_and_return_map_of_prim_to_object() -> None:
 def test_endpoints_container_get_and_return_optional() -> None:
     """Test getAndReturnOptional endpoint with WireMock"""
     test_id = "endpoints.container.get_and_return_optional.0"
-    client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
+    client = get_client(test_id)
     result = client.endpoints.container.get_and_return_optional(request={"string": "string"})
     verify_request_count(test_id, "POST", "/container/opt-objects", None, 1)

--- a/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_container.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_container.py
@@ -1,4 +1,4 @@
-from conftest import get_client, verify_request_count
+from .conftest import get_client, verify_request_count
 
 
 def test_endpoints_container_get_and_return_list_of_primitives() -> None:

--- a/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_contentType.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_contentType.py
@@ -1,12 +1,10 @@
-from conftest import verify_request_count
-
-from seed import SeedExhaustive
+from conftest import get_client, verify_request_count
 
 
 def test_endpoints_contentType_post_json_patch_content_type() -> None:
     """Test postJsonPatchContentType endpoint with WireMock"""
     test_id = "endpoints.content_type.post_json_patch_content_type.0"
-    client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
+    client = get_client(test_id)
     result = client.endpoints.content_type.post_json_patch_content_type(
         string="string",
         integer=1,
@@ -28,7 +26,7 @@ def test_endpoints_contentType_post_json_patch_content_type() -> None:
 def test_endpoints_contentType_post_json_patch_content_with_charset_type() -> None:
     """Test postJsonPatchContentWithCharsetType endpoint with WireMock"""
     test_id = "endpoints.content_type.post_json_patch_content_with_charset_type.0"
-    client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
+    client = get_client(test_id)
     result = client.endpoints.content_type.post_json_patch_content_with_charset_type(
         string="string",
         integer=1,

--- a/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_contentType.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_contentType.py
@@ -1,4 +1,4 @@
-from conftest import get_client, verify_request_count
+from .conftest import get_client, verify_request_count
 
 
 def test_endpoints_contentType_post_json_patch_content_type() -> None:

--- a/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_enum.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_enum.py
@@ -1,4 +1,4 @@
-from conftest import get_client, verify_request_count
+from .conftest import get_client, verify_request_count
 
 
 def test_endpoints_enum_get_and_return_enum() -> None:

--- a/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_enum.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_enum.py
@@ -1,11 +1,9 @@
-from conftest import verify_request_count
-
-from seed import SeedExhaustive
+from conftest import get_client, verify_request_count
 
 
 def test_endpoints_enum_get_and_return_enum() -> None:
     """Test getAndReturnEnum endpoint with WireMock"""
     test_id = "endpoints.enum.get_and_return_enum.0"
-    client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
+    client = get_client(test_id)
     result = client.endpoints.enum.get_and_return_enum(request="SUNNY")
     verify_request_count(test_id, "POST", "/enum", None, 1)

--- a/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_httpMethods.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_httpMethods.py
@@ -1,4 +1,4 @@
-from conftest import get_client, verify_request_count
+from .conftest import get_client, verify_request_count
 
 
 def test_endpoints_httpMethods_test_get() -> None:

--- a/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_httpMethods.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_httpMethods.py
@@ -1,12 +1,10 @@
-from conftest import verify_request_count
-
-from seed import SeedExhaustive
+from conftest import get_client, verify_request_count
 
 
 def test_endpoints_httpMethods_test_get() -> None:
     """Test testGet endpoint with WireMock"""
     test_id = "endpoints.http_methods.test_get.0"
-    client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
+    client = get_client(test_id)
     result = client.endpoints.http_methods.test_get("id")
     verify_request_count(test_id, "GET", "/http-methods/id", None, 1)
 
@@ -14,7 +12,7 @@ def test_endpoints_httpMethods_test_get() -> None:
 def test_endpoints_httpMethods_test_post() -> None:
     """Test testPost endpoint with WireMock"""
     test_id = "endpoints.http_methods.test_post.0"
-    client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
+    client = get_client(test_id)
     result = client.endpoints.http_methods.test_post(string="string")
     verify_request_count(test_id, "POST", "/http-methods", None, 1)
 
@@ -22,7 +20,7 @@ def test_endpoints_httpMethods_test_post() -> None:
 def test_endpoints_httpMethods_test_put() -> None:
     """Test testPut endpoint with WireMock"""
     test_id = "endpoints.http_methods.test_put.0"
-    client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
+    client = get_client(test_id)
     result = client.endpoints.http_methods.test_put("id", string="string")
     verify_request_count(test_id, "PUT", "/http-methods/id", None, 1)
 
@@ -30,7 +28,7 @@ def test_endpoints_httpMethods_test_put() -> None:
 def test_endpoints_httpMethods_test_patch() -> None:
     """Test testPatch endpoint with WireMock"""
     test_id = "endpoints.http_methods.test_patch.0"
-    client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
+    client = get_client(test_id)
     result = client.endpoints.http_methods.test_patch(
         "id",
         string="string",
@@ -53,6 +51,6 @@ def test_endpoints_httpMethods_test_patch() -> None:
 def test_endpoints_httpMethods_test_delete() -> None:
     """Test testDelete endpoint with WireMock"""
     test_id = "endpoints.http_methods.test_delete.0"
-    client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
+    client = get_client(test_id)
     result = client.endpoints.http_methods.test_delete("id")
     verify_request_count(test_id, "DELETE", "/http-methods/id", None, 1)

--- a/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_object.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_object.py
@@ -1,4 +1,4 @@
-from conftest import get_client, verify_request_count
+from .conftest import get_client, verify_request_count
 
 
 def test_endpoints_object_get_and_return_with_optional_field() -> None:

--- a/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_object.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_object.py
@@ -1,12 +1,10 @@
-from conftest import verify_request_count
-
-from seed import SeedExhaustive
+from conftest import get_client, verify_request_count
 
 
 def test_endpoints_object_get_and_return_with_optional_field() -> None:
     """Test getAndReturnWithOptionalField endpoint with WireMock"""
     test_id = "endpoints.object.get_and_return_with_optional_field.0"
-    client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
+    client = get_client(test_id)
     result = client.endpoints.object.get_and_return_with_optional_field(
         string="string",
         integer=1,
@@ -28,7 +26,7 @@ def test_endpoints_object_get_and_return_with_optional_field() -> None:
 def test_endpoints_object_get_and_return_with_required_field() -> None:
     """Test getAndReturnWithRequiredField endpoint with WireMock"""
     test_id = "endpoints.object.get_and_return_with_required_field.0"
-    client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
+    client = get_client(test_id)
     result = client.endpoints.object.get_and_return_with_required_field(string="string")
     verify_request_count(test_id, "POST", "/object/get-and-return-with-required-field", None, 1)
 
@@ -36,7 +34,7 @@ def test_endpoints_object_get_and_return_with_required_field() -> None:
 def test_endpoints_object_get_and_return_with_map_of_map() -> None:
     """Test getAndReturnWithMapOfMap endpoint with WireMock"""
     test_id = "endpoints.object.get_and_return_with_map_of_map.0"
-    client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
+    client = get_client(test_id)
     result = client.endpoints.object.get_and_return_with_map_of_map(map_={"map": {"map": "map"}})
     verify_request_count(test_id, "POST", "/object/get-and-return-with-map-of-map", None, 1)
 
@@ -44,7 +42,7 @@ def test_endpoints_object_get_and_return_with_map_of_map() -> None:
 def test_endpoints_object_get_and_return_nested_with_optional_field() -> None:
     """Test getAndReturnNestedWithOptionalField endpoint with WireMock"""
     test_id = "endpoints.object.get_and_return_nested_with_optional_field.0"
-    client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
+    client = get_client(test_id)
     result = client.endpoints.object.get_and_return_nested_with_optional_field(
         string="string",
         nested_object={
@@ -69,7 +67,7 @@ def test_endpoints_object_get_and_return_nested_with_optional_field() -> None:
 def test_endpoints_object_get_and_return_nested_with_required_field() -> None:
     """Test getAndReturnNestedWithRequiredField endpoint with WireMock"""
     test_id = "endpoints.object.get_and_return_nested_with_required_field.0"
-    client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
+    client = get_client(test_id)
     result = client.endpoints.object.get_and_return_nested_with_required_field(
         "string",
         string="string",
@@ -95,7 +93,7 @@ def test_endpoints_object_get_and_return_nested_with_required_field() -> None:
 def test_endpoints_object_get_and_return_nested_with_required_field_as_list() -> None:
     """Test getAndReturnNestedWithRequiredFieldAsList endpoint with WireMock"""
     test_id = "endpoints.object.get_and_return_nested_with_required_field_as_list.0"
-    client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
+    client = get_client(test_id)
     result = client.endpoints.object.get_and_return_nested_with_required_field_as_list(
         request=[
             {

--- a/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_params.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_params.py
@@ -1,4 +1,4 @@
-from conftest import get_client, verify_request_count
+from .conftest import get_client, verify_request_count
 
 
 def test_endpoints_params_get_with_path() -> None:

--- a/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_params.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_params.py
@@ -1,12 +1,10 @@
-from conftest import verify_request_count
-
-from seed import SeedExhaustive
+from conftest import get_client, verify_request_count
 
 
 def test_endpoints_params_get_with_path() -> None:
     """Test getWithPath endpoint with WireMock"""
     test_id = "endpoints.params.get_with_path.0"
-    client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
+    client = get_client(test_id)
     result = client.endpoints.params.get_with_path("param")
     verify_request_count(test_id, "GET", "/params/path/param", None, 1)
 
@@ -14,7 +12,7 @@ def test_endpoints_params_get_with_path() -> None:
 def test_endpoints_params_get_with_inline_path() -> None:
     """Test getWithInlinePath endpoint with WireMock"""
     test_id = "endpoints.params.get_with_inline_path.0"
-    client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
+    client = get_client(test_id)
     result = client.endpoints.params.get_with_inline_path("param")
     verify_request_count(test_id, "GET", "/params/path/param", None, 1)
 
@@ -22,7 +20,7 @@ def test_endpoints_params_get_with_inline_path() -> None:
 def test_endpoints_params_get_with_query() -> None:
     """Test getWithQuery endpoint with WireMock"""
     test_id = "endpoints.params.get_with_query.0"
-    client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
+    client = get_client(test_id)
     result = client.endpoints.params.get_with_query(query="query", number=1)
     verify_request_count(test_id, "GET", "/params", {"query": "query", "number": "1"}, 1)
 
@@ -30,7 +28,7 @@ def test_endpoints_params_get_with_query() -> None:
 def test_endpoints_params_get_with_allow_multiple_query() -> None:
     """Test getWithAllowMultipleQuery endpoint with WireMock"""
     test_id = "endpoints.params.get_with_allow_multiple_query.0"
-    client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
+    client = get_client(test_id)
     result = client.endpoints.params.get_with_allow_multiple_query(query="query", number=1)
     verify_request_count(test_id, "GET", "/params", {"query": "query", "number": "1"}, 1)
 
@@ -38,7 +36,7 @@ def test_endpoints_params_get_with_allow_multiple_query() -> None:
 def test_endpoints_params_get_with_path_and_query() -> None:
     """Test getWithPathAndQuery endpoint with WireMock"""
     test_id = "endpoints.params.get_with_path_and_query.0"
-    client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
+    client = get_client(test_id)
     result = client.endpoints.params.get_with_path_and_query("param", query="query")
     verify_request_count(test_id, "GET", "/params/path-query/param", {"query": "query"}, 1)
 
@@ -46,7 +44,7 @@ def test_endpoints_params_get_with_path_and_query() -> None:
 def test_endpoints_params_get_with_inline_path_and_query() -> None:
     """Test getWithInlinePathAndQuery endpoint with WireMock"""
     test_id = "endpoints.params.get_with_inline_path_and_query.0"
-    client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
+    client = get_client(test_id)
     result = client.endpoints.params.get_with_inline_path_and_query("param", query="query")
     verify_request_count(test_id, "GET", "/params/path-query/param", {"query": "query"}, 1)
 
@@ -54,7 +52,7 @@ def test_endpoints_params_get_with_inline_path_and_query() -> None:
 def test_endpoints_params_modify_with_path() -> None:
     """Test modifyWithPath endpoint with WireMock"""
     test_id = "endpoints.params.modify_with_path.0"
-    client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
+    client = get_client(test_id)
     result = client.endpoints.params.modify_with_path("param", request="string")
     verify_request_count(test_id, "PUT", "/params/path/param", None, 1)
 
@@ -62,6 +60,6 @@ def test_endpoints_params_modify_with_path() -> None:
 def test_endpoints_params_modify_with_inline_path() -> None:
     """Test modifyWithInlinePath endpoint with WireMock"""
     test_id = "endpoints.params.modify_with_inline_path.0"
-    client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
+    client = get_client(test_id)
     result = client.endpoints.params.modify_with_inline_path("param", request="string")
     verify_request_count(test_id, "PUT", "/params/path/param", None, 1)

--- a/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_primitive.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_primitive.py
@@ -1,12 +1,10 @@
-from conftest import verify_request_count
-
-from seed import SeedExhaustive
+from conftest import get_client, verify_request_count
 
 
 def test_endpoints_primitive_get_and_return_string() -> None:
     """Test getAndReturnString endpoint with WireMock"""
     test_id = "endpoints.primitive.get_and_return_string.0"
-    client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
+    client = get_client(test_id)
     result = client.endpoints.primitive.get_and_return_string(request="string")
     verify_request_count(test_id, "POST", "/primitive/string", None, 1)
 
@@ -14,7 +12,7 @@ def test_endpoints_primitive_get_and_return_string() -> None:
 def test_endpoints_primitive_get_and_return_int() -> None:
     """Test getAndReturnInt endpoint with WireMock"""
     test_id = "endpoints.primitive.get_and_return_int.0"
-    client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
+    client = get_client(test_id)
     result = client.endpoints.primitive.get_and_return_int(request=1)
     verify_request_count(test_id, "POST", "/primitive/integer", None, 1)
 
@@ -22,7 +20,7 @@ def test_endpoints_primitive_get_and_return_int() -> None:
 def test_endpoints_primitive_get_and_return_long() -> None:
     """Test getAndReturnLong endpoint with WireMock"""
     test_id = "endpoints.primitive.get_and_return_long.0"
-    client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
+    client = get_client(test_id)
     result = client.endpoints.primitive.get_and_return_long(request=1000000)
     verify_request_count(test_id, "POST", "/primitive/long", None, 1)
 
@@ -30,7 +28,7 @@ def test_endpoints_primitive_get_and_return_long() -> None:
 def test_endpoints_primitive_get_and_return_double() -> None:
     """Test getAndReturnDouble endpoint with WireMock"""
     test_id = "endpoints.primitive.get_and_return_double.0"
-    client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
+    client = get_client(test_id)
     result = client.endpoints.primitive.get_and_return_double(request=1.1)
     verify_request_count(test_id, "POST", "/primitive/double", None, 1)
 
@@ -38,7 +36,7 @@ def test_endpoints_primitive_get_and_return_double() -> None:
 def test_endpoints_primitive_get_and_return_bool() -> None:
     """Test getAndReturnBool endpoint with WireMock"""
     test_id = "endpoints.primitive.get_and_return_bool.0"
-    client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
+    client = get_client(test_id)
     result = client.endpoints.primitive.get_and_return_bool(request=True)
     verify_request_count(test_id, "POST", "/primitive/boolean", None, 1)
 
@@ -46,7 +44,7 @@ def test_endpoints_primitive_get_and_return_bool() -> None:
 def test_endpoints_primitive_get_and_return_datetime() -> None:
     """Test getAndReturnDatetime endpoint with WireMock"""
     test_id = "endpoints.primitive.get_and_return_datetime.0"
-    client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
+    client = get_client(test_id)
     result = client.endpoints.primitive.get_and_return_datetime(request="2024-01-15T09:30:00Z")
     verify_request_count(test_id, "POST", "/primitive/datetime", None, 1)
 
@@ -54,7 +52,7 @@ def test_endpoints_primitive_get_and_return_datetime() -> None:
 def test_endpoints_primitive_get_and_return_date() -> None:
     """Test getAndReturnDate endpoint with WireMock"""
     test_id = "endpoints.primitive.get_and_return_date.0"
-    client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
+    client = get_client(test_id)
     result = client.endpoints.primitive.get_and_return_date(request="2023-01-15")
     verify_request_count(test_id, "POST", "/primitive/date", None, 1)
 
@@ -62,7 +60,7 @@ def test_endpoints_primitive_get_and_return_date() -> None:
 def test_endpoints_primitive_get_and_return_uuid() -> None:
     """Test getAndReturnUUID endpoint with WireMock"""
     test_id = "endpoints.primitive.get_and_return_uuid.0"
-    client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
+    client = get_client(test_id)
     result = client.endpoints.primitive.get_and_return_uuid(request="d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32")
     verify_request_count(test_id, "POST", "/primitive/uuid", None, 1)
 
@@ -70,6 +68,6 @@ def test_endpoints_primitive_get_and_return_uuid() -> None:
 def test_endpoints_primitive_get_and_return_base_64() -> None:
     """Test getAndReturnBase64 endpoint with WireMock"""
     test_id = "endpoints.primitive.get_and_return_base_64.0"
-    client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
+    client = get_client(test_id)
     result = client.endpoints.primitive.get_and_return_base_64(request="SGVsbG8gd29ybGQh")
     verify_request_count(test_id, "POST", "/primitive/base64", None, 1)

--- a/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_primitive.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_primitive.py
@@ -1,4 +1,4 @@
-from conftest import get_client, verify_request_count
+from .conftest import get_client, verify_request_count
 
 
 def test_endpoints_primitive_get_and_return_string() -> None:

--- a/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_put.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_put.py
@@ -1,11 +1,9 @@
-from conftest import verify_request_count
-
-from seed import SeedExhaustive
+from conftest import get_client, verify_request_count
 
 
 def test_endpoints_put_add() -> None:
     """Test add endpoint with WireMock"""
     test_id = "endpoints.put.add.0"
-    client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
+    client = get_client(test_id)
     result = client.endpoints.put.add("id")
     verify_request_count(test_id, "PUT", "/id", None, 1)

--- a/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_put.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_put.py
@@ -1,4 +1,4 @@
-from conftest import get_client, verify_request_count
+from .conftest import get_client, verify_request_count
 
 
 def test_endpoints_put_add() -> None:

--- a/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_union.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_union.py
@@ -1,4 +1,4 @@
-from conftest import get_client, verify_request_count
+from .conftest import get_client, verify_request_count
 
 
 def test_endpoints_union_get_and_return_union() -> None:

--- a/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_union.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_union.py
@@ -1,11 +1,9 @@
-from conftest import verify_request_count
-
-from seed import SeedExhaustive
+from conftest import get_client, verify_request_count
 
 
 def test_endpoints_union_get_and_return_union() -> None:
     """Test getAndReturnUnion endpoint with WireMock"""
     test_id = "endpoints.union.get_and_return_union.0"
-    client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
+    client = get_client(test_id)
     result = client.endpoints.union.get_and_return_union(request={"animal": "dog", "name": "name", "likesToWoof": True})
     verify_request_count(test_id, "POST", "/union", None, 1)

--- a/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_urls.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_urls.py
@@ -1,12 +1,10 @@
-from conftest import verify_request_count
-
-from seed import SeedExhaustive
+from conftest import get_client, verify_request_count
 
 
 def test_endpoints_urls_with_mixed_case() -> None:
     """Test withMixedCase endpoint with WireMock"""
     test_id = "endpoints.urls.with_mixed_case.0"
-    client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
+    client = get_client(test_id)
     result = client.endpoints.urls.with_mixed_case()
     verify_request_count(test_id, "GET", "/urls/MixedCase", None, 1)
 
@@ -14,7 +12,7 @@ def test_endpoints_urls_with_mixed_case() -> None:
 def test_endpoints_urls_no_ending_slash() -> None:
     """Test noEndingSlash endpoint with WireMock"""
     test_id = "endpoints.urls.no_ending_slash.0"
-    client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
+    client = get_client(test_id)
     result = client.endpoints.urls.no_ending_slash()
     verify_request_count(test_id, "GET", "/urls/no-ending-slash", None, 1)
 
@@ -22,7 +20,7 @@ def test_endpoints_urls_no_ending_slash() -> None:
 def test_endpoints_urls_with_ending_slash() -> None:
     """Test withEndingSlash endpoint with WireMock"""
     test_id = "endpoints.urls.with_ending_slash.0"
-    client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
+    client = get_client(test_id)
     result = client.endpoints.urls.with_ending_slash()
     verify_request_count(test_id, "GET", "/urls/with-ending-slash/", None, 1)
 
@@ -30,6 +28,6 @@ def test_endpoints_urls_with_ending_slash() -> None:
 def test_endpoints_urls_with_underscores() -> None:
     """Test withUnderscores endpoint with WireMock"""
     test_id = "endpoints.urls.with_underscores.0"
-    client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
+    client = get_client(test_id)
     result = client.endpoints.urls.with_underscores()
     verify_request_count(test_id, "GET", "/urls/with_underscores", None, 1)

--- a/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_urls.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_endpoints_urls.py
@@ -1,4 +1,4 @@
-from conftest import get_client, verify_request_count
+from .conftest import get_client, verify_request_count
 
 
 def test_endpoints_urls_with_mixed_case() -> None:

--- a/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_inlinedRequests.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_inlinedRequests.py
@@ -1,12 +1,10 @@
-from conftest import verify_request_count
-
-from seed import SeedExhaustive
+from conftest import get_client, verify_request_count
 
 
 def test_inlinedRequests_post_with_object_bodyand_response() -> None:
     """Test postWithObjectBodyandResponse endpoint with WireMock"""
     test_id = "inlined_requests.post_with_object_bodyand_response.0"
-    client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
+    client = get_client(test_id)
     result = client.inlined_requests.post_with_object_bodyand_response(
         string="string",
         integer=1,

--- a/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_inlinedRequests.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_inlinedRequests.py
@@ -1,4 +1,4 @@
-from conftest import get_client, verify_request_count
+from .conftest import get_client, verify_request_count
 
 
 def test_inlinedRequests_post_with_object_bodyand_response() -> None:

--- a/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_noAuth.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_noAuth.py
@@ -1,11 +1,9 @@
-from conftest import verify_request_count
-
-from seed import SeedExhaustive
+from conftest import get_client, verify_request_count
 
 
 def test_noAuth_post_with_no_auth() -> None:
     """Test postWithNoAuth endpoint with WireMock"""
     test_id = "no_auth.post_with_no_auth.0"
-    client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
+    client = get_client(test_id)
     result = client.no_auth.post_with_no_auth(request={"key": "value"})
     verify_request_count(test_id, "POST", "/no-auth", None, 1)

--- a/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_noAuth.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_noAuth.py
@@ -1,4 +1,4 @@
-from conftest import get_client, verify_request_count
+from .conftest import get_client, verify_request_count
 
 
 def test_noAuth_post_with_no_auth() -> None:

--- a/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_noReqBody.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_noReqBody.py
@@ -1,4 +1,4 @@
-from conftest import get_client, verify_request_count
+from .conftest import get_client, verify_request_count
 
 
 def test_noReqBody_get_with_no_request_body() -> None:

--- a/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_noReqBody.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_noReqBody.py
@@ -1,12 +1,10 @@
-from conftest import verify_request_count
-
-from seed import SeedExhaustive
+from conftest import get_client, verify_request_count
 
 
 def test_noReqBody_get_with_no_request_body() -> None:
     """Test getWithNoRequestBody endpoint with WireMock"""
     test_id = "no_req_body.get_with_no_request_body.0"
-    client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
+    client = get_client(test_id)
     result = client.no_req_body.get_with_no_request_body()
     verify_request_count(test_id, "GET", "/no-req-body", None, 1)
 
@@ -14,6 +12,6 @@ def test_noReqBody_get_with_no_request_body() -> None:
 def test_noReqBody_post_with_no_request_body() -> None:
     """Test postWithNoRequestBody endpoint with WireMock"""
     test_id = "no_req_body.post_with_no_request_body.0"
-    client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
+    client = get_client(test_id)
     result = client.no_req_body.post_with_no_request_body()
     verify_request_count(test_id, "POST", "/no-req-body", None, 1)

--- a/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_reqWithHeaders.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_reqWithHeaders.py
@@ -1,12 +1,10 @@
-from conftest import verify_request_count
-
-from seed import SeedExhaustive
+from conftest import get_client, verify_request_count
 
 
 def test_reqWithHeaders_get_with_custom_header() -> None:
     """Test getWithCustomHeader endpoint with WireMock"""
     test_id = "req_with_headers.get_with_custom_header.0"
-    client = SeedExhaustive(base_url="http://localhost:8080", headers={"X-Test-Id": test_id})
+    client = get_client(test_id)
     result = client.req_with_headers.get_with_custom_header(
         x_test_service_header="X-TEST-SERVICE-HEADER", x_test_endpoint_header="X-TEST-ENDPOINT-HEADER", request="string"
     )

--- a/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_reqWithHeaders.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/tests/wire/test_reqWithHeaders.py
@@ -1,4 +1,4 @@
-from conftest import get_client, verify_request_count
+from .conftest import get_client, verify_request_count
 
 
 def test_reqWithHeaders_get_with_custom_header() -> None:


### PR DESCRIPTION
## Description

Refs: Slack thread from @tjb9dc

Refactors the Python wire test generator to properly construct clients that require API keys or token parameters by centralizing client construction in a `get_client()` helper function.

**Link to Devin run:** https://app.devin.ai/sessions/7c0e1ff44d9346c9b6df82678d2965bc
**Requested by:** thomas@buildwithfern.com (@tjb9dc)

## Changes Made

- Added `get_client(test_id)` function in generated `conftest.py` that constructs the client with all required auth parameters
- Updated test functions to use `get_client(test_id)` instead of inline client construction
- Added support for multiple auth schemes:
  - Bearer auth: supplies `token="test_token"`
  - Basic auth: supplies `username="test_username"` and `password="test_password"`
  - Header auth: supplies the header parameter with a fake value
  - OAuth/Inferred: supplies `_token_getter_override=lambda: "test_token"`
- Also handles global headers that require values

## Updates since last revision

Fixed two issues reported by the user:

1. **Added `__init__.py` to `tests/wire/`** - Makes the wire test directory a proper Python package, which is required for mypy type checking
2. **Fixed import paths**:
   - Changed client import from `from seed import SeedExhaustive` to `from seed.client import SeedExhaustive` (matches the pattern used by other tests in the repo)
   - Changed test file imports from `from conftest import ...` to `from .conftest import ...` (relative imports required now that `tests/wire/` is a package)

## Testing

- [x] Ran `pnpm run check` - lint passes
- [x] Ran `pnpm seed:local test --generator python-sdk --fixture exhaustive:no-custom-config` - test passes

## Human Review Checklist

- [ ] Verify the auth scheme parameter names (e.g., `token`, `username`, `password`) match what the Python SDK generator actually produces for different auth configurations
- [ ] Verify `_token_getter_override` is the correct parameter name for OAuth/inferred auth cases
- [ ] Consider testing with fixtures that use different auth schemes (basic auth, header auth) to ensure coverage
- [ ] Verify the `from seed.client import ...` pattern works for all SDK configurations (not just exhaustive)