### PR TITLE
feat(php): Add credential redaction to prevent accidental logging of sensitive data

### DIFF
--- a/generators/php/base/src/AsIs.ts
+++ b/generators/php/base/src/AsIs.ts
@@ -9,6 +9,7 @@ export enum AsIsFiles {
     BaseApiRequest = "Client/BaseApiRequest.Template.php",
     HttpMethod = "Client/HttpMethod.Template.php",
     RawClient = "Client/RawClient.Template.php",
+    Redactor = "Client/Redactor.Template.php",
     RetryMiddleware = "Client/RetryMiddleware.Template.php",
     RawClientTest = "Client/RawClientTest.Template.php",
 

--- a/generators/php/base/src/asIs/Client/Redactor.Template.php
+++ b/generators/php/base/src/asIs/Client/Redactor.Template.php
@@ -1,0 +1,248 @@
+<?php
+
+namespace <%= namespace%>;
+
+/**
+ * Utility class for redacting sensitive information from logs and error messages.
+ * This helps prevent accidental exposure of credentials like bearer tokens,
+ * client IDs, client secrets, and other sensitive data.
+ */
+final class Redactor
+{
+    /**
+     * Headers that should be redacted when logging.
+     * @var array<string>
+     */
+    private const SENSITIVE_HEADERS = [
+        'authorization',
+        'www-authenticate',
+        'x-api-key',
+        'api-key',
+        'apikey',
+        'x-api-token',
+        'x-auth-token',
+        'auth-token',
+        'cookie',
+        'set-cookie',
+        'proxy-authorization',
+        'proxy-authenticate',
+        'x-csrf-token',
+        'x-xsrf-token',
+        'x-session-token',
+        'x-access-token',
+    ];
+
+    /**
+     * Query parameters that should be redacted when logging.
+     * @var array<string>
+     */
+    private const SENSITIVE_QUERY_PARAMS = [
+        'api_key',
+        'api-key',
+        'apikey',
+        'token',
+        'access_token',
+        'access-token',
+        'auth_token',
+        'auth-token',
+        'password',
+        'passwd',
+        'secret',
+        'api_secret',
+        'api-secret',
+        'apisecret',
+        'key',
+        'session',
+        'session_id',
+        'session-id',
+    ];
+
+    /**
+     * Body/JSON keys that should be redacted when logging.
+     * @var array<string>
+     */
+    private const SENSITIVE_BODY_KEYS = [
+        'access_token',
+        'accessToken',
+        'refresh_token',
+        'refreshToken',
+        'id_token',
+        'idToken',
+        'token',
+        'client_secret',
+        'clientSecret',
+        'password',
+        'api_key',
+        'apiKey',
+        'secret',
+    ];
+
+    private const REDACTED = '[REDACTED]';
+
+    /**
+     * Redacts sensitive values from an array of headers.
+     *
+     * @param array<string, string> $headers
+     * @return array<string, string>
+     */
+    public static function redactHeaders(array $headers): array
+    {
+        $redacted = [];
+        foreach ($headers as $key => $value) {
+            if (in_array(strtolower($key), self::SENSITIVE_HEADERS, true)) {
+                $redacted[$key] = self::REDACTED;
+            } else {
+                $redacted[$key] = $value;
+            }
+        }
+        return $redacted;
+    }
+
+    /**
+     * Redacts sensitive values from query parameters.
+     *
+     * @param array<int|string, mixed>|null $params
+     * @return array<int|string, mixed>|null
+     */
+    public static function redactQueryParams(?array $params): ?array
+    {
+        if ($params === null) {
+            return null;
+        }
+        $redacted = [];
+        foreach ($params as $key => $value) {
+            $keyStr = is_string($key) ? $key : (string) $key;
+            if (in_array(strtolower($keyStr), self::SENSITIVE_QUERY_PARAMS, true)) {
+                $redacted[$key] = self::REDACTED;
+            } else {
+                $redacted[$key] = $value;
+            }
+        }
+        return $redacted;
+    }
+
+    /**
+     * Redacts credentials from a URL (userinfo and sensitive query params).
+     *
+     * @param string $url
+     * @return string
+     */
+    public static function redactUrl(string $url): string
+    {
+        $parsed = parse_url($url);
+        if ($parsed === false) {
+            return $url;
+        }
+
+        // Redact userinfo (user:pass@host)
+        if (isset($parsed['user']) || isset($parsed['pass'])) {
+            $parsed['user'] = self::REDACTED;
+            unset($parsed['pass']);
+        }
+
+        // Redact sensitive query parameters
+        if (isset($parsed['query'])) {
+            parse_str($parsed['query'], $queryParams);
+            $redactedParams = self::redactQueryParams($queryParams);
+            $parsed['query'] = http_build_query($redactedParams ?? []);
+        }
+
+        return self::buildUrl($parsed);
+    }
+
+    /**
+     * Redacts sensitive keys from a mixed body (array, object, or JSON string).
+     *
+     * @param mixed $body
+     * @return mixed
+     */
+    public static function redactBody(mixed $body): mixed
+    {
+        if ($body === null) {
+            return null;
+        }
+
+        // If it's a string, try to decode as JSON
+        if (is_string($body)) {
+            $decoded = json_decode($body, true);
+            if (json_last_error() === JSON_ERROR_NONE && is_array($decoded)) {
+                $redacted = self::redactArray($decoded);
+                return json_encode($redacted) ?: '';
+            }
+            return $body;
+        }
+
+        // If it's an array, redact recursively
+        if (is_array($body)) {
+            return self::redactArray($body);
+        }
+
+        // If it's an object, convert to array, redact, and return as object
+        if (is_object($body)) {
+            $array = (array) $body;
+            return (object) self::redactArray($array);
+        }
+
+        return $body;
+    }
+
+    /**
+     * Recursively redacts sensitive keys from an array.
+     *
+     * @param array<string, mixed> $data
+     * @return array<string, mixed>
+     */
+    private static function redactArray(array $data): array
+    {
+        $redacted = [];
+        foreach ($data as $key => $value) {
+            if (is_string($key) && in_array(strtolower($key), array_map('strtolower', self::SENSITIVE_BODY_KEYS), true)) {
+                $redacted[$key] = self::REDACTED;
+            } elseif (is_array($value)) {
+                $redacted[$key] = self::redactArray($value);
+            } elseif (is_object($value)) {
+                $redacted[$key] = (object) self::redactArray((array) $value);
+            } else {
+                $redacted[$key] = $value;
+            }
+        }
+        return $redacted;
+    }
+
+    /**
+     * Builds a URL from parsed components.
+     *
+     * @param array<string, mixed> $parts
+     * @return string
+     */
+    private static function buildUrl(array $parts): string
+    {
+        $url = '';
+        if (isset($parts['scheme'])) {
+            $url .= $parts['scheme'] . '://';
+        }
+        if (isset($parts['user'])) {
+            $url .= $parts['user'];
+            if (isset($parts['pass'])) {
+                $url .= ':' . $parts['pass'];
+            }
+            $url .= '@';
+        }
+        if (isset($parts['host'])) {
+            $url .= $parts['host'];
+        }
+        if (isset($parts['port'])) {
+            $url .= ':' . $parts['port'];
+        }
+        if (isset($parts['path'])) {
+            $url .= $parts['path'];
+        }
+        if (isset($parts['query']) && $parts['query'] !== '') {
+            $url .= '?' . $parts['query'];
+        }
+        if (isset($parts['fragment'])) {
+            $url .= '#' . $parts['fragment'];
+        }
+        return $url;
+    }
+}

--- a/generators/php/sdk/src/SdkGeneratorContext.ts
+++ b/generators/php/sdk/src/SdkGeneratorContext.ts
@@ -555,6 +555,7 @@ export class SdkGeneratorContext extends AbstractPhpGeneratorContext<SdkCustomCo
             AsIsFiles.HttpMethod,
             AsIsFiles.JsonApiRequest,
             AsIsFiles.RawClient,
+            AsIsFiles.Redactor,
             AsIsFiles.RetryMiddleware,
             AsIsFiles.MultipartApiRequest,
             AsIsFiles.MultipartFormData,

--- a/generators/php/sdk/src/error/BaseApiExceptionGenerator.ts
+++ b/generators/php/sdk/src/error/BaseApiExceptionGenerator.ts
@@ -73,8 +73,14 @@ export class BaseApiExceptionGenerator extends FileGenerator<PhpFile, SdkCustomC
                 writer.controlFlow("if", php.codeblock("empty($this->body)"));
                 writer.writeTextStatement('return "$this->message; Status Code: $this->code\\n"');
                 writer.endControlFlow();
+                writer.write("$redactedBody = ");
+                writer.writeNode(this.context.getCoreClientClassReference("Redactor"));
+                writer.writeTextStatement("::redactBody($this->body)");
+                writer.controlFlow("if", php.codeblock("!is_string($redactedBody)"));
+                writer.writeTextStatement("$redactedBody = json_encode($redactedBody) ?: ''");
+                writer.endControlFlow();
                 writer.writeTextStatement(
-                    'return "$this->message; Status Code: $this->code; Body: " . $this->body . "\\n"'
+                    'return "$this->message; Status Code: $this->code; Body: " . $redactedBody . "\\n"'
                 );
             })
         });

