### PR TITLE
fix(ci): use 'all' fixture for PHP SDK tests on merges to main

### DIFF
--- a/.github/workflows/sdk-ete-tests.yml
+++ b/.github/workflows/sdk-ete-tests.yml
@@ -135,6 +135,11 @@ on:
       - main
     paths:
       - 'generators/php/**'
+  push:
+    branches:
+      - main
+    paths:
+      - 'generators/php/**'
 
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -198,7 +203,12 @@ jobs:
         run: |
           cli_path="$(pwd)/packages/cli/cli/dist/dev/cli.cjs"
           cd test-definitions
-          test_definition="${{ inputs.test-definition || 'exhaustive' }}"
+          # Use 'all' for push events (merges to main), 'exhaustive' for PRs, or the input value for workflow_dispatch
+          if [ "${{ github.event_name }}" = "push" ]; then
+            test_definition="all"
+          else
+            test_definition="${{ inputs.test-definition || 'exhaustive' }}"
+          fi
           
           if [ "$test_definition" = "all" ]; then
             echo "Running fern generate for all test definitions with php-sdk group..."


### PR DESCRIPTION
## Description

Refs: Slack request from @dsinghvi

Updates the SDK ETE tests workflow to run all PHP SDK test fixtures when code is merged to main, while keeping the `exhaustive` fixture for PR checks.

## Changes Made

- Added `push` trigger for the main branch (with same path filter for `generators/php/**`)
- Modified test_definition logic to use `all` for push events (merges to main) and `exhaustive` for pull_request events

## Human Review Checklist

- [ ] Verify the conditional logic correctly distinguishes between PR and push events
- [ ] Confirm running all fixtures on every merge to main is acceptable (more resource usage)

## Testing

- [ ] Manual testing not possible - workflow changes can only be verified after merge or via workflow_dispatch

---

Link to Devin run: https://app.devin.ai/sessions/fe760f9b571342b4beb70057c6b77407
Requested by: Deep Singhvi (deep@buildwithfern.com) / @dsinghvi