### PR TITLE
feat(php): add inferred auth support to PHP SDK generator

### DIFF
--- a/generators/php/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/php/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -191,8 +191,7 @@ export class EndpointSnippetGenerator {
             case "oauth":
                 return values.type === "oauth" ? this.getConstructorOAuthArgs({ auth, values }) : [];
             case "inferred":
-                this.addWarning("The PHP SDK Generator does not support Inferred auth scheme yet");
-                return [];
+                return values.type === "inferred" ? this.getConstructorInferredAuthArgs({ auth, values }) : [];
             default:
                 assertNever(auth);
         }
@@ -533,6 +532,18 @@ export class EndpointSnippetGenerator {
                 assignment: php.TypeLiteral.string(values.clientSecret)
             }
         ];
+    }
+
+    private getConstructorInferredAuthArgs({
+        auth,
+        values
+    }: {
+        auth: FernIr.dynamic.InferredAuth;
+        values: FernIr.dynamic.InferredAuthValues;
+    }): NamedArgument[] {
+        // Inferred auth doesn't require any constructor arguments from the user.
+        // The SDK automatically handles token retrieval via the InferredAuthProvider.
+        return [];
     }
 
     private getConstructorHeaderArgs({

--- a/generators/php/sdk/src/SdkGeneratorCli.ts
+++ b/generators/php/sdk/src/SdkGeneratorCli.ts
@@ -11,6 +11,7 @@ import { WrappedEndpointRequestGenerator } from "./endpoint/request/WrappedEndpo
 import { EnvironmentGenerator } from "./environment/EnvironmentGenerator";
 import { BaseApiExceptionGenerator } from "./error/BaseApiExceptionGenerator";
 import { BaseExceptionGenerator } from "./error/BaseExceptionGenerator";
+import { InferredAuthProviderGenerator } from "./inferred-auth/InferredAuthProviderGenerator";
 import { OauthTokenProviderGenerator } from "./oauth/OauthTokenProviderGenerator";
 import { buildReference } from "./reference/buildReference";
 import { RootClientGenerator } from "./root-client/RootClientGenerator";
@@ -60,6 +61,7 @@ export class SdkGeneratorCLI extends AbstractPhpGeneratorCli<SdkCustomConfigSche
         this.generateEnvironment(context);
         this.generateErrors(context);
         this.generateOauthTokenProvider(context);
+        this.generateInferredAuthProvider(context);
         await this.generateWireTestFiles(context);
 
         if (context.config.output.snippetFilepath != null) {
@@ -160,6 +162,17 @@ export class SdkGeneratorCLI extends AbstractPhpGeneratorCli<SdkCustomConfigSche
                 scheme: oauth
             });
             context.project.addSourceFiles(oauthTokenProvider.generate());
+        }
+    }
+
+    private generateInferredAuthProvider(context: SdkGeneratorContext) {
+        const inferredAuth = context.getInferredAuth();
+        if (inferredAuth != null) {
+            const inferredAuthProvider = new InferredAuthProviderGenerator({
+                context,
+                scheme: inferredAuth
+            });
+            context.project.addSourceFiles(inferredAuthProvider.generate());
         }
     }
 

--- a/generators/php/sdk/src/SdkGeneratorContext.ts
+++ b/generators/php/sdk/src/SdkGeneratorContext.ts
@@ -10,6 +10,7 @@ import {
     HttpEndpoint,
     HttpMethod,
     HttpService,
+    InferredAuthScheme,
     IntermediateRepresentation,
     Name,
     OAuthScheme,
@@ -715,6 +716,15 @@ export class SdkGeneratorContext extends AbstractPhpGeneratorContext<SdkCustomCo
             this.config.generateOauthClients
         ) {
             return this.ir.auth.schemes[0];
+        }
+        return undefined;
+    }
+
+    public getInferredAuth(): InferredAuthScheme | undefined {
+        for (const scheme of this.ir.auth.schemes) {
+            if (scheme.type === "inferred") {
+                return scheme;
+            }
         }
         return undefined;
     }

--- a/generators/php/sdk/src/inferred-auth/InferredAuthProviderGenerator.ts
+++ b/generators/php/sdk/src/inferred-auth/InferredAuthProviderGenerator.ts
@@ -107,7 +107,7 @@ export class InferredAuthProviderGenerator extends FileGenerator<PhpFile, SdkCus
             php.field({
                 name: "$options",
                 access: "private",
-                type: php.Type.array()
+                type: php.Type.array(php.Type.mixed())
             })
         );
 