--- a/seed/php-sdk/bearer-token-environment-variable/reference.md
+++ b/seed/php-sdk/bearer-token-environment-variable/reference.md
@@ -1,0 +1,40 @@
+# Reference
+## Service
+<details><summary><code>$client->service->getWithBearerToken() -> string</code></summary>
+<dl>
+<dd>
+
+#### 📝 Description
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+GET request with custom api key
+</dd>
+</dl>
+</dd>
+</dl>
+
+#### 🔌 Usage
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+```php
+$client->service->getWithBearerToken();
+```
+</dd>
+</dl>
+</dd>
+</dl>
+
+
+</dd>
+</dl>
+</details>

--- a/seed/php-sdk/bearer-token-environment-variable/src/Core/Client/Redactor.php
+++ b/seed/php-sdk/bearer-token-environment-variable/src/Core/Client/Redactor.php
@@ -1,0 +1,248 @@
+<?php
+
+namespace Seed\Core\Client;
+
+/**
+ * Utility class for redacting sensitive information from logs and error messages.
+ * This helps prevent accidental exposure of credentials like bearer tokens,
+ * client IDs, client secrets, and other sensitive data.
+ */
+final class Redactor
+{
+    /**
+     * Headers that should be redacted when logging.
+     * @var array<string>
+     */
+    private const SENSITIVE_HEADERS = [
+        'authorization',
+        'www-authenticate',
+        'x-api-key',
+        'api-key',
+        'apikey',
+        'x-api-token',
+        'x-auth-token',
+        'auth-token',
+        'cookie',
+        'set-cookie',
+        'proxy-authorization',
+        'proxy-authenticate',
+        'x-csrf-token',
+        'x-xsrf-token',
+        'x-session-token',
+        'x-access-token',
+    ];
+
+    /**
+     * Query parameters that should be redacted when logging.
+     * @var array<string>
+     */
+    private const SENSITIVE_QUERY_PARAMS = [
+        'api_key',
+        'api-key',
+        'apikey',
+        'token',
+        'access_token',
+        'access-token',
+        'auth_token',
+        'auth-token',
+        'password',
+        'passwd',
+        'secret',
+        'api_secret',
+        'api-secret',
+        'apisecret',
+        'key',
+        'session',
+        'session_id',
+        'session-id',
+    ];
+
+    /**
+     * Body/JSON keys that should be redacted when logging.
+     * @var array<string>
+     */
+    private const SENSITIVE_BODY_KEYS = [
+        'access_token',
+        'accessToken',
+        'refresh_token',
+        'refreshToken',
+        'id_token',
+        'idToken',
+        'token',
+        'client_secret',
+        'clientSecret',
+        'password',
+        'api_key',
+        'apiKey',
+        'secret',
+    ];
+
+    private const REDACTED = '[REDACTED]';
+
+    /**
+     * Redacts sensitive values from an array of headers.
+     *
+     * @param array<string, string> $headers
+     * @return array<string, string>
+     */
+    public static function redactHeaders(array $headers): array
+    {
+        $redacted = [];
+        foreach ($headers as $key => $value) {
+            if (in_array(strtolower($key), self::SENSITIVE_HEADERS, true)) {
+                $redacted[$key] = self::REDACTED;
+            } else {
+                $redacted[$key] = $value;
+            }
+        }
+        return $redacted;
+    }
+
+    /**
+     * Redacts sensitive values from query parameters.
+     *
+     * @param array<int|string, mixed>|null $params
+     * @return array<int|string, mixed>|null
+     */
+    public static function redactQueryParams(?array $params): ?array
+    {
+        if ($params === null) {
+            return null;
+        }
+        $redacted = [];
+        foreach ($params as $key => $value) {
+            $keyStr = is_string($key) ? $key : (string) $key;
+            if (in_array(strtolower($keyStr), self::SENSITIVE_QUERY_PARAMS, true)) {
+                $redacted[$key] = self::REDACTED;
+            } else {
+                $redacted[$key] = $value;
+            }
+        }
+        return $redacted;
+    }
+
+    /**
+     * Redacts credentials from a URL (userinfo and sensitive query params).
+     *
+     * @param string $url
+     * @return string
+     */
+    public static function redactUrl(string $url): string
+    {
+        $parsed = parse_url($url);
+        if ($parsed === false) {
+            return $url;
+        }
+
+        // Redact userinfo (user:pass@host)
+        if (isset($parsed['user']) || isset($parsed['pass'])) {
+            $parsed['user'] = self::REDACTED;
+            unset($parsed['pass']);
+        }
+
+        // Redact sensitive query parameters
+        if (isset($parsed['query'])) {
+            parse_str($parsed['query'], $queryParams);
+            $redactedParams = self::redactQueryParams($queryParams);
+            $parsed['query'] = http_build_query($redactedParams ?? []);
+        }
+
+        return self::buildUrl($parsed);
+    }
+
+    /**
+     * Redacts sensitive keys from a mixed body (array, object, or JSON string).
+     *
+     * @param mixed $body
+     * @return mixed
+     */
+    public static function redactBody(mixed $body): mixed
+    {
+        if ($body === null) {
+            return null;
+        }
+
+        // If it's a string, try to decode as JSON
+        if (is_string($body)) {
+            $decoded = json_decode($body, true);
+            if (json_last_error() === JSON_ERROR_NONE && is_array($decoded)) {
+                $redacted = self::redactArray($decoded);
+                return json_encode($redacted) ?: '';
+            }
+            return $body;
+        }
+
+        // If it's an array, redact recursively
+        if (is_array($body)) {
+            return self::redactArray($body);
+        }
+
+        // If it's an object, convert to array, redact, and return as object
+        if (is_object($body)) {
+            $array = (array) $body;
+            return (object) self::redactArray($array);
+        }
+
+        return $body;
+    }
+
+    /**
+     * Recursively redacts sensitive keys from an array.
+     *
+     * @param array<string, mixed> $data
+     * @return array<string, mixed>
+     */
+    private static function redactArray(array $data): array
+    {
+        $redacted = [];
+        foreach ($data as $key => $value) {
+            if (is_string($key) && in_array(strtolower($key), array_map('strtolower', self::SENSITIVE_BODY_KEYS), true)) {
+                $redacted[$key] = self::REDACTED;
+            } elseif (is_array($value)) {
+                $redacted[$key] = self::redactArray($value);
+            } elseif (is_object($value)) {
+                $redacted[$key] = (object) self::redactArray((array) $value);
+            } else {
+                $redacted[$key] = $value;
+            }
+        }
+        return $redacted;
+    }
+
+    /**
+     * Builds a URL from parsed components.
+     *
+     * @param array<string, mixed> $parts
+     * @return string
+     */
+    private static function buildUrl(array $parts): string
+    {
+        $url = '';
+        if (isset($parts['scheme'])) {
+            $url .= $parts['scheme'] . '://';
+        }
+        if (isset($parts['user'])) {
+            $url .= $parts['user'];
+            if (isset($parts['pass'])) {
+                $url .= ':' . $parts['pass'];
+            }
+            $url .= '@';
+        }
+        if (isset($parts['host'])) {
+            $url .= $parts['host'];
+        }
+        if (isset($parts['port'])) {
+            $url .= ':' . $parts['port'];
+        }
+        if (isset($parts['path'])) {
+            $url .= $parts['path'];
+        }
+        if (isset($parts['query']) && $parts['query'] !== '') {
+            $url .= '?' . $parts['query'];
+        }
+        if (isset($parts['fragment'])) {
+            $url .= '#' . $parts['fragment'];
+        }
+        return $url;
+    }
+}

