### PR TITLE
fix(php): add phpstan-ignore-line for enum string return types

### DIFF
--- a/.github/workflow-resource-files/seed-groups/php-sdk-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/php-sdk-seed-groups.json
@@ -153,7 +153,11 @@
         "no-environment",
         "streaming",
         "folders",
-        "exhaustive"
+        "exhaustive:no-custom-config",
+        "exhaustive:wire-tests",
+        "no-retries",
+        "nullable-request-body",
+        "unions-with-local-date"
       ],
       "groupTotalTimeSeconds": 813
     }

--- a/generators/php/sdk/src/endpoint/http/HttpEndpointGenerator.ts
+++ b/generators/php/sdk/src/endpoint/http/HttpEndpointGenerator.ts
@@ -717,9 +717,8 @@ export class HttpEndpointGenerator extends AbstractEndpointGenerator {
                     methodSuffix: upperFirst(internalType.type)
                 });
             case "enumString":
-                return this.decodeJsonResponseForPrimitive({
-                    arguments_,
-                    methodSuffix: "String"
+                return this.decodeJsonResponseForEnumString({
+                    arguments_
                 });
             case "union":
                 return this.decodeJsonResponseForUnion({
@@ -796,6 +795,20 @@ export class HttpEndpointGenerator extends AbstractEndpointGenerator {
                     static_: true
                 })
             );
+        });
+    }
+
+    private decodeJsonResponseForEnumString({ arguments_ }: { arguments_: Arguments }): php.CodeBlock {
+        return php.codeblock((writer) => {
+            writer.writeNode(
+                php.invokeMethod({
+                    on: this.context.getJsonDecoderClassReference(),
+                    method: "decodeString",
+                    arguments_,
+                    static_: true
+                })
+            );
+            writer.writeLine("; // @phpstan-ignore-line");
         });
     }
 

--- a/generators/php/sdk/versions.yml
+++ b/generators/php/sdk/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.22.1
+  changelogEntry:
+    - summary: |
+        Fix PHPStan error for enum string return types by adding @phpstan-ignore-line suppression.
+      type: fix
+  createdAt: "2025-11-25"
+  irVersion: 62
+
 - version: 1.22.0
   changelogEntry:
     - summary: |

--- a/seed/php-sdk/exhaustive/no-custom-config/src/Endpoints/Enum/EnumClient.php
+++ b/seed/php-sdk/exhaustive/no-custom-config/src/Endpoints/Enum/EnumClient.php
@@ -80,7 +80,7 @@ class EnumClient
             $statusCode = $response->getStatusCode();
             if ($statusCode >= 200 && $statusCode < 400) {
                 $json = $response->getBody()->getContents();
-                return JsonDecoder::decodeString($json);
+                return JsonDecoder::decodeString($json); // @phpstan-ignore-line
             }
         } catch (JsonException $e) {
             throw new SeedException(message: "Failed to deserialize response: {$e->getMessage()}", previous: $e);

--- a/seed/php-sdk/exhaustive/wire-tests/src/Endpoints/Enum/EnumClient.php
+++ b/seed/php-sdk/exhaustive/wire-tests/src/Endpoints/Enum/EnumClient.php
@@ -80,7 +80,7 @@ class EnumClient
             $statusCode = $response->getStatusCode();
             if ($statusCode >= 200 && $statusCode < 400) {
                 $json = $response->getBody()->getContents();
-                return JsonDecoder::decodeString($json);
+                return JsonDecoder::decodeString($json); // @phpstan-ignore-line
             }
         } catch (JsonException $e) {
             throw new SeedException(message: "Failed to deserialize response: {$e->getMessage()}", previous: $e);


### PR DESCRIPTION
## Description

Refs: https://buildwithfern.slack.com/archives/C09NRQZ4A2X/p1764111808216409

Fixes PHPStan compile error where `getAndReturnEnum()` method returns `string` but the PHPDoc declares `value-of<WeatherReport>` (e.g., `'CLOUDY'|'RAINING'|'SNOWING'|'SUNNY'`).

## Changes Made

- Added new `decodeJsonResponseForEnumString` method that appends `// @phpstan-ignore-line` to suppress the type mismatch warning
- This follows the same pattern used for `decodeJsonResponseForArray` and `decodeJsonResponseForUnion` which also use `@phpstan-ignore-line` for similar type narrowing issues
- Updated seed files for exhaustive fixture with the fix applied
- Updated `php-sdk-seed-groups.json` to fix CI (replaced `exhaustive` with `exhaustive:no-custom-config` and `exhaustive:wire-tests`, added missing fixtures)
- Bumped PHP SDK version to 1.22.1

## Testing

- [ ] Unit tests added/updated
- [x] Lint checks pass locally (`pnpm run check`)
- [x] Seed tests pass locally for php-sdk exhaustive fixture

## Human Review Checklist

- [ ] Verify the `@phpstan-ignore-line` suppression approach is acceptable (consistent with existing patterns in `decodeJsonResponseForArray` and `decodeJsonResponseForUnion`)
- [ ] Confirm CI seed tests pass for PHP SDK generation
- [ ] Verify version bump to 1.22.1 is correct

---

Link to Devin run: https://app.devin.ai/sessions/f8bb43f62c274e3c8cfe1d677fb6d0b4
Requested by: Deep Singhvi (@dsinghvi)