### PR TITLE
chore(php): upgrade PHP SDK to use IR version 62.1.0

### DIFF
--- a/generators/php/base/package.json
+++ b/generators/php/base/package.json
@@ -43,7 +43,7 @@
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/logging-execa": "workspace:*",
     "@fern-api/php-codegen": "workspace:*",
-    "@fern-fern/ir-sdk": "^61.7.0",
+    "@fern-fern/ir-sdk": "^62.1.0",
     "@types/lodash-es": "^4.17.12",
     "@types/node": "18.15.3",
     "depcheck": "^1.4.7",

--- a/generators/php/dynamic-snippets/package.json
+++ b/generators/php/dynamic-snippets/package.json
@@ -37,7 +37,7 @@
     "@fern-api/browser-compatible-base-generator": "workspace:*",
     "@fern-api/configs": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
-    "@fern-api/dynamic-ir-sdk": "^61.7.0",
+    "@fern-api/dynamic-ir-sdk": "^62.1.0",
     "@fern-api/path-utils": "workspace:*",
     "@fern-api/php-codegen": "workspace:*",
     "@types/lodash-es": "^4.17.12",

--- a/generators/php/model/package.json
+++ b/generators/php/model/package.json
@@ -44,7 +44,7 @@
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/php-base": "workspace:*",
     "@fern-api/php-codegen": "workspace:*",
-    "@fern-fern/ir-sdk": "^61.7.0",
+    "@fern-fern/ir-sdk": "^62.1.0",
     "@types/node": "18.15.3",
     "depcheck": "^1.4.7",
     "tsup": "^8.5.0",

--- a/generators/php/model/versions.yml
+++ b/generators/php/model/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.0.2
+  changelogEntry:
+    - summary: |
+        Upgrade to IR version 62.
+      type: chore
+  createdAt: "2025-11-25"
+  irVersion: 62
+
 - version: 0.0.1
   changelogEntry:
     - summary: |

--- a/generators/php/sdk/package.json
+++ b/generators/php/sdk/package.json
@@ -50,7 +50,7 @@
     "@fern-api/php-model": "workspace:*",
     "@fern-fern/generator-cli-sdk": "^0.1.5",
     "@fern-fern/generator-exec-sdk": "^0.0.1167",
-    "@fern-fern/ir-sdk": "^61.7.0",
+    "@fern-fern/ir-sdk": "^62.1.0",
     "@types/lodash-es": "^4.17.12",
     "@types/node": "18.15.3",
     "depcheck": "^1.4.7",

--- a/generators/php/sdk/versions.yml
+++ b/generators/php/sdk/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.22.0
+  changelogEntry:
+    - summary: |
+        Upgrade to IR version 62.
+      type: chore
+  createdAt: "2025-11-25"
+  irVersion: 62
+
 - version: 1.21.0
   changelogEntry:
     - summary: |

--- a/packages/cli/generation/ir-migrations/src/migrations/v62-to-v61/migrateFromV62ToV61.ts
+++ b/packages/cli/generation/ir-migrations/src/migrations/v62-to-v61/migrateFromV62ToV61.ts
@@ -37,8 +37,8 @@ export const V62_TO_V61_MIGRATION: IrMigration<
         [GeneratorName.CSHARP_SDK]: GeneratorWasNeverUpdatedToConsumeNewIR,
         [GeneratorName.SWIFT_MODEL]: GeneratorWasNeverUpdatedToConsumeNewIR,
         [GeneratorName.SWIFT_SDK]: GeneratorWasNeverUpdatedToConsumeNewIR,