--- a/seed/php-sdk/bearer-token-environment-variable/src/Exceptions/SeedApiException.php
+++ b/seed/php-sdk/bearer-token-environment-variable/src/Exceptions/SeedApiException.php
@@ -3,6 +3,7 @@
 namespace Seed\Exceptions;
 
 use Throwable;
+use Seed\Core\Client\Redactor;
 
 /**
  * This exception type will be thrown for any non-2XX API responses.
@@ -48,6 +49,10 @@ class SeedApiException extends SeedException
         if (empty($this->body)) {
             return "$this->message; Status Code: $this->code\n";
         }
-        return "$this->message; Status Code: $this->code; Body: " . $this->body . "\n";
+        $redactedBody = Redactor::redactBody($this->body);
+        if (!is_string($redactedBody)) {
+            $redactedBody = json_encode($redactedBody) ?: '';
+        }
+        return "$this->message; Status Code: $this->code; Body: " . $redactedBody . "\n";
     }
 }

--- a/seed/php-sdk/oauth-client-credentials/README.md
+++ b/seed/php-sdk/oauth-client-credentials/README.md
@@ -39,7 +39,10 @@ namespace Example;
 use Seed\SeedClient;
 use Seed\Auth\Requests\GetTokenRequest;
 
-$client = new SeedClient();
+$client = new SeedClient(
+    clientId: '<clientId>',
+    clientSecret: '<clientSecret>',
+);
 $client->auth->getTokenWithClientCredentials(
     new GetTokenRequest([
         'clientId' => 'my_oauth_app_123',

--- a/seed/php-sdk/oauth-client-credentials/reference.md
+++ b/seed/php-sdk/oauth-client-credentials/reference.md
@@ -1,0 +1,248 @@
+# Reference
+## Auth
+<details><summary><code>$client->auth->getTokenWithClientCredentials($request) -> TokenResponse</code></summary>
+<dl>
+<dd>
+
+#### 🔌 Usage
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+```php
+$client->auth->getTokenWithClientCredentials(
+    new GetTokenRequest([
+        'clientId' => 'my_oauth_app_123',
+        'clientSecret' => 'sk_live_abcdef123456789',
+        'audience' => 'https://api.example.com',
+        'grantType' => 'client_credentials',
+        'scope' => 'read:users',
+    ]),
+);
+```
+</dd>
+</dl>
+</dd>
+</dl>
+
+#### ⚙️ Parameters
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+**$clientId:** `string` 
+    
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**$clientSecret:** `string` 
+    
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**$audience:** `string` 
+    
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**$grantType:** `string` 
+    
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**$scope:** `?string` 
+    
+</dd>
+</dl>
+</dd>
+</dl>
+
+
+</dd>
+</dl>
+</details>
+
+<details><summary><code>$client->auth->refreshToken($request) -> TokenResponse</code></summary>
+<dl>
+<dd>
+
+#### 🔌 Usage
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+```php
+$client->auth->refreshToken(
+    new RefreshTokenRequest([
+        'clientId' => 'my_oauth_app_123',
+        'clientSecret' => 'sk_live_abcdef123456789',
+        'refreshToken' => 'refresh_token',
+        'audience' => 'https://api.example.com',
+        'grantType' => 'refresh_token',
+        'scope' => 'read:users',
+    ]),
+);
+```
+</dd>
+</dl>
+</dd>
+</dl>
+
+#### ⚙️ Parameters
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+**$clientId:** `string` 
+    
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**$clientSecret:** `string` 
+    
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**$refreshToken:** `string` 
+    
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**$audience:** `string` 
+    
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**$grantType:** `string` 
+    
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**$scope:** `?string` 
+    
+</dd>
+</dl>
+</dd>
+</dl>
+
+
+</dd>
+</dl>
+</details>
+
+## NestedNoAuth Api
+<details><summary><code>$client->nestedNoAuth->api->getSomething()</code></summary>
+<dl>
+<dd>
+
+#### 🔌 Usage
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+```php
+$client->nestedNoAuth->api->getSomething();
+```
+</dd>
+</dl>
+</dd>
+</dl>
+
+
+</dd>
+</dl>
+</details>
+
+## Nested Api
+<details><summary><code>$client->nested->api->getSomething()</code></summary>
+<dl>
+<dd>
+
+#### 🔌 Usage
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+```php
+$client->nested->api->getSomething();
+```
+</dd>
+</dl>
+</dd>
+</dl>
+
+
+</dd>
+</dl>
+</details>
+
+## Simple
+<details><summary><code>$client->simple->getSomething()</code></summary>
+<dl>
+<dd>
+
+#### 🔌 Usage
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+```php
+$client->simple->getSomething();
+```
+</dd>
+</dl>
+</dd>
+</dl>
+
+
+</dd>
+</dl>
+</details>

--- a/seed/php-sdk/oauth-client-credentials/src/Core/Client/Redactor.php
+++ b/seed/php-sdk/oauth-client-credentials/src/Core/Client/Redactor.php
@@ -1,0 +1,248 @@
+<?php
+
+namespace Seed\Core\Client;
+
+/**
+ * Utility class for redacting sensitive information from logs and error messages.
+ * This helps prevent accidental exposure of credentials like bearer tokens,
+ * client IDs, client secrets, and other sensitive data.
+ */
+final class Redactor
+{
+    /**
+     * Headers that should be redacted when logging.
+     * @var array<string>
+     */
+    private const SENSITIVE_HEADERS = [
+        'authorization',
+        'www-authenticate',
+        'x-api-key',
+        'api-key',
+        'apikey',
+        'x-api-token',
+        'x-auth-token',
+        'auth-token',
+        'cookie',
+        'set-cookie',
+        'proxy-authorization',
+        'proxy-authenticate',
+        'x-csrf-token',
+        'x-xsrf-token',
+        'x-session-token',
+        'x-access-token',
+    ];
+
+    /**
+     * Query parameters that should be redacted when logging.
+     * @var array<string>
+     */
+    private const SENSITIVE_QUERY_PARAMS = [
+        'api_key',
+        'api-key',
+        'apikey',
+        'token',
+        'access_token',
+        'access-token',
+        'auth_token',
+        'auth-token',
+        'password',
+        'passwd',
+        'secret',
+        'api_secret',
+        'api-secret',
+        'apisecret',
+        'key',
+        'session',
+        'session_id',
+        'session-id',
+    ];
+
+    /**
+     * Body/JSON keys that should be redacted when logging.
+     * @var array<string>
+     */
+    private const SENSITIVE_BODY_KEYS = [
+        'access_token',
+        'accessToken',
+        'refresh_token',
+        'refreshToken',
+        'id_token',
+        'idToken',
+        'token',
+        'client_secret',
+        'clientSecret',
+        'password',
+        'api_key',
+        'apiKey',
+        'secret',
+    ];
+
+    private const REDACTED = '[REDACTED]';
+
+    /**
+     * Redacts sensitive values from an array of headers.
+     *
+     * @param array<string, string> $headers
+     * @return array<string, string>
+     */
+    public static function redactHeaders(array $headers): array
+    {
+        $redacted = [];
+        foreach ($headers as $key => $value) {
+            if (in_array(strtolower($key), self::SENSITIVE_HEADERS, true)) {
+                $redacted[$key] = self::REDACTED;
+            } else {
+                $redacted[$key] = $value;
+            }
+        }
+        return $redacted;
+    }
+
+    /**
+     * Redacts sensitive values from query parameters.
+     *
+     * @param array<int|string, mixed>|null $params
+     * @return array<int|string, mixed>|null
+     */
+    public static function redactQueryParams(?array $params): ?array
+    {
+        if ($params === null) {
+            return null;
+        }
+        $redacted = [];
+        foreach ($params as $key => $value) {
+            $keyStr = is_string($key) ? $key : (string) $key;
+            if (in_array(strtolower($keyStr), self::SENSITIVE_QUERY_PARAMS, true)) {
+                $redacted[$key] = self::REDACTED;
+            } else {
+                $redacted[$key] = $value;
+            }
+        }
+        return $redacted;
+    }
+
+    /**
+     * Redacts credentials from a URL (userinfo and sensitive query params).
+     *
+     * @param string $url
+     * @return string
+     */
+    public static function redactUrl(string $url): string
+    {
+        $parsed = parse_url($url);
+        if ($parsed === false) {
+            return $url;
+        }
+
+        // Redact userinfo (user:pass@host)
+        if (isset($parsed['user']) || isset($parsed['pass'])) {
+            $parsed['user'] = self::REDACTED;
+            unset($parsed['pass']);
+        }
+
+        // Redact sensitive query parameters
+        if (isset($parsed['query'])) {
+            parse_str($parsed['query'], $queryParams);
+            $redactedParams = self::redactQueryParams($queryParams);
+            $parsed['query'] = http_build_query($redactedParams ?? []);
+        }
+
+        return self::buildUrl($parsed);
+    }
+
+    /**
+     * Redacts sensitive keys from a mixed body (array, object, or JSON string).
+     *
+     * @param mixed $body
+     * @return mixed
+     */
+    public static function redactBody(mixed $body): mixed
+    {
+        if ($body === null) {
+            return null;
+        }
+
+        // If it's a string, try to decode as JSON
+        if (is_string($body)) {
+            $decoded = json_decode($body, true);
+            if (json_last_error() === JSON_ERROR_NONE && is_array($decoded)) {
+                $redacted = self::redactArray($decoded);
+                return json_encode($redacted) ?: '';
+            }
+            return $body;
+        }
+
+        // If it's an array, redact recursively
+        if (is_array($body)) {
+            return self::redactArray($body);
+        }
+
+        // If it's an object, convert to array, redact, and return as object
+        if (is_object($body)) {
+            $array = (array) $body;
+            return (object) self::redactArray($array);
+        }
+
+        return $body;
+    }
+
+    /**
+     * Recursively redacts sensitive keys from an array.
+     *
+     * @param array<string, mixed> $data
+     * @return array<string, mixed>
+     */
+    private static function redactArray(array $data): array
+    {
+        $redacted = [];
+        foreach ($data as $key => $value) {
+            if (is_string($key) && in_array(strtolower($key), array_map('strtolower', self::SENSITIVE_BODY_KEYS), true)) {
+                $redacted[$key] = self::REDACTED;
+            } elseif (is_array($value)) {
+                $redacted[$key] = self::redactArray($value);
+            } elseif (is_object($value)) {
+                $redacted[$key] = (object) self::redactArray((array) $value);
+            } else {
+                $redacted[$key] = $value;
+            }
+        }
+        return $redacted;
+    }
+
+    /**
+     * Builds a URL from parsed components.
+     *
+     * @param array<string, mixed> $parts
+     * @return string
+     */
+    private static function buildUrl(array $parts): string
+    {
+        $url = '';
+        if (isset($parts['scheme'])) {
+            $url .= $parts['scheme'] . '://';
+        }
+        if (isset($parts['user'])) {
+            $url .= $parts['user'];
+            if (isset($parts['pass'])) {
+                $url .= ':' . $parts['pass'];
+            }
+            $url .= '@';
+        }
+        if (isset($parts['host'])) {
+            $url .= $parts['host'];
+        }
+        if (isset($parts['port'])) {
+            $url .= ':' . $parts['port'];
+        }
+        if (isset($parts['path'])) {
+            $url .= $parts['path'];
+        }
+        if (isset($parts['query']) && $parts['query'] !== '') {
+            $url .= '?' . $parts['query'];
+        }
+        if (isset($parts['fragment'])) {
+            $url .= '#' . $parts['fragment'];
+        }
+        return $url;
+    }
+}

