### PR TITLE
fix(ci): Only push to ECR on manual publish

### DIFF
--- a/.github/workflows/publish-generator-java-sdk.yml
+++ b/.github/workflows/publish-generator-java-sdk.yml
@@ -45,11 +45,13 @@ jobs:
           fern-token: ${{ secrets.FERN_TOKEN }}
           docker-pwd: ${{ secrets.FERN_API_DOCKERHUB_PASSWORD }}
       - name: Configure AWS Credentials
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: "arn:aws:iam::985111089818:role/github-ci"
           aws-region: "us-east-1"
       - name: Upload to ECR for scanning
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |-
           aws sts get-caller-identity
           docker pull fernapi/fern-java-sdk:${{ inputs.version }}


### PR DESCRIPTION
## Description
We really only need to run this when working on image hardening. 

## Changes Made
Conditionally trigger ECR push on manual publish

## Testing
No changes to behavior, just not running a new CI feature on automated runs (how it was before my PR)