-        [GeneratorName.PHP_MODEL]: GeneratorWasNeverUpdatedToConsumeNewIR,
-        [GeneratorName.PHP_SDK]: GeneratorWasNeverUpdatedToConsumeNewIR,
+        [GeneratorName.PHP_MODEL]: "0.0.2",
+        [GeneratorName.PHP_SDK]: "1.22.0",
         [GeneratorName.RUST_MODEL]: GeneratorWasNeverUpdatedToConsumeNewIR,
         [GeneratorName.RUST_SDK]: GeneratorWasNeverUpdatedToConsumeNewIR
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -924,8 +924,8 @@ importers:
         specifier: workspace:*
         version: link:../codegen
       '@fern-fern/ir-sdk':
-        specifier: ^61.7.0
-        version: 61.7.0
+        specifier: ^62.1.0
+        version: 62.1.0
       '@types/lodash-es':
         specifier: ^4.17.12
         version: 4.17.12
@@ -1000,8 +1000,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/commons/core-utils
       '@fern-api/dynamic-ir-sdk':
-        specifier: ^61.7.0
-        version: 61.7.0
+        specifier: ^62.1.0
+        version: 62.1.0
       '@fern-api/path-utils':
         specifier: workspace:*
         version: link:../../../packages/commons/path-utils
@@ -1048,8 +1048,8 @@ importers:
         specifier: workspace:*
         version: link:../codegen
       '@fern-fern/ir-sdk':
-        specifier: ^61.7.0
-        version: 61.7.0
+        specifier: ^62.1.0
+        version: 62.1.0
       '@types/node':
         specifier: 18.15.3
         version: 18.15.3
@@ -1105,8 +1105,8 @@ importers:
         specifier: ^0.0.1167
         version: 0.0.1167
       '@fern-fern/ir-sdk':
-        specifier: ^61.7.0
-        version: 61.7.0
+        specifier: ^62.1.0
+        version: 62.1.0
       '@types/lodash-es':
         specifier: ^4.17.12
         version: 4.17.12
@@ -9605,6 +9605,9 @@ packages:
   '@fern-api/dynamic-ir-sdk@61.7.0':
     resolution: {integrity: sha512-3BcgNnTgr3qucG2AYr1hCOjVMjM5VLZZIkSTgOlVjwASTvH5eqxApfYasUNLAAA9xXU7anfCqtnd7IOE2G2jTw==}
 
+  '@fern-api/dynamic-ir-sdk@62.1.0':
+    resolution: {integrity: sha512-3GrWtmxRpgStXUyejFxa+yA5kIm5NS5FsxmKT3sLQN52OKGd9phskyPk8GiiPmIeKdeGIHT8HIwKz003ksxZSg==}
+
   '@fern-api/fai-sdk@0.0.6-2ee1b7e28':
     resolution: {integrity: sha512-3qhAAuc4ZJWLaFtyZzaYXfF9OQ5iviNrvLDXtjKScKUNS134fR3v3c3xedCidTq5KedapuBECziUaOmmd6KXVA==}
     engines: {node: '>=18.0.0'}
@@ -9661,6 +9664,9 @@ packages:
 
   '@fern-fern/ir-sdk@61.7.0':
     resolution: {integrity: sha512-LHz8xJRISnuMVzLZHjwh1ziEofE0smL08Ddoe/YHnod8p7DPS/mpOcQKEfzqUn2mdLB6iqUBKB74NMchP/nM+Q==}
+
+  '@fern-fern/ir-sdk@62.1.0':
+    resolution: {integrity: sha512-0FVJFtG1TvxAvPe6NlxOUSOYgs4dVTbYB1Faj/Fj+/ounMyucifW3QVy/DJeYjgdyn3DUzochSwIMvPrf1atqQ==}
 
   '@fern-fern/ir-v1-model@0.0.2':
     resolution: {integrity: sha512-Rho6qXYfRoB1sAISFS4V7vttVFN0ypoaztmbfKKNFmSTNVOyLN++e2xNZ+Aw9ckE5ZZmfMXK9v4+dnFReWVzvA==}
@@ -17326,6 +17332,8 @@ snapshots:
 
   '@fern-api/dynamic-ir-sdk@61.7.0': {}
 