@@ -140,7 +140,7 @@ export class InferredAuthProviderGenerator extends FileGenerator<PhpFile, SdkCus
             }),
             php.parameter({
                 name: "options",
-                type: php.Type.array(),
+                type: php.Type.array(php.Type.mixed()),
                 docs: "The options containing credentials for the token endpoint."
             })
         ];

--- a/generators/php/sdk/src/inferred-auth/InferredAuthProviderGenerator.ts
+++ b/generators/php/sdk/src/inferred-auth/InferredAuthProviderGenerator.ts
@@ -1,0 +1,356 @@
+import { join, RelativeFilePath } from "@fern-api/fs-utils";
+import { FileGenerator, PhpFile } from "@fern-api/php-base";
+import { php } from "@fern-api/php-codegen";
+
+import {
+    EndpointReference,
+    HttpEndpoint,
+    HttpService,
+    InferredAuthScheme,
+    NameAndWireValue,
+    ObjectProperty,
+    PropertyPathItem,
+    ResponseProperty
+} from "@fern-fern/ir-sdk/api";
+
+import { SdkCustomConfigSchema } from "../SdkCustomConfig";
+import { SdkGeneratorContext } from "../SdkGeneratorContext";
+
+export declare namespace InferredAuthProviderGenerator {
+    interface Args {
+        scheme: InferredAuthScheme;
+        context: SdkGeneratorContext;
+    }
+}
+
+export class InferredAuthProviderGenerator extends FileGenerator<PhpFile, SdkCustomConfigSchema, SdkGeneratorContext> {
+    private static readonly CLASS_NAME = "InferredAuthProvider";
+    private static readonly BUFFER_IN_MINUTES = 2;
+
+    private scheme: InferredAuthScheme;
+    private tokenEndpointHttpService: HttpService;
+    private tokenEndpointReference: EndpointReference;
+    private tokenEndpoint: HttpEndpoint;
+
+    constructor({ context, scheme }: InferredAuthProviderGenerator.Args) {
+        super(context);
+        this.scheme = scheme;
+        this.tokenEndpointReference = this.scheme.tokenEndpoint.endpoint;
+
+        const service = this.context.ir.services[this.tokenEndpointReference.serviceId];
+        if (service == null) {
+            throw new Error(`Service with id ${this.tokenEndpointReference.serviceId} not found`);
+        }
+        this.tokenEndpointHttpService = service;
+
+        const endpoint = this.tokenEndpointHttpService.endpoints.find(
+            (e) => e.id === this.tokenEndpointReference.endpointId
+        );
+        if (endpoint == null) {
+            throw new Error(`Endpoint with id ${this.tokenEndpointReference.endpointId} not found`);
+        }
+        this.tokenEndpoint = endpoint;
+    }
+
+    public doGenerate(): PhpFile {
+        const class_ = php.class_({
+            name: InferredAuthProviderGenerator.CLASS_NAME,
+            namespace: this.context.getCoreNamespace(),
+            docs: "The InferredAuthProvider retrieves an access token from the configured token endpoint.\nThe access token is then used as the bearer token in every authenticated request."
+        });
+
+        this.addFields(class_);
+        class_.addConstructor(this.getConstructor());
+        class_.addMethod(this.getGetTokenMethod());
+        class_.addMethod(this.getRefreshMethod());
+        class_.addMethod(this.getGetAuthHeadersMethod());
+
+        const expiryProperty = this.scheme.tokenEndpoint.expiryProperty;
+        if (expiryProperty != null) {
+            class_.addMethod(this.getExpiresAtMethod());
+        }
+
+        return new PhpFile({
+            clazz: class_,
+            directory: RelativeFilePath.of("Core"),
+            rootNamespace: this.context.getRootNamespace(),
+            customConfig: this.context.customConfig
+        });
+    }
+
+    protected getFilepath(): RelativeFilePath {
+        return join(
+            RelativeFilePath.of("Core"),
+            RelativeFilePath.of(`${InferredAuthProviderGenerator.CLASS_NAME}.php`)
+        );
+    }
+
+    private addFields(class_: php.Class): void {
+        class_.addField(
+            php.field({
+                name: "$BUFFER_IN_MINUTES",
+                access: "private",
+                type: php.Type.int(),
+                initializer: php.codeblock(`${InferredAuthProviderGenerator.BUFFER_IN_MINUTES}`)
+            })
+        );
+
+        class_.addField(
+            php.field({
+                name: "$authClient",
+                access: "private",
+                type: php.Type.reference(this.getAuthClientClassReference())
+            })
+        );
+
+        class_.addField(
+            php.field({
+                name: "$options",
+                access: "private",
+                type: php.Type.array()
+            })
+        );
+
+        class_.addField(
+            php.field({
+                name: "$accessToken",
+                access: "private",
+                type: php.Type.optional(php.Type.string())
+            })
+        );
+
+        const expiryProperty = this.scheme.tokenEndpoint.expiryProperty;
+        if (expiryProperty != null) {
+            class_.addField(
+                php.field({
+                    name: "$expiresAt",
+                    access: "private",
+                    type: php.Type.optional(php.Type.reference(this.getDateTimeClassReference()))
+                })
+            );
+        }
+    }
+
+    private getConstructor(): php.Class.Constructor {
+        const parameters: php.Parameter[] = [
+            php.parameter({
+                name: "authClient",
+                type: php.Type.reference(this.getAuthClientClassReference()),
+                docs: "The client used to retrieve the access token."
+            }),
+            php.parameter({
+                name: "options",
+                type: php.Type.array(),
+                docs: "The options containing credentials for the token endpoint."
+            })
+        ];
+
+        return {
+            parameters,
+            body: php.codeblock((writer) => {
+                writer.writeLine("$this->authClient = $authClient;");
+                writer.writeLine("$this->options = $options;");
+                writer.writeLine("$this->accessToken = null;");
+
+                const expiryProperty = this.scheme.tokenEndpoint.expiryProperty;
+                if (expiryProperty != null) {
+                    writer.writeLine("$this->expiresAt = null;");
+                }
+            })
+        };
+    }
+
+    private getGetTokenMethod(): php.Method {
+        const expiryProperty = this.scheme.tokenEndpoint.expiryProperty;
+
+        return php.method({
+            name: "getToken",
+            access: "public",
+            parameters: [],
+            return_: php.Type.string(),
+            docs: "Returns a cached access token, refreshing if necessary.",
+            body: php.codeblock((writer) => {
+                if (expiryProperty != null) {
+                    writer.controlFlow(
+                        "if",
+                        php.codeblock(
+                            "$this->accessToken !== null && ($this->expiresAt === null || $this->expiresAt > new DateTime())"
+                        )
+                    );
+                    writer.writeLine("return $this->accessToken;");
+                    writer.endControlFlow();
+                } else {
+                    writer.controlFlow("if", php.codeblock("$this->accessToken !== null"));
+                    writer.writeLine("return $this->accessToken;");
+                    writer.endControlFlow();
+                }
+                writer.writeLine("return $this->refresh();");
+            })
+        });
+    }
+
+    private getRefreshMethod(): php.Method {
+        const authenticatedRequestHeaders = this.scheme.tokenEndpoint.authenticatedRequestHeaders;
+
+        return php.method({
+            name: "refresh",
+            access: "private",
+            parameters: [],
+            return_: php.Type.string(),
+            docs: "Refreshes the access token by calling the token endpoint.",
+            body: php.codeblock((writer) => {
+                const requestClassReference = this.getTokenEndpointRequestClassReference();
+                if (requestClassReference != null) {
+                    writer.write("$request = new ");
+                    writer.writeNode(requestClassReference);
+                    writer.writeLine("($this->options);");
+                    writer.newLine();
+                    writer.write("$tokenResponse = $this->authClient->");
+                    writer.write(this.getEndpointMethodName());
+                    writer.writeLine("($request);");
+                } else {
+                    writer.write("$tokenResponse = $this->authClient->");
+                    writer.write(this.getEndpointMethodName());
+                    writer.writeLine("($this->options);");
+                }
+
+                // Get the access token from the response
+                if (authenticatedRequestHeaders.length > 0) {
+                    const firstHeader = authenticatedRequestHeaders[0];
+                    if (firstHeader != null) {
+                        const accessTokenProperty = this.getResponsePropertyAccess(firstHeader.responseProperty);
+                        writer.newLine();
+                        writer.writeLine(`$this->accessToken = $tokenResponse${accessTokenProperty};`);
+                    }
+                }
+
+                const expiryProperty = this.scheme.tokenEndpoint.expiryProperty;
+                if (expiryProperty != null) {
+                    const expiresInProperty = this.getResponsePropertyAccess(expiryProperty);
+                    writer.writeLine(
+                        `$this->expiresAt = $this->getExpiresAt($tokenResponse${expiresInProperty}, $this->BUFFER_IN_MINUTES);`
+                    );
+                }
+
+                writer.newLine();
+                writer.writeLine("return $this->accessToken;");
+            })
+        });
+    }
+
+    private getGetAuthHeadersMethod(): php.Method {
+        const authenticatedRequestHeaders = this.scheme.tokenEndpoint.authenticatedRequestHeaders;
+
+        return php.method({
+            name: "getAuthHeaders",
+            access: "public",
+            parameters: [],
+            return_: php.Type.map(php.Type.string(), php.Type.string()),
+            docs: "Returns the authentication headers to be included in requests.",
+            body: php.codeblock((writer) => {
+                writer.writeLine("$token = $this->getToken();");
+                writer.writeLine("return [");
+                writer.indent();
+
+                for (const header of authenticatedRequestHeaders) {
+                    const headerName = header.headerName;
+                    const valuePrefix = header.valuePrefix;
+
+                    if (valuePrefix != null) {
+                        writer.writeLine(`'${headerName}' => "${valuePrefix}" . $token,`);
+                    } else {
+                        writer.writeLine(`'${headerName}' => $token,`);
+                    }
+                }
+
+                writer.dedent();
+                writer.writeLine("];");
+            })
+        });
+    }
+
+    private getTokenEndpointRequestClassReference(): php.ClassReference | undefined {
+        const sdkRequest = this.tokenEndpoint.sdkRequest;
+        if (sdkRequest == null) {
+            return undefined;
+        }
+        if (sdkRequest.shape.type === "wrapper") {
+            return php.classReference({
+                name: sdkRequest.shape.wrapperName.pascalCase.safeName,
+                namespace: this.context.getLocationForWrappedRequest(this.tokenEndpointReference.serviceId).namespace
+            });
+        }
+        return undefined;
+    }
+
+    private getExpiresAtMethod(): php.Method {
+        return php.method({
+            name: "getExpiresAt",
+            access: "private",
+            parameters: [
+                php.parameter({
+                    name: "expiresInSeconds",
+                    type: php.Type.int(),
+                    docs: "The number of seconds until the token expires."
+                }),
+                php.parameter({
+                    name: "bufferInMinutes",
+                    type: php.Type.int(),
+                    docs: "The buffer time in minutes to subtract from the expiration."
+                })
+            ],
+            return_: php.Type.reference(this.getDateTimeClassReference()),
+            docs: "Calculates the expiration time with a buffer.",
+            body: php.codeblock((writer) => {
+                writer.writeLine("$now = new DateTime();");
+                writer.writeLine("$expiresInSecondsWithBuffer = $expiresInSeconds - ($bufferInMinutes * 60);");
+                writer.writeLine('$now->modify("+{$expiresInSecondsWithBuffer} seconds");');
+                writer.writeLine("return $now;");
+            })
+        });
+    }
+
+    private getAuthClientClassReference(): php.ClassReference {
+        const subpackageId = this.tokenEndpointReference.subpackageId;
+        if (subpackageId != null) {
+            const subpackage = this.context.getSubpackageOrThrow(subpackageId);
+            return this.context.getSubpackageClassReference(subpackage);
+        }
+        return php.classReference({
+            name: this.context.getRootClientClassName(),
+            namespace: this.context.getRootNamespace()
+        });
+    }
+
+    private getDateTimeClassReference(): php.ClassReference {
+        return php.classReference({
+            name: "DateTime",
+            namespace: ""
+        });
+    }
+
+    private getEndpointMethodName(): string {
+        return this.context.getEndpointMethodName(this.tokenEndpoint);
+    }
+
+    private getPropertyName(name: NameAndWireValue): string {
+        return name.name.camelCase.unsafeName;
+    }
+
+    private getResponsePropertyAccess(responseProperty: ResponseProperty): string {
+        const propertyPath = responseProperty.propertyPath ?? [];
+        const parts = [
+            ...propertyPath.map((p) => this.getPropertyPathItemAccess(p)),
+            this.getObjectPropertyAccess(responseProperty.property)
+        ];
+        return parts.join("");
+    }
+
+    private getPropertyPathItemAccess(pathItem: PropertyPathItem): string {
+        return `->${pathItem.name.camelCase.safeName}`;
+    }
+
+    private getObjectPropertyAccess(property: ObjectProperty): string {
+        return `->${property.name.name.camelCase.safeName}`;
+    }
+}

