### PR TITLE
fix(ruby): use snake_case for property names in dynamic snippets

### DIFF
--- a/generators/ruby-v2/dynamic-snippets/src/__test__/__snapshots__/DynamicSnippetsGenerator.test.ts.snap
+++ b/generators/ruby-v2/dynamic-snippets/src/__test__/__snapshots__/DynamicSnippetsGenerator.test.ts.snap
@@ -8,7 +8,7 @@ client = Acme::Client.new(token: '<YOUR_API_KEY>');
 client.service.get_metadata(
   shallow: false,
   tag: ['development', 'public'],
-  xAPIVersion: '0.0.1'
+  x_api_version: '0.0.1'
 );
 "
 `;
@@ -160,7 +160,7 @@ client = Acme::Client.new();
 
 client.service.just_file_with_query_params(
   integer: 42,
-  maybeString: 'exists'
+  maybe_string: 'exists'
 );
 "
 `;
@@ -214,7 +214,7 @@ client = Acme::Client.new(
   environment: Acme::Environment::PRODUCTION
 );
 
-client.s3.get_presigned_url(s3Key: 'xyz');
+client.s3.get_presigned_url(s3key: 'xyz');
 "
 `;
 
@@ -226,7 +226,7 @@ client = Acme::Client.new(
   environment: Acme::Environment::STAGING
 );
 
-client.s3.get_presigned_url(s3Key: 'xyz');
+client.s3.get_presigned_url(s3key: 'xyz');
 "
 `;
 

--- a/generators/ruby-v2/dynamic-snippets/src/context/DynamicSnippetsGeneratorContext.ts
+++ b/generators/ruby-v2/dynamic-snippets/src/context/DynamicSnippetsGeneratorContext.ts
@@ -89,7 +89,7 @@ export class DynamicSnippetsGeneratorContext extends AbstractDynamicSnippetsGene
     }
 
     public getPropertyName(name: FernIr.Name): string {
-        return this.getName(name.camelCase.safeName);
+        return this.getName(name.snakeCase.safeName);
     }
 
     private getName(name: string): string {


### PR DESCRIPTION
## Summary
- Fix dynamic snippet generator to use `snake_case` for property names instead of `camelCase`
- Ruby convention uses snake_case for all parameter/property names

The issue was in `DynamicSnippetsGeneratorContext.ts` where `getPropertyName()` was using `camelCase.safeName` instead of `snakeCase.safeName`.

## Test plan
- Generated README snippets will now show `processing_terminal_id:` instead of `processingTerminalId:`

🤖 Generated with [Claude Code](https://claude.com/claude-code)