+  '@fern-api/dynamic-ir-sdk@62.1.0': {}
+
   '@fern-api/fai-sdk@0.0.6-2ee1b7e28': {}
 
   '@fern-api/fdr-sdk@0.142.0-aae6ba0ae(typescript@5.9.3)':
@@ -17452,6 +17460,16 @@ snapshots:
       - encoding
 
   '@fern-fern/ir-sdk@61.7.0':
+    dependencies:
+      form-data: 4.0.4
+      formdata-node: 6.0.3
+      node-fetch: 2.7.0
+      qs: 6.13.0
+      readable-stream: 4.7.0
+    transitivePeerDependencies:
+      - encoding
+
+  '@fern-fern/ir-sdk@62.1.0':
     dependencies:
       form-data: 4.0.4
       formdata-node: 6.0.3

--- a/seed/php-model/seed.yml
+++ b/seed/php-model/seed.yml
@@ -1,4 +1,4 @@
-irVersion: v61
+irVersion: v62
 displayName: PHP Model
 image: fernapi/fern-php-model
 changelogLocation: ../../generators/php/model/versions.yml

--- a/seed/php-sdk/seed.yml
+++ b/seed/php-sdk/seed.yml
@@ -1,4 +1,4 @@
-irVersion: v61
+irVersion: v62
 displayName: PHP SDK
 image: fernapi/fern-php-sdk
 changelogLocation: ../../generators/php/sdk/versions.yml


### PR DESCRIPTION
## Description

This PR upgrades the PHP SDK generators to consume IR version 62.1.0 by updating the ir-sdk dependency versions, configuring the reverse migration mapping, and adding version changelog entries.

**Link to Devin run:** https://app.devin.ai/sessions/cbc9c9e1b2944784aa8ec37baa43a451  
**Requested by:** Deep Singhvi (@dsinghvi)

## Changes Made

- Updated `@fern-fern/ir-sdk` from `^61.7.0` to `^62.1.0` in PHP generator package.json files:
  - `generators/php/base/package.json`
  - `generators/php/model/package.json`
  - `generators/php/sdk/package.json`
- Updated `@fern-api/dynamic-ir-sdk` from `^61.7.0` to `^62.1.0` in `generators/php/dynamic-snippets/package.json`
- Updated the v62-to-v61 reverse migration to specify:
  - `PHP_MODEL`: version `0.0.2` will be the first to consume IR v62
  - `PHP_SDK`: version `1.22.0` will be the first to consume IR v62
- Added version changelog entries to document the IR upgrade:
  - `generators/php/sdk/versions.yml`: Added version 1.22.0 with irVersion 62
  - `generators/php/model/versions.yml`: Added version 0.0.2 with irVersion 62
- Updated `pnpm-lock.yaml` with new dependency versions

## Testing

- [x] Compilation successful for all PHP generator packages
- [x] Compilation successful for IR migrations package
- [x] Lint checks passed (`pnpm run check`)
- [x] All CI checks passed, including PHP SDK and PHP Model seed tests

## Review Checklist

**Important items to verify:**

1. **Version numbers consistency**: Confirm that the version numbers in the migration file (`0.0.2` for PHP_MODEL and `1.22.0` for PHP_SDK) match the versions added to the versions.yml files. ✓ Verified - they match.

2. **IR v62 compatibility**: Verify that IR v62 doesn't introduce breaking changes that would affect PHP generators. The existing v62-to-v61 migration logic handles error declarations and HTTP services - confirm this is sufficient for PHP.

3. **Dependency coverage**: Verify that all PHP generator packages that depend on ir-sdk have been updated (base, model, sdk, dynamic-snippets). ✓ All four packages updated.

4. **Migration mapping**: The reverse migration now maps PHP generators to specific versions instead of `GeneratorWasNeverUpdatedToConsumeNewIR`. This means future PHP generator versions >= 0.0.2 (model) and >= 1.22.0 (sdk) will receive IR v62, while older versions will receive IR v61.