### PR TITLE
fix(ci): Update publish-generator-java-sdk.yml to support automated CI runs on main

### DIFF
--- a/.github/workflows/publish-generator-java-sdk.yml
+++ b/.github/workflows/publish-generator-java-sdk.yml
@@ -20,7 +20,7 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     env:
-      BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+      BRANCH_NAME: ${{ github.head_ref || github.ref_name || 'main' }}
     steps:
       - name: Checkout repo at current ref
         uses: actions/checkout@v4

--- a/.github/workflows/publish-generator-java-sdk.yml
+++ b/.github/workflows/publish-generator-java-sdk.yml
@@ -54,6 +54,7 @@ jobs:
           aws sts get-caller-identity
           docker pull fernapi/fern-java-sdk:${{ inputs.version }}
           SANITIZED_BRANCH="${BRANCH_NAME//\//-}"
+          echo $SANITIZED_BRANCH
           docker tag fernapi/fern-java-sdk:${{ inputs.version }} 985111089818.dkr.ecr.us-east-1.amazonaws.com/dev/java-sdk-generator:${{ inputs.version }}-$SANITIZED_BRANCH-${{ github.sha }}
           aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 985111089818.dkr.ecr.us-east-1.amazonaws.com
           docker push 985111089818.dkr.ecr.us-east-1.amazonaws.com/dev/java-sdk-generator:${{ inputs.version }}-$SANITIZED_BRANCH-${{ github.sha }}


### PR DESCRIPTION
## Description
Added support for CI action to be run from triggers other than branch pushes

## Testing
CI