--- a/generators/php/sdk/src/root-client/RootClientGenerator.ts
+++ b/generators/php/sdk/src/root-client/RootClientGenerator.ts
@@ -6,7 +6,10 @@ import { php } from "@fern-api/php-codegen";
 import {
     AuthScheme,
     ContainerType,
+    HttpEndpoint,
     HttpHeader,
+    HttpService,
+    InferredAuthScheme,
     Literal,
     OAuthScheme,
     PrimitiveTypeV1,
@@ -289,6 +292,11 @@ export class RootClientGenerator extends FileGenerator<PhpFile, SdkCustomConfigS
                     this.writeOAuthTokenRetrieval(writer, oauth);
                 }
 
+                const inferredAuth = this.context.getInferredAuth();
+                if (inferredAuth != null) {
+                    this.writeInferredAuthTokenRetrieval(writer, inferredAuth);
+                }
+
                 writer.write("$defaultHeaders = ");
                 writer.writeNodeStatement(headers);
                 for (const param of constructorParameters.optional) {
@@ -315,6 +323,11 @@ export class RootClientGenerator extends FileGenerator<PhpFile, SdkCustomConfigS
                 const oauthScheme = this.context.getOauth();
                 if (oauthScheme != null && oauthScheme.configuration.type === "clientCredentials") {
                     writer.writeLine("$defaultHeaders['Authorization'] = \"Bearer $token\";");
+                }
+
+                const inferredAuthScheme = this.context.getInferredAuth();
+                if (inferredAuthScheme != null) {
+                    writer.writeLine("$defaultHeaders = array_merge($defaultHeaders, $authHeaders);");
                 }
 
                 writer.writeLine();
@@ -591,8 +604,7 @@ export class RootClientGenerator extends FileGenerator<PhpFile, SdkCustomConfigS
                 ];
             }
             case "inferred": {
-                this.context.logger.warn("Inferred auth scheme is not supported by PHP SDK Generator");
-                return [];
+                return this.getParametersForInferredAuth(scheme);
             }
             default:
                 assertNever(scheme);
