### PR TITLE
fix(internal): handle null custom config in readme generation

### DIFF
--- a/generators/csharp/sdk/src/readme/ReadmeConfigBuilder.ts
+++ b/generators/csharp/sdk/src/readme/ReadmeConfigBuilder.ts
@@ -86,6 +86,9 @@ function getCustomSections(context: SdkGeneratorContext): FernGeneratorCli.Custo
 }
 
 function parseCustomConfigOrUndefined(logger: Logger, customConfig: unknown): CsharpConfigSchema | undefined {
+    if (customConfig == null) {
+        return undefined;
+    }
     try {
         return CsharpConfigSchema.parse(customConfig);
     } catch (error) {

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.9.4
+  changelogEntry:
+    - summary: |
+        Remove error on null config in README generation.
+      type: fix
+  createdAt: "2025-11-26"
+  irVersion: 61
+
 - version: 2.9.3
   changelogEntry:
     - summary: |

--- a/generators/go-v2/sdk/src/readme/ReadmeConfigBuilder.ts
+++ b/generators/go-v2/sdk/src/readme/ReadmeConfigBuilder.ts
@@ -89,6 +89,9 @@ function getCustomSections(context: SdkGeneratorContext): FernGeneratorCli.Custo
 }
 
 function parseCustomConfigOrUndefined(logger: Logger, customConfig: unknown): SdkCustomConfigSchema | undefined {
+    if (customConfig == null) {
+        return undefined;
+    }
     try {
         return SdkCustomConfigSchema.parse(customConfig);
     } catch (error) {

--- a/generators/java-v2/sdk/src/readme/ReadmeConfigBuilder.ts
+++ b/generators/java-v2/sdk/src/readme/ReadmeConfigBuilder.ts
@@ -130,6 +130,9 @@ function getCustomSections(context: SdkGeneratorContext): FernGeneratorCli.Custo
 }
 
 function parseCustomConfigOrUndefined(logger: Logger, customConfig: unknown): SdkCustomConfigSchema | undefined {
+    if (customConfig == null) {
+        return undefined;
+    }
     try {
         return SdkCustomConfigSchema.parse(customConfig);
     } catch (error) {

--- a/generators/php/sdk/src/readme/ReadmeConfigBuilder.ts
+++ b/generators/php/sdk/src/readme/ReadmeConfigBuilder.ts
@@ -100,6 +100,9 @@ function getCustomSections(context: SdkGeneratorContext): FernGeneratorCli.Custo
 }
 
 function parseCustomConfigOrUndefined(logger: Logger, customConfig: unknown): SdkCustomConfigSchema | undefined {
+    if (customConfig == null) {
+        return undefined;
+    }
     try {
         return SdkCustomConfigSchema.parse(customConfig);
     } catch (error) {

--- a/generators/php/sdk/versions.yml
+++ b/generators/php/sdk/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.23.1
+  changelogEntry:
+    - summary: |
+        Remove error on null config in README generation.
+      type: fix
+  createdAt: "2025-11-26"
+  irVersion: 62
+
 - version: 1.23.0
   changelogEntry:
     - summary: |

--- a/generators/ruby-v2/sdk/src/readme/ReadmeConfigBuilder.ts
+++ b/generators/ruby-v2/sdk/src/readme/ReadmeConfigBuilder.ts
@@ -98,6 +98,9 @@ function getCustomSections(context: SdkGeneratorContext): FernGeneratorCli.Custo
 }
 
 function parseCustomConfigOrUndefined(logger: Logger, customConfig: unknown): SdkCustomConfigSchema | undefined {
+    if (customConfig == null) {
+        return undefined;
+    }
     try {
         return SdkCustomConfigSchema.parse(customConfig);
     } catch (error) {

--- a/generators/ruby-v2/sdk/versions.yml
+++ b/generators/ruby-v2/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.0.0-rc44
+  createdAt: "2025-11-26"
+  changelogEntry:
+    - type: fix
+      summary: |
+        Remove error on null config in README generation.
+  irVersion: 61
+
 - version: 1.0.0-rc43
   createdAt: "2025-11-24"
   changelogEntry:

--- a/generators/rust/sdk/src/readme/ReadmeConfigBuilder.ts
+++ b/generators/rust/sdk/src/readme/ReadmeConfigBuilder.ts
@@ -92,6 +92,9 @@ function getCustomSections(context: SdkGeneratorContext): FernGeneratorCli.Custo
 }
 
 function parseCustomConfigOrUndefined(logger: Logger, customConfig: unknown): SdkCustomConfigSchema | undefined {
+    if (customConfig == null) {
+        return undefined;
+    }
     try {
         return SdkCustomConfigSchema.parse(customConfig);
     } catch (error) {

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.13.3
+  createdAt: "2025-11-26"
+  changelogEntry:
+    - type: fix
+      summary: |
+        Remove error on null config in README generation.
+  irVersion: 61
+
 - version: 0.13.2
   createdAt: "2025-11-25"
   changelogEntry:

--- a/generators/swift/sdk/src/readme/ReadmeConfigBuilder.ts
+++ b/generators/swift/sdk/src/readme/ReadmeConfigBuilder.ts
@@ -97,6 +97,9 @@ function getCustomSections(context: SdkGeneratorContext): FernGeneratorCli.Custo
 }
 
 function parseCustomConfigOrUndefined(logger: Logger, customConfig: unknown): SdkCustomConfigSchema | undefined {
+    if (customConfig == null) {
+        return undefined;
+    }
     try {
         return SdkCustomConfigSchema.parse(customConfig);
     } catch (error) {

--- a/generators/swift/sdk/versions.yml
+++ b/generators/swift/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 0.25.2
+  changelogEntry:
+    - summary: |
+        Remove error on null config in README generation.
+      type: fix
+  createdAt: "2025-11-26"
+  irVersion: 61
+
 - version: 0.25.1
   changelogEntry:
     - summary: |

--- a/generators/typescript/sdk/generator/src/readme/ReadmeConfigBuilder.ts
+++ b/generators/typescript/sdk/generator/src/readme/ReadmeConfigBuilder.ts
@@ -146,6 +146,9 @@ function getCustomSections(
 }
 
 function parseCustomConfigOrUndefined(logger: Logger, customConfig: unknown): SdkCustomConfigSchema | undefined {
+    if (customConfig == null) {
+        return undefined;
+    }
     try {
         return SdkCustomConfigSchema.parse(customConfig);
     } catch (error) {

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.34.1
+  changelogEntry:
+    - summary: |
+        Remove error on null config in README generation.
+      type: fix
+  createdAt: "2025-11-26"
+  irVersion: 61
+
 - version: 3.34.0
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Fixes spurious error logs during readme generation when no custom config is provided. The error was:
```
Error parsing custom config during readme generation: [{"code": "invalid_type", "expected": "object", "received": "undefined", ...}]
```

Having a null/undefined custom config is a valid case that should be handled gracefully rather than logged as an error.

Requested by: thomas@buildwithfern.com (@tjb9dc)
[Link to Devin run](https://app.devin.ai/sessions/8320f923340f4f3f8a80ee30192db2fa)

## Changes Made

- Added early return in `parseCustomConfigOrUndefined` function when `customConfig` is null/undefined
- Applied fix to all 8 affected generators: ruby-v2, typescript, swift, php, go-v2, csharp, rust, java-v2
- Added changelog entries (PATCH increment) for generators with versions.yml:
  - ruby-v2: 1.0.0-rc44
  - typescript: 3.34.1
  - swift: 0.25.2
  - php: 1.23.1
  - csharp: 2.9.4
  - rust: 0.13.3
  
Note: go-v2 and java-v2 don't have their own versions.yml files (they're internal packages).

## Testing

- [x] Lint checks pass (`pnpm run check`)
- [ ] Manual testing - the fix is straightforward: null configs now return `undefined` without logging an error, while actual invalid configs still log errors

## Human Review Checklist

- [ ] Verify the null check (`customConfig == null`) correctly catches both `null` and `undefined`
- [ ] Confirm error logging is preserved for genuinely invalid (non-null but malformed) configs
- [ ] Verify changelog entries follow the correct format and version increments are appropriate