### PR TITLE
fix(ruby): improve README snippet generation

### DIFF
--- a/generators/ruby-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/ruby-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -419,10 +419,15 @@ export class EndpointSnippetGenerator {
                 ignoreMissingParameters: true
             });
             for (const parameter of associated) {
+                const value = this.context.dynamicTypeLiteralMapper.convert(parameter);
+                // Skip nop values (undefined/null) to avoid generating empty arguments like "channel: ,"
+                if (ruby.TypeLiteral.isNop(value)) {
+                    continue;
+                }
                 args.push(
                     ruby.keywordArgument({
                         name: this.context.getPropertyName(parameter.name.name),
-                        value: this.context.dynamicTypeLiteralMapper.convert(parameter)
+                        value
                     })
                 );
             }
@@ -445,10 +450,15 @@ export class EndpointSnippetGenerator {
             values: this.context.getRecord(snippet.requestBody) ?? {}
         });
         for (const parameter of bodyProperties) {
+            const value = this.context.dynamicTypeLiteralMapper.convert(parameter);
+            // Skip nop values (undefined/null) to avoid generating empty arguments like "channel: ,"
+            if (ruby.TypeLiteral.isNop(value)) {
+                continue;
+            }
             args.push(
                 ruby.keywordArgument({
                     name: this.context.getPropertyName(parameter.name.name),
-                    value: this.context.dynamicTypeLiteralMapper.convert(parameter)
+                    value
                 })
             );
         }

--- a/generators/ruby-v2/dynamic-snippets/src/__test__/__snapshots__/DynamicSnippetsGenerator.test.ts.snap
+++ b/generators/ruby-v2/dynamic-snippets/src/__test__/__snapshots__/DynamicSnippetsGenerator.test.ts.snap
@@ -31,7 +31,7 @@ exports[`snippets (default) > examples > 'POST /big-entity (simple)' 1`] = `
 client = Acme::Client.new(token: '<YOUR_API_KEY>');
 
 client.service.create_big_entity({
-  extendedMovie: {
+  extended_movie: {
     cast: ['John Travolta', 'Samuel L. Jackson', 'Uma Thurman', 'Bruce Willis'],
     id: 'movie-sda231x',
     title: 'Pulp Fiction',
@@ -249,8 +249,8 @@ client.nullable.create_user(
   username: 'john.doe',
   tags: ['admin'],
   metadata: {
-    createdAt: '1980-01-01T00:00:00Z',
-    updatedAt: '1980-01-01T00:00:00Z',
+    created_at: '1980-01-01T00:00:00Z',
+    updated_at: '1980-01-01T00:00:00Z',
     avatar: nil,
     activated: nil
   },

--- a/generators/ruby-v2/dynamic-snippets/src/context/DynamicToLiteralMapper.ts
+++ b/generators/ruby-v2/dynamic-snippets/src/context/DynamicToLiteralMapper.ts
@@ -272,8 +272,10 @@ export class DynamicTypeLiteralMapper {
                 this.context.errors.scope(key);
                 const property = object.properties.find((p) => p.name.wireValue === key);
                 const typeReference = property?.typeReference ?? { type: "unknown" };
+                // Use snake_case property name for Ruby, falling back to wire value if not found
+                const propertyName = property?.name.name.snakeCase.safeName ?? key;
                 const astNode = {
-                    key: ruby.TypeLiteral.string(key),
+                    key: ruby.TypeLiteral.string(propertyName),
                     value: this.convert({ typeReference, value: val })
                 };
                 this.context.errors.unscope();

--- a/generators/ruby-v2/sdk/src/readme/ReadmeSnippetBuilder.ts
+++ b/generators/ruby-v2/sdk/src/readme/ReadmeSnippetBuilder.ts
@@ -365,7 +365,7 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
             return undefined;
         }
 
-        return `${this.rootPackageClientName}::Environment::${defaultEnvironment.name.pascalCase.unsafeName}`;
+        return `${this.rootPackageClientName}::Environment::${defaultEnvironment.name.screamingSnakeCase.safeName}`;
     }
 
     private getRootPackageClientName(): string {

--- a/generators/ruby-v2/sdk/versions.yml
+++ b/generators/ruby-v2/sdk/versions.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.0.0-rc46
+  createdAt: "2025-11-26"
+  changelogEntry:
+    - type: fix
+      summary: |
+        Improve README snippet generation: use SCREAMING_SNAKE_CASE for Environment references,
+        snake_case for nested object property names, and filter out empty/undefined values to
+        avoid syntax errors like "param: ,".
+  irVersion: 61
+
 - version: 1.0.0-rc45
   createdAt: "2025-11-26"
   changelogEntry:


### PR DESCRIPTION
## Summary

Three fixes for README snippet generation:

### 1. Environment reference casing
**File:** `sdk/src/readme/ReadmeSnippetBuilder.ts:368`

Changed from `pascalCase.unsafeName` to `screamingSnakeCase.safeName` to match the generated Environment class constants.

```ruby
# Before
base_url: Payroc::Environment::Production

# After  
base_url: Payroc::Environment::PRODUCTION
```

### 2. Nested object properties use snake_case
**File:** `dynamic-snippets/src/context/DynamicToLiteralMapper.ts:276`

Hash keys in dynamic snippets now use snake_case instead of camelCase wire values.

```ruby
# Before
order: { orderId: 'OrderRef6543', firstName: 'Sarah' }

# After
order: { order_id: 'OrderRef6543', first_name: 'Sarah' }
```

### 3. Skip empty/undefined values
**File:** `dynamic-snippets/src/EndpointSnippetGenerator.ts:421-432, 452-463`

Filter out nop (undefined/null) values when generating keyword arguments to avoid syntax errors.

```ruby
# Before (syntax error)
channel: ,
payment_method: ,

# After (omitted entirely)
# These parameters are simply not included in the snippet
```

## Test plan
- Regenerate a Ruby SDK with multi-URL environments and verify the README looks correct
- Environment references should use SCREAMING_SNAKE_CASE
- Nested objects should use snake_case keys
- No empty values like `param: ,` should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)