--- a/seed/php-sdk/oauth-client-credentials/src/Core/OAuthTokenProvider.php
+++ b/seed/php-sdk/oauth-client-credentials/src/Core/OAuthTokenProvider.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Seed\Core;
+
+use Seed\Auth\AuthClient;
+use DateTime;
+use Seed\Auth\Requests\GetTokenRequest;
+
+/**
+ * The OAuthTokenProvider retrieves an OAuth access token, refreshing it as needed.
+ * The access token is then used as the bearer token in every authenticated request.
+ */
+class OAuthTokenProvider
+{
+    /**
+     * @var int $BUFFER_IN_MINUTES
+     */
+    private int $BUFFER_IN_MINUTES = 2;
+
+    /**
+     * @var string $clientId
+     */
+    private string $clientId;
+
+    /**
+     * @var string $clientSecret
+     */
+    private string $clientSecret;
+
+    /**
+     * @var AuthClient $authClient
+     */
+    private AuthClient $authClient;
+
+    /**
+     * @var ?string $accessToken
+     */
+    private ?string $accessToken;
+
+    /**
+     * @var ?DateTime $expiresAt
+     */
+    private ?DateTime $expiresAt;
+
+    /**
+     * @param string $clientId The client ID for OAuth authentication.
+     * @param string $clientSecret The client secret for OAuth authentication.
+     * @param AuthClient $authClient The client used to retrieve the OAuth token.
+     */
+    public function __construct(
+        string $clientId,
+        string $clientSecret,
+        AuthClient $authClient,
+    ) {
+        $this->clientId = $clientId;
+        $this->clientSecret = $clientSecret;
+        $this->authClient = $authClient;
+        $this->accessToken = null;
+        $this->expiresAt = null;
+    }
+
+    /**
+     * Returns a cached access token, refreshing if necessary.
+     *
+     * @return string
+     */
+    public function getToken(): string
+    {
+        if ($this->accessToken !== null && ($this->expiresAt === null || $this->expiresAt > new DateTime())) {
+            return $this->accessToken;
+        }
+        return $this->refresh();
+    }
+
+    /**
+     * Returns debug information with sensitive credentials redacted.
+     *
+     * @return array<mixed>
+     */
+    public function __debugInfo(): array
+    {
+        return [
+            'clientId' => '[REDACTED]',
+            'clientSecret' => '[REDACTED]',
+            'hasAccessToken' => $this->accessToken !== null,
+            'expiresAt' => $this->expiresAt,
+        ];
+    }
+
+    /**
+     * Refreshes the access token by calling the token endpoint.
+     *
+     * @return string
+     */
+    private function refresh(): string
+    {
+        $request = new GetTokenRequest([
+            'clientId' => $this->clientId,
+            'clientSecret' => $this->clientSecret,
+            'audience' => 'https://api.example.com',
+            'grantType' => 'client_credentials',
+        ]);
+
+        $tokenResponse = $this->authClient->getTokenWithClientCredentials($request);
+
+        $this->accessToken = $tokenResponse->accessToken;
+        $this->expiresAt = $this->getExpiresAt($tokenResponse->expiresIn, $this->BUFFER_IN_MINUTES);
+
+        return $this->accessToken;
+    }
+
+    /**
+     * Calculates the expiration time with a buffer.
+     *
+     * @param int $expiresInSeconds The number of seconds until the token expires.
+     * @param int $bufferInMinutes The buffer time in minutes to subtract from the expiration.
+     * @return DateTime
+     */
+    private function getExpiresAt(int $expiresInSeconds, int $bufferInMinutes): DateTime
+    {
+        $now = new DateTime();
+        $expiresInSecondsWithBuffer = $expiresInSeconds - ($bufferInMinutes * 60);
+        $now->modify("+{$expiresInSecondsWithBuffer} seconds");
+        return $now;
+    }
+}

