### PR TITLE
feat(openapi): support generating examples for x-fern-type: literal values

### DIFF
--- a/packages/cli/api-importers/v3-importer-commons/src/converters/ExampleConverter.ts
+++ b/packages/cli/api-importers/v3-importer-commons/src/converters/ExampleConverter.ts
@@ -1083,7 +1083,7 @@ export class ExampleConverter extends AbstractConverter<AbstractConverterContext
     }
 
     private maybeConvertLiteralFernType(resolvedSchema: OpenAPIV3_1.SchemaObject): ExampleConverter.Output | undefined {
-        const fernType = resolvedSchema["x-fern-type"];
+        const fernType = (resolvedSchema as Record<string, unknown>)["x-fern-type"];
         if (typeof fernType !== "string") {
             return undefined;
         }

--- a/packages/cli/api-importers/v3-importer-commons/src/converters/ExampleConverter.ts
+++ b/packages/cli/api-importers/v3-importer-commons/src/converters/ExampleConverter.ts
@@ -3,6 +3,8 @@ import { OpenAPIV3_1 } from "openapi-types";
 
 import { AbstractConverter, AbstractConverterContext, APIError } from "..";
 
+const LITERAL_REGEX = /^literal<\s*(?:"(.*)"|(true|false))\s*>$/;
+
 export declare namespace ExampleConverter {
     export interface Args extends AbstractConverter.Args<AbstractConverterContext<object>> {
         schema: OpenAPIV3_1.SchemaObject | OpenAPIV3_1.ReferenceObject;
@@ -167,6 +169,12 @@ export class ExampleConverter extends AbstractConverter<AbstractConverterContext
                 validExample: this.example,
                 errors: []
             };
+        }
+
+        // Check for x-fern-type: literal<...> extension and return the literal value as the example
+        const maybeLiteralExample = this.maybeConvertLiteralFernType(resolvedSchema);
+        if (maybeLiteralExample != null) {
+            return maybeLiteralExample;
         }
 
         if (Array.isArray(resolvedSchema.type)) {
@@ -1071,6 +1079,42 @@ export class ExampleConverter extends AbstractConverter<AbstractConverterContext
             }
             return Object.values(examples ?? {})[0] as Type;
         }
+        return undefined;
+    }
+
+    private maybeConvertLiteralFernType(resolvedSchema: OpenAPIV3_1.SchemaObject): ExampleConverter.Output | undefined {
+        const fernType = resolvedSchema["x-fern-type"];
+        if (typeof fernType !== "string") {
+            return undefined;
+        }
+
+        const literalMatch = fernType.match(LITERAL_REGEX);
+        if (literalMatch == null) {
+            return undefined;
+        }
+
+        // Group 1 captures string literals (e.g., literal<"value">)
+        if (literalMatch[1] != null) {
+            return {
+                isValid: true,
+                coerced: false,
+                usedProvidedExample: false,
+                validExample: literalMatch[1],
+                errors: []
+            };
+        }
+
+        // Group 2 captures boolean literals (e.g., literal<true> or literal<false>)
+        if (literalMatch[2] != null) {
+            return {
+                isValid: true,
+                coerced: false,
+                usedProvidedExample: false,
+                validExample: literalMatch[2] === "true",
+                errors: []
+            };
+        }
+
         return undefined;
     }
 

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -2,10 +2,10 @@
 - changelogEntry:
     - summary: |
         Support generating examples for `x-fern-type: literal<...>` values in OpenAPI specs. Parameters with literal type annotations now generate examples using the underlying literal value.
-      type: feat
+      type: fix
   irVersion: 62
   createdAt: "2025-11-25"
-  version: 2.7.0
+  version: 2.6.2
 
 - changelogEntry:
     - summary: |

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Support generating examples for `x-fern-type: literal<...>` values in OpenAPI specs. Parameters with literal type annotations now generate examples using the underlying literal value.
+      type: feat
+  irVersion: 62
+  createdAt: "2025-11-25"
+  version: 2.7.0
+
+- changelogEntry:
+    - summary: |
         Fix docs broken-links validator incorrectly flagging external URLs that contain the docs domain in query parameters.
       type: fix
   irVersion: 62


### PR DESCRIPTION
## Description

<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
<!-- Provide a clear and concise description of the changes made in this PR -->

Adds support for generating examples for `x-fern-type: literal<...>` values in OpenAPI specs. When a parameter or schema has a literal type annotation like `x-fern-type: literal<"2025-04-21">`, the generated example will now use the underlying literal value instead of a generic fallback.

## Changes Made

- Added `LITERAL_REGEX` constant to parse literal type strings (matches pattern from fern-definition-schema)
- Added `maybeConvertLiteralFernType()` method in `ExampleConverter.ts` that extracts literal values from `x-fern-type` extensions
- Supports both string literals (e.g., `literal<"value">`) and boolean literals (e.g., `literal<true>`)
- Added changelog entry for version 2.7.0
- [ ] Updated README.md generator (if applicable) - N/A

## Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed - verified TypeScript compilation passes locally

## Human Review Checklist

- [ ] Verify the regex pattern handles edge cases (e.g., escaped quotes in string literals)
- [ ] Confirm whether unit tests should be added for the new `maybeConvertLiteralFernType` method
- [ ] Verify changelog entry format is correct

---

Requested by: Deep Singhvi (@dsinghvi)
Devin Session: https://app.devin.ai/sessions/200382dad78d4b05b31b887ed9681135