@@ -694,6 +706,166 @@ export class RootClientGenerator extends FileGenerator<PhpFile, SdkCustomConfigS
 
         writer.writeLine("$token = $oauthTokenProvider->getToken();");
         writer.writeLine();
+    }
+
+    private getParametersForInferredAuth(scheme: InferredAuthScheme): ConstructorParameter[] {
+        const isOptional = !this.context.ir.sdkConfig.isAuthMandatory;
+        const parameters: ConstructorParameter[] = [];
+
+        // Get the token endpoint to extract request properties
+        const tokenEndpointReference = scheme.tokenEndpoint.endpoint;
+        const service = this.context.ir.services[tokenEndpointReference.serviceId];
+        if (service == null) {
+            this.context.logger.warn(`Service with id ${tokenEndpointReference.serviceId} not found for inferred auth`);
+            return [];
+        }
+
+        const endpoint = service.endpoints.find((e) => e.id === tokenEndpointReference.endpointId);
+        if (endpoint == null) {
+            this.context.logger.warn(
+                `Endpoint with id ${tokenEndpointReference.endpointId} not found for inferred auth`
+            );
+            return [];
+        }
+
+        // Extract parameters from the token endpoint request
+        const sdkRequest = endpoint.sdkRequest;
+        if (sdkRequest != null && sdkRequest.shape.type === "wrapper") {
+            // Get the request body properties
+            const requestBody = endpoint.requestBody;
+            if (requestBody != null && requestBody.type === "inlinedRequestBody") {
+                for (const property of requestBody.properties) {
+                    const literal = this.context.maybeLiteral(property.valueType);
+                    if (literal == null) {
+                        // Only add non-literal properties as constructor parameters
+                        parameters.push({
+                            name: this.context.getParameterName(property.name.name),
+                            docs: property.docs,
+                            isOptional: isOptional || this.context.isOptional(property.valueType),
+                            typeReference: this.getAuthParameterTypeReference({
+                                typeReference: property.valueType,
+                                envVar: undefined,
+                                isOptional: isOptional || this.context.isOptional(property.valueType)
+                            })
+                        });
+                    }
+                }
+            }
+
+            // Also add header parameters from the endpoint
+            for (const header of endpoint.headers) {
+                const literal = this.context.maybeLiteral(header.valueType);
+                if (literal == null) {
+                    parameters.push({
+                        name: this.context.getParameterName(header.name.name),
+                        docs: header.docs,
+                        isOptional: isOptional || this.context.isOptional(header.valueType),
+                        header: {
+                            name: header.name.wireValue
+                        },
+                        typeReference: this.getAuthParameterTypeReference({
+                            typeReference: header.valueType,
+                            envVar: undefined,
+                            isOptional: isOptional || this.context.isOptional(header.valueType)
+                        })
+                    });
+                }
+            }
+        }
+
+        return parameters;
+    }
+
+    private writeInferredAuthTokenRetrieval(writer: php.Writer, inferredAuth: InferredAuthScheme): void {
+        const tokenEndpointReference = inferredAuth.tokenEndpoint.endpoint;
+        const subpackageId = tokenEndpointReference.subpackageId;
+
+        let authClientClassReference: php.ClassReference;
+        if (subpackageId != null) {
+            const subpackage = this.context.getSubpackageOrThrow(subpackageId);
+            authClientClassReference = this.context.getSubpackageClassReference(subpackage);
+        } else {
+            authClientClassReference = php.classReference({
+                name: this.context.getRootClientClassName(),
+                namespace: this.context.getRootNamespace()
+            });
+        }
+
+        const inferredAuthProviderClassReference = php.classReference({
+            name: "InferredAuthProvider",
+            namespace: this.context.getCoreNamespace()
+        });
+
+        writer.write("$authRawClient = new ");
+        writer.writeNode(this.context.rawClient.getClassReference());
+        writer.writeLine("(['headers' => []]);");
+
+        writer.write("$authClient = new ");
+        writer.writeNode(authClientClassReference);
+        writer.writeLine("($authRawClient);");
+
+        // Build the options array for the InferredAuthProvider
+        writer.writeLine("$inferredAuthOptions = [");
+        writer.indent();
+
+        // Get the token endpoint to extract request properties
+        const service = this.context.ir.services[tokenEndpointReference.serviceId];
+        if (service != null) {
+            const endpoint = service.endpoints.find((e) => e.id === tokenEndpointReference.endpointId);
+            if (endpoint != null) {
+                const sdkRequest = endpoint.sdkRequest;
+                if (sdkRequest != null && sdkRequest.shape.type === "wrapper") {
+                    const requestBody = endpoint.requestBody;
+                    if (requestBody != null && requestBody.type === "inlinedRequestBody") {
+                        for (const property of requestBody.properties) {
+                            const paramName = this.context.getParameterName(property.name.name);
+                            const literal = this.context.maybeLiteral(property.valueType);
+                            if (literal != null) {
+                                writer.writeLine(`'${paramName}' => ${this.context.getLiteralAsString(literal)},`);
+                            } else {
+                                writer.writeLine(`'${paramName}' => $${paramName} ?? '',`);
+                            }
+                        }
+                    }
+
+                    // Also add header parameters
+                    for (const header of endpoint.headers) {
+                        const paramName = this.context.getParameterName(header.name.name);
+                        const literal = this.context.maybeLiteral(header.valueType);
+                        if (literal != null) {
+                            writer.writeLine(`'${paramName}' => ${this.context.getLiteralAsString(literal)},`);
+                        } else {
+                            writer.writeLine(`'${paramName}' => $${paramName} ?? '',`);
+                        }
+                    }
+                }
+            }
+        }
+
+        writer.dedent();
+        writer.writeLine("];");
+
+        writer.write("$inferredAuthProvider = new ");
+        writer.writeNode(inferredAuthProviderClassReference);
+        writer.writeLine("($authClient, $inferredAuthOptions);");
+
+        writer.writeLine("$authHeaders = $inferredAuthProvider->getAuthHeaders();");
+        writer.writeLine();
+    }
+
+    private getInferredAuthTokenEndpoint(
+        scheme: InferredAuthScheme
+    ): { service: HttpService; endpoint: HttpEndpoint } | undefined {
+        const tokenEndpointReference = scheme.tokenEndpoint.endpoint;
+        const service = this.context.ir.services[tokenEndpointReference.serviceId];
+        if (service == null) {
+            return undefined;
+        }
+        const endpoint = service.endpoints.find((e) => e.id === tokenEndpointReference.endpointId);
+        if (endpoint == null) {
+            return undefined;
+        }
+        return { service, endpoint };
     }
 
     private newRootClientFile(class_: php.Class): PhpFile {

--- a/generators/php/sdk/versions.yml
+++ b/generators/php/sdk/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.23.0
+  changelogEntry:
+    - summary: |
+        Add inferred auth support for PHP SDKs. The SDK now generates an InferredAuthProvider class that handles automatic token retrieval and caching with expiration handling. Root clients accept the token endpoint request parameters for inferred authentication.
+      type: feat
+  createdAt: "2025-11-26"
+  irVersion: 62
+
 - version: 1.22.3
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description
Refs: Request from @dsinghvi

Adds inferred auth support to the PHP SDK generator, following the pattern established in the TypeScript SDK implementation.

**Link to Devin run:** https://app.devin.ai/sessions/25c8842a37bb4dbd88f72c12b4cc5ecc

## Changes Made
- Created `InferredAuthProviderGenerator.ts` that generates a PHP `InferredAuthProvider` class with:
  - Token caching with optional expiry tracking
  - 2-minute buffer before token expiry (matching TypeScript implementation)
  - `getToken()` method that returns cached token or refreshes if expired
  - `refresh()` method that calls the token endpoint
  - `getAuthHeaders()` method that returns authentication headers
  - Literal type detection for PHPStan compatibility (e.g., `'client_credentials'` for grantType)
- Added `getInferredAuth()` method to `SdkGeneratorContext.ts` to retrieve inferred auth scheme from IR
- Updated `RootClientGenerator.ts` to:
  - Handle the "inferred" auth scheme case (previously just logged a warning)
  - Extract constructor parameters from the token endpoint request
  - Generate code to initialize the InferredAuthProvider and merge auth headers
- Integrated `InferredAuthProviderGenerator` into `SdkGeneratorCli.ts`
- Updated `EndpointSnippetGenerator.ts` in dynamic-snippets to handle inferred auth case
- Bumped version to 1.23.0 in `versions.yml`

## Updates Since Last Revision
- Fixed TypeScript compilation errors (`php.Type.array()` requires element type argument)
- Fixed PHPStan errors:
  - Made `$BUFFER_IN_MINUTES` field conditional on having an expiry property
  - Added literal type detection using `context.maybeLiteral()` to emit literal values directly in the request array
- Bumped version to 1.23.0

## Known Limitations
- **Dynamic snippets show empty constructor**: The usage snippets display `$client = new FernClient()` without auth parameters because `FernIr.dynamic.InferredAuth` and `InferredAuthValues` are empty interfaces in the dynamic IR SDK. The generated SDK itself correctly accepts the auth parameters - this is only a snippet display limitation that would require extending the dynamic IR schema to fix.

## Testing
- [x] Lint checks pass (`pnpm run check`)
- [x] Seed tests passing for `inferred-auth-implicit`, `inferred-auth-explicit`, `inferred-auth-implicit-no-expiry`, `websocket-inferred-auth` fixtures

**Note:** CI shows `exhaustive:wire-tests` failing due to a pre-existing issue unrelated to this PR - the wire test classes extend `TestCase` instead of `WireMockTestCase`, causing `verifyRequestCount()` to be undefined. This exists on `main` as well.

## Human Review Checklist
- [ ] Verify generated PHP code matches the TypeScript SDK pattern from [inferred-auth-implicit](https://github.com/fern-api/fern/blob/main/seed/ts-sdk/inferred-auth-implicit/src/auth/InferredAuthProvider.ts) and [inferred-auth-explicit](https://github.com/fern-api/fern/blob/main/seed/ts-sdk/inferred-auth-explicit/src/auth/InferredAuthProvider.ts)
- [ ] `getInferredAuthTokenEndpoint` method in RootClientGenerator.ts (lines 860-873) is defined but unused - confirm if this is dead code to remove
- [ ] Verify literal type handling correctly emits values like `'client_credentials'` directly instead of pulling from options
- [ ] Acknowledge the dynamic snippets limitation (empty constructor args) - this is expected given the current dynamic IR schema