--- a/seed/php-sdk/oauth-client-credentials/src/Exceptions/SeedApiException.php
+++ b/seed/php-sdk/oauth-client-credentials/src/Exceptions/SeedApiException.php
@@ -3,6 +3,7 @@
 namespace Seed\Exceptions;
 
 use Throwable;
+use Seed\Core\Client\Redactor;
 
 /**
  * This exception type will be thrown for any non-2XX API responses.
@@ -48,6 +49,10 @@ class SeedApiException extends SeedException
         if (empty($this->body)) {
             return "$this->message; Status Code: $this->code\n";
         }
-        return "$this->message; Status Code: $this->code; Body: " . $this->body . "\n";
+        $redactedBody = Redactor::redactBody($this->body);
+        if (!is_string($redactedBody)) {
+            $redactedBody = json_encode($redactedBody) ?: '';
+        }
+        return "$this->message; Status Code: $this->code; Body: " . $redactedBody . "\n";
     }
 }

--- a/seed/php-sdk/oauth-client-credentials/src/SeedClient.php
+++ b/seed/php-sdk/oauth-client-credentials/src/SeedClient.php
@@ -8,6 +8,7 @@ use Seed\Nested\NestedClient;
 use Seed\Simple\SimpleClient;
 use GuzzleHttp\ClientInterface;
 use Seed\Core\Client\RawClient;
+use Seed\Core\OAuthTokenProvider;
 
 class SeedClient
 {
@@ -48,7 +49,8 @@ class SeedClient
     private RawClient $client;
 
     /**
-     * @param string $token The token to use for authentication.
+     * @param ?string $clientId The client ID for OAuth authentication.
+     * @param ?string $clientSecret The client secret for OAuth authentication.
      * @param ?array{
      *   baseUrl?: string,
      *   client?: ClientInterface,
@@ -58,18 +60,22 @@ class SeedClient
      * } $options
      */
     public function __construct(
-        string $token,
+        ?string $clientId = null,
+        ?string $clientSecret = null,
         ?array $options = null,
     ) {
+        $authRawClient = new RawClient(['headers' => []]);
+        $authClient = new AuthClient($authRawClient);
+        $oauthTokenProvider = new OAuthTokenProvider($clientId ?? '', $clientSecret ?? '', $authClient);
+        $token = $oauthTokenProvider->getToken();
+
         $defaultHeaders = [
             'X-Fern-Language' => 'PHP',
             'X-Fern-SDK-Name' => 'Seed',
             'X-Fern-SDK-Version' => '0.0.1',
             'User-Agent' => 'seed/seed/0.0.1',
         ];
-        if ($token != null) {
-            $defaultHeaders['Authorization'] = "Bearer $token";
-        }
+        $defaultHeaders['Authorization'] = "Bearer $token";
 
         $this->options = $options ?? [];
         $this->options['headers'] = array_merge(

--- a/seed/php-sdk/oauth-client-credentials/src/dynamic-snippets/example0/snippet.php
+++ b/seed/php-sdk/oauth-client-credentials/src/dynamic-snippets/example0/snippet.php
@@ -6,6 +6,8 @@ use Seed\SeedClient;
 use Seed\Auth\Requests\GetTokenRequest;
 
 $client = new SeedClient(
+    clientId: '<clientId>',
+    clientSecret: '<clientSecret>',
     options: [
         'baseUrl' => 'https://api.fern.com',
     ],

--- a/seed/php-sdk/oauth-client-credentials/src/dynamic-snippets/example1/snippet.php
+++ b/seed/php-sdk/oauth-client-credentials/src/dynamic-snippets/example1/snippet.php
@@ -6,6 +6,8 @@ use Seed\SeedClient;
 use Seed\Auth\Requests\GetTokenRequest;
 
 $client = new SeedClient(
+    clientId: '<clientId>',
+    clientSecret: '<clientSecret>',
     options: [
         'baseUrl' => 'https://api.fern.com',
     ],

--- a/seed/php-sdk/oauth-client-credentials/src/dynamic-snippets/example2/snippet.php
+++ b/seed/php-sdk/oauth-client-credentials/src/dynamic-snippets/example2/snippet.php
@@ -6,6 +6,8 @@ use Seed\SeedClient;
 use Seed\Auth\Requests\RefreshTokenRequest;
 
 $client = new SeedClient(
+    clientId: '<clientId>',
+    clientSecret: '<clientSecret>',
     options: [
         'baseUrl' => 'https://api.fern.com',
     ],

--- a/seed/php-sdk/oauth-client-credentials/src/dynamic-snippets/example3/snippet.php
+++ b/seed/php-sdk/oauth-client-credentials/src/dynamic-snippets/example3/snippet.php
@@ -6,6 +6,8 @@ use Seed\SeedClient;
 use Seed\Auth\Requests\RefreshTokenRequest;
 
 $client = new SeedClient(
+    clientId: '<clientId>',
+    clientSecret: '<clientSecret>',
     options: [
         'baseUrl' => 'https://api.fern.com',
     ],

--- a/seed/php-sdk/oauth-client-credentials/src/dynamic-snippets/example4/snippet.php
+++ b/seed/php-sdk/oauth-client-credentials/src/dynamic-snippets/example4/snippet.php
@@ -5,6 +5,8 @@ namespace Example;
 use Seed\SeedClient;
 
 $client = new SeedClient(
+    clientId: '<clientId>',
+    clientSecret: '<clientSecret>',
     options: [
         'baseUrl' => 'https://api.fern.com',
     ],

--- a/seed/php-sdk/oauth-client-credentials/src/dynamic-snippets/example5/snippet.php
+++ b/seed/php-sdk/oauth-client-credentials/src/dynamic-snippets/example5/snippet.php
@@ -5,6 +5,8 @@ namespace Example;
 use Seed\SeedClient;
 
 $client = new SeedClient(
+    clientId: '<clientId>',
+    clientSecret: '<clientSecret>',
     options: [
         'baseUrl' => 'https://api.fern.com',
     ],

--- a/seed/php-sdk/oauth-client-credentials/src/dynamic-snippets/example6/snippet.php
+++ b/seed/php-sdk/oauth-client-credentials/src/dynamic-snippets/example6/snippet.php
@@ -5,6 +5,8 @@ namespace Example;
 use Seed\SeedClient;
 
 $client = new SeedClient(
+    clientId: '<clientId>',
+    clientSecret: '<clientSecret>',
     options: [
         'baseUrl' => 'https://api.fern.com',
     ],


### PR DESCRIPTION
## Description

Refs: Slack thread discussion about PHP SDK credential redaction

This PR adds credential redaction functionality to the PHP SDK generator to prevent accidental exposure of bearer tokens, client IDs, client secrets, and other sensitive data in logs and error messages.

**Link to Devin run:** https://app.devin.ai/sessions/b595205e120e472b9bbe659ed2b83cbe
**Requested by:** Deep Singhvi (@dsinghvi)

## Changes Made

- Added new `Redactor` utility class (`Redactor.Template.php`) with static methods for redacting:
  - Headers (authorization, api-key, cookies, session tokens, etc.)
  - Query parameters (api_key, token, password, secret, etc.)
  - URLs (userinfo credentials and sensitive query params)
  - JSON bodies (access_token, refresh_token, client_secret, password, etc.)
- Modified `BaseApiExceptionGenerator` to use `Redactor::redactBody()` in `__toString()` method, preventing credential leaks in exception messages
- Added `__debugInfo()` method to `OAuthTokenProvider` to prevent credential exposure via `var_dump()`
- Registered Redactor in `AsIsFiles` enum and `getCoreAsIsFiles()` so it's included in all generated SDKs
- [ ] Updated README.md generator (not applicable)

## Testing

- [x] Seed tests run for `bearer-token-environment-variable` fixture (passes)
- [x] Seed tests run for `oauth-client-credentials` fixture (passes)
- [x] PHPStan type checking passes
- [x] Biome lint checks pass
- [ ] Unit tests added/updated (redaction tested indirectly through seed tests)

## Human Review Checklist

- [ ] Verify the sensitive field lists in `Redactor` class are comprehensive
- [ ] Review the `oauth-client-credentials` fixture changes - the `SeedClient` now internally creates an `OAuthTokenProvider`, which changes the client initialization pattern
- [ ] Confirm PHPStan type annotations are correct (especially `array<int|string, mixed>` for query params)