### PR TITLE
fix(php): pass branch through to readme generation

### DIFF
--- a/generators/php/sdk/src/PhpGeneratorAgent.ts
+++ b/generators/php/sdk/src/PhpGeneratorAgent.ts
@@ -64,7 +64,7 @@ export class PhpGeneratorAgent extends AbstractGeneratorAgent<SdkGeneratorContex
             sourceDirectory: "fern/output",
             uri: this.publishConfig.uri,
             token: this.publishConfig.token,
-            branch: undefined
+            branch: this.publishConfig.branch
         };
     }
 }


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of the changes made in this PR -->
Passes through the `branch` field from the IR's `publishConfig` to the GitHub config in the PHP generator agent. Previously, `branch` was hardcoded to `undefined`, which meant the branch configuration was not being used when generating READMEs.

## Changes Made
- Updated `PhpGeneratorAgent.getGitHubConfig()` to pass `this.publishConfig.branch` instead of `undefined`

## Testing
- [x] Lint checks pass
- [x] TypeScript compilation passes

## Human Review Checklist
- [ ] Verify this is the intended behavior for PHP README generation
- [ ] Consider if other generators (Swift, Rust, C#) need the same fix - they also have `branch: undefined`

---
Link to Devin run: https://app.devin.ai/sessions/306cf38d7127449590d85048686d29ce
Requested by: Deep Singhvi (@dsinghvi)