### PR TITLE
fix(ruby): add missing # in README error handling string interpolation

### DIFF
--- a/generators/ruby-v2/sdk/src/readme/ReadmeSnippetBuilder.ts
+++ b/generators/ruby-v2/sdk/src/readme/ReadmeSnippetBuilder.ts
@@ -185,9 +185,9 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
             rescue ${this.rootPackageClientName}::Errors::ServerError
                 puts "API returned some other 5xx status, this is probably a bug"
             rescue ${this.rootPackageClientName}::Errors::ResponseError => e
-                puts "API returned an unexpected status other than 5xx: #{e.code} {e.message}"
+                puts "API returned an unexpected status other than 5xx: #{e.code} #{e.message}"
             rescue ${this.rootPackageClientName}::Errors::ApiError => e
-                puts "Some other error occurred when calling the API: {e.message}"
+                puts "Some other error occurred when calling the API: #{e.message}"
             end
         `);
     }


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)