### PR TITLE
fix(typescript): implement NoOpAuthProvider to prevent infinite recursion

### DIFF
--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.34.2
+  changelogEntry:
+    - summary: |
+        Avoid infinite recursion when an auth client is incorrectly configured to use itself for authentication.
+        To circumvent the infinite recursion, auth providers receive a no-op auth provider when constructing themselves.
+      type: fix
+  createdAt: "2025-11-26"
+  irVersion: 61
+
 - version: 3.34.1
   changelogEntry:
     - summary: |

--- a/generators/typescript/utils/commons/src/core-utilities/Auth.ts
+++ b/generators/typescript/utils/commons/src/core-utilities/Auth.ts
@@ -30,6 +30,10 @@ export interface Auth {
             getReturnTypeNode: () => ts.TypeNode;
         };
     };
+
+    NoOpAuthProvider: {
+        _getReferenceTo: () => ts.Expression;
+    };
 }
 
 export const MANIFEST: CoreUtility.Manifest = {
@@ -158,5 +162,12 @@ export class AuthImpl extends CoreUtility implements Auth {
                     this.AuthRequest._getReferenceToType()
                 ])
         }
+    };
+
+    public readonly NoOpAuthProvider = {
+        _getReferenceTo: this.withExportedName(
+            "NoOpAuthProvider",
+            (NoOpAuthProvider) => () => NoOpAuthProvider.getExpression()
+        )
     };
 }

--- a/generators/typescript/utils/core-utilities/src/core/auth/NoOpAuthProvider.ts
+++ b/generators/typescript/utils/core-utilities/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider";
+import type { AuthRequest } from "./AuthRequest";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/generators/typescript/utils/core-utilities/src/core/auth/index.ts
+++ b/generators/typescript/utils/core-utilities/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider";
 export type { AuthRequest } from "./AuthRequest";
 export { BasicAuth } from "./BasicAuth";
 export { BearerToken } from "./BearerToken";
+export { NoOpAuthProvider } from "./NoOpAuthProvider";

--- a/seed/ts-sdk/accept-header/src/BaseClient.ts
+++ b/seed/ts-sdk/accept-header/src/BaseClient.ts
@@ -67,6 +67,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/accept-header/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/accept-header/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/accept-header/src/core/auth/index.ts
+++ b/seed/ts-sdk/accept-header/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/any-auth/generate-endpoint-metadata/src/BaseClient.ts
+++ b/seed/ts-sdk/any-auth/generate-endpoint-metadata/src/BaseClient.ts
@@ -73,18 +73,28 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= (() => {
         const authProviders: core.AuthProvider[] = [];
-        if (BearerAuthProvider.canCreate(options)) {
-            authProviders.push(new BearerAuthProvider(options));
+        if (BearerAuthProvider.canCreate(normalizedWithNoOpAuthProvider)) {
+            authProviders.push(new BearerAuthProvider(normalizedWithNoOpAuthProvider));
         }
-        if (HeaderAuthProvider.canCreate(options)) {
-            authProviders.push(new HeaderAuthProvider(options));
+        if (HeaderAuthProvider.canCreate(normalizedWithNoOpAuthProvider)) {
+            authProviders.push(new HeaderAuthProvider(normalizedWithNoOpAuthProvider));
         }
-        if (OAuthAuthProvider.canCreate(options)) {
-            authProviders.push(new OAuthAuthProvider(options));
+        if (OAuthAuthProvider.canCreate(normalizedWithNoOpAuthProvider)) {
+            authProviders.push(new OAuthAuthProvider(normalizedWithNoOpAuthProvider));
         }
         return new AnyAuthProvider(authProviders);
     })();
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/any-auth/generate-endpoint-metadata/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/any-auth/generate-endpoint-metadata/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/any-auth/generate-endpoint-metadata/src/core/auth/index.ts
+++ b/seed/ts-sdk/any-auth/generate-endpoint-metadata/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/any-auth/no-custom-config/src/BaseClient.ts
+++ b/seed/ts-sdk/any-auth/no-custom-config/src/BaseClient.ts
@@ -73,18 +73,28 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= (() => {
         const authProviders: core.AuthProvider[] = [];
-        if (BearerAuthProvider.canCreate(options)) {
-            authProviders.push(new BearerAuthProvider(options));
+        if (BearerAuthProvider.canCreate(normalizedWithNoOpAuthProvider)) {
+            authProviders.push(new BearerAuthProvider(normalizedWithNoOpAuthProvider));
         }
-        if (HeaderAuthProvider.canCreate(options)) {
-            authProviders.push(new HeaderAuthProvider(options));
+        if (HeaderAuthProvider.canCreate(normalizedWithNoOpAuthProvider)) {
+            authProviders.push(new HeaderAuthProvider(normalizedWithNoOpAuthProvider));
         }
-        if (OAuthAuthProvider.canCreate(options)) {
-            authProviders.push(new OAuthAuthProvider(options));
+        if (OAuthAuthProvider.canCreate(normalizedWithNoOpAuthProvider)) {
+            authProviders.push(new OAuthAuthProvider(normalizedWithNoOpAuthProvider));
         }
         return new AnyAuthProvider(authProviders);
     })();
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/any-auth/no-custom-config/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/any-auth/no-custom-config/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/any-auth/no-custom-config/src/core/auth/index.ts
+++ b/seed/ts-sdk/any-auth/no-custom-config/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/basic-auth-environment-variables/src/BaseClient.ts
+++ b/seed/ts-sdk/basic-auth-environment-variables/src/BaseClient.ts
@@ -68,6 +68,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BasicAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BasicAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/basic-auth-environment-variables/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/basic-auth-environment-variables/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/basic-auth-environment-variables/src/core/auth/index.ts
+++ b/seed/ts-sdk/basic-auth-environment-variables/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/basic-auth/src/BaseClient.ts
+++ b/seed/ts-sdk/basic-auth/src/BaseClient.ts
@@ -68,6 +68,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BasicAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BasicAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/basic-auth/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/basic-auth/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/basic-auth/src/core/auth/index.ts
+++ b/seed/ts-sdk/basic-auth/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/bearer-token-environment-variable/src/BaseClient.ts
+++ b/seed/ts-sdk/bearer-token-environment-variable/src/BaseClient.ts
@@ -72,6 +72,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/bearer-token-environment-variable/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/bearer-token-environment-variable/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/bearer-token-environment-variable/src/core/auth/index.ts
+++ b/seed/ts-sdk/bearer-token-environment-variable/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/client-side-params/src/BaseClient.ts
+++ b/seed/ts-sdk/client-side-params/src/BaseClient.ts
@@ -67,6 +67,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/client-side-params/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/client-side-params/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/client-side-params/src/core/auth/index.ts
+++ b/seed/ts-sdk/client-side-params/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/examples/examples-with-api-reference/src/BaseClient.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/src/BaseClient.ts
@@ -68,6 +68,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/examples/examples-with-api-reference/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/examples/examples-with-api-reference/src/core/auth/index.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/examples/retain-original-casing/src/BaseClient.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/src/BaseClient.ts
@@ -68,6 +68,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/examples/retain-original-casing/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/examples/retain-original-casing/src/core/auth/index.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/BaseClient.ts
@@ -67,6 +67,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/core/auth/index.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/BaseClient.ts
@@ -67,6 +67,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/core/auth/index.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/exhaustive/bigint/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/BaseClient.ts
@@ -67,6 +67,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/exhaustive/bigint/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/exhaustive/bigint/src/core/auth/index.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/BaseClient.ts
@@ -67,6 +67,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/core/auth/index.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/BaseClient.ts
@@ -67,6 +67,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/core/auth/index.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/BaseClient.js
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/BaseClient.js
@@ -50,6 +50,10 @@ function normalizeClientOptions(options) {
 function normalizeClientOptionsWithAuth(options) {
     var _a;
     const normalized = normalizeClientOptions(options);
-    (_a = normalized.authProvider) !== null && _a !== void 0 ? _a : (normalized.authProvider = new BearerAuthProvider_js_1.BearerAuthProvider(options));
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    (_a = normalized.authProvider) !== null && _a !== void 0 ? _a : (normalized.authProvider = new BearerAuthProvider_js_1.BearerAuthProvider(normalizedWithNoOpAuthProvider));
     return normalized;
+}
+function withNoOpAuthProvider(options) {
+    return Object.assign(Object.assign({}, options), { authProvider: new core.NoOpAuthProvider() });
 }

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/core/auth/NoOpAuthProvider.d.ts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/core/auth/NoOpAuthProvider.d.ts
@@ -1,0 +1,5 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+export declare class NoOpAuthProvider implements AuthProvider {
+    getAuthRequest(): Promise<AuthRequest>;
+}

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/core/auth/NoOpAuthProvider.js
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/core/auth/NoOpAuthProvider.js
@@ -1,0 +1,9 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.NoOpAuthProvider = void 0;
+class NoOpAuthProvider {
+    getAuthRequest() {
+        return Promise.resolve({ headers: {} });
+    }
+}
+exports.NoOpAuthProvider = NoOpAuthProvider;

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/core/auth/index.d.ts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/core/auth/index.d.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/core/auth/index.js
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/core/auth/index.js
@@ -1,7 +1,9 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.BearerToken = exports.BasicAuth = void 0;
+exports.NoOpAuthProvider = exports.BearerToken = exports.BasicAuth = void 0;
 var BasicAuth_js_1 = require("./BasicAuth.js");
 Object.defineProperty(exports, "BasicAuth", { enumerable: true, get: function () { return BasicAuth_js_1.BasicAuth; } });
 var BearerToken_js_1 = require("./BearerToken.js");
 Object.defineProperty(exports, "BearerToken", { enumerable: true, get: function () { return BearerToken_js_1.BearerToken; } });
+var NoOpAuthProvider_js_1 = require("./NoOpAuthProvider.js");
+Object.defineProperty(exports, "NoOpAuthProvider", { enumerable: true, get: function () { return NoOpAuthProvider_js_1.NoOpAuthProvider; } });

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/BaseClient.mjs
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/BaseClient.mjs
@@ -13,6 +13,10 @@ export function normalizeClientOptions(options) {
 export function normalizeClientOptionsWithAuth(options) {
     var _a;
     const normalized = normalizeClientOptions(options);
-    (_a = normalized.authProvider) !== null && _a !== void 0 ? _a : (normalized.authProvider = new BearerAuthProvider(options));
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    (_a = normalized.authProvider) !== null && _a !== void 0 ? _a : (normalized.authProvider = new BearerAuthProvider(normalizedWithNoOpAuthProvider));
     return normalized;
+}
+function withNoOpAuthProvider(options) {
+    return Object.assign(Object.assign({}, options), { authProvider: new core.NoOpAuthProvider() });
 }

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/core/auth/NoOpAuthProvider.d.mts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/core/auth/NoOpAuthProvider.d.mts
@@ -1,0 +1,5 @@
+import type { AuthProvider } from "./AuthProvider.mjs";
+import type { AuthRequest } from "./AuthRequest.mjs";
+export declare class NoOpAuthProvider implements AuthProvider {
+    getAuthRequest(): Promise<AuthRequest>;
+}

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/core/auth/NoOpAuthProvider.mjs
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/core/auth/NoOpAuthProvider.mjs
@@ -1,0 +1,5 @@
+export class NoOpAuthProvider {
+    getAuthRequest() {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/core/auth/index.d.mts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/core/auth/index.d.mts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.mjs";
 export type { AuthRequest } from "./AuthRequest.mjs";
 export { BasicAuth } from "./BasicAuth.mjs";
 export { BearerToken } from "./BearerToken.mjs";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.mjs";

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/core/auth/index.mjs
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/core/auth/index.mjs
@@ -1,2 +1,3 @@
 export { BasicAuth } from "./BasicAuth.mjs";
 export { BearerToken } from "./BearerToken.mjs";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.mjs";

--- a/seed/ts-sdk/exhaustive/local-files/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/local-files/BaseClient.ts
@@ -64,6 +64,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/exhaustive/local-files/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/exhaustive/local-files/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/exhaustive/local-files/core/auth/index.ts
+++ b/seed/ts-sdk/exhaustive/local-files/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/BaseClient.ts
@@ -67,6 +67,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/core/auth/index.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/exhaustive/never-throw-errors/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/src/BaseClient.ts
@@ -67,6 +67,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/exhaustive/never-throw-errors/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/exhaustive/never-throw-errors/src/core/auth/index.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/BaseClient.ts
@@ -67,6 +67,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/core/auth/index.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/exhaustive/node-fetch/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/BaseClient.ts
@@ -67,6 +67,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/exhaustive/node-fetch/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/exhaustive/node-fetch/src/core/auth/index.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/BaseClient.ts
@@ -67,6 +67,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/core/auth/index.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/BaseClient.ts
@@ -67,6 +67,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/core/auth/index.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/BaseClient.ts
@@ -67,6 +67,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/core/auth/index.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/BaseClient.ts
@@ -67,6 +67,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/core/auth/index.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/BaseClient.ts
@@ -67,6 +67,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/core/auth/index.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/BaseClient.ts
@@ -67,6 +67,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/core/auth/index.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/exhaustive/serde-layer/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/BaseClient.ts
@@ -67,6 +67,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/exhaustive/serde-layer/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/exhaustive/serde-layer/src/core/auth/index.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/exhaustive/use-jest/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/BaseClient.ts
@@ -67,6 +67,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/exhaustive/use-jest/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/exhaustive/use-jest/src/core/auth/index.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/BaseClient.ts
@@ -67,6 +67,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/core/auth/index.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/exhaustive/with-audiences/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/with-audiences/src/BaseClient.ts
@@ -67,6 +67,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/exhaustive/with-audiences/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/exhaustive/with-audiences/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/exhaustive/with-audiences/src/core/auth/index.ts
+++ b/seed/ts-sdk/exhaustive/with-audiences/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/header-auth-environment-variable/src/BaseClient.ts
+++ b/seed/ts-sdk/header-auth-environment-variable/src/BaseClient.ts
@@ -67,6 +67,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new HeaderAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new HeaderAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/header-auth-environment-variable/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/header-auth-environment-variable/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/header-auth-environment-variable/src/core/auth/index.ts
+++ b/seed/ts-sdk/header-auth-environment-variable/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/header-auth/src/BaseClient.ts
+++ b/seed/ts-sdk/header-auth/src/BaseClient.ts
@@ -67,6 +67,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new HeaderAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new HeaderAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/header-auth/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/header-auth/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/header-auth/src/core/auth/index.ts
+++ b/seed/ts-sdk/header-auth/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/idempotency-headers/src/BaseClient.ts
+++ b/seed/ts-sdk/idempotency-headers/src/BaseClient.ts
@@ -72,6 +72,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/idempotency-headers/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/idempotency-headers/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/idempotency-headers/src/core/auth/index.ts
+++ b/seed/ts-sdk/idempotency-headers/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/imdb/branded-string-aliases/src/BaseClient.ts
+++ b/seed/ts-sdk/imdb/branded-string-aliases/src/BaseClient.ts
@@ -67,6 +67,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/imdb/branded-string-aliases/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/imdb/branded-string-aliases/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/imdb/branded-string-aliases/src/core/auth/index.ts
+++ b/seed/ts-sdk/imdb/branded-string-aliases/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/imdb/no-custom-config/src/BaseClient.ts
+++ b/seed/ts-sdk/imdb/no-custom-config/src/BaseClient.ts
@@ -67,6 +67,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/imdb/no-custom-config/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/imdb/no-custom-config/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/imdb/no-custom-config/src/core/auth/index.ts
+++ b/seed/ts-sdk/imdb/no-custom-config/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/imdb/omit-undefined/src/BaseClient.ts
+++ b/seed/ts-sdk/imdb/omit-undefined/src/BaseClient.ts
@@ -67,6 +67,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/imdb/omit-undefined/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/imdb/omit-undefined/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/imdb/omit-undefined/src/core/auth/index.ts
+++ b/seed/ts-sdk/imdb/omit-undefined/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/inferred-auth-explicit/src/BaseClient.ts
+++ b/seed/ts-sdk/inferred-auth-explicit/src/BaseClient.ts
@@ -70,6 +70,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new InferredAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new InferredAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/inferred-auth-explicit/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/inferred-auth-explicit/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/inferred-auth-explicit/src/core/auth/index.ts
+++ b/seed/ts-sdk/inferred-auth-explicit/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/inferred-auth-implicit-no-expiry/src/BaseClient.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-no-expiry/src/BaseClient.ts
@@ -70,6 +70,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new InferredAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new InferredAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/inferred-auth-implicit-no-expiry/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-no-expiry/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/inferred-auth-implicit-no-expiry/src/core/auth/index.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-no-expiry/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/inferred-auth-implicit/src/BaseClient.ts
+++ b/seed/ts-sdk/inferred-auth-implicit/src/BaseClient.ts
@@ -70,6 +70,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new InferredAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new InferredAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/inferred-auth-implicit/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/inferred-auth-implicit/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/inferred-auth-implicit/src/core/auth/index.ts
+++ b/seed/ts-sdk/inferred-auth-implicit/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/multi-url-environment-no-default/src/BaseClient.ts
+++ b/seed/ts-sdk/multi-url-environment-no-default/src/BaseClient.ts
@@ -71,6 +71,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/multi-url-environment-no-default/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/multi-url-environment-no-default/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/multi-url-environment-no-default/src/core/auth/index.ts
+++ b/seed/ts-sdk/multi-url-environment-no-default/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/multi-url-environment/src/BaseClient.ts
+++ b/seed/ts-sdk/multi-url-environment/src/BaseClient.ts
@@ -70,6 +70,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/multi-url-environment/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/multi-url-environment/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/multi-url-environment/src/core/auth/index.ts
+++ b/seed/ts-sdk/multi-url-environment/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/multiple-request-bodies/src/BaseClient.ts
+++ b/seed/ts-sdk/multiple-request-bodies/src/BaseClient.ts
@@ -68,6 +68,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/multiple-request-bodies/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/multiple-request-bodies/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/multiple-request-bodies/src/core/auth/index.ts
+++ b/seed/ts-sdk/multiple-request-bodies/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/no-environment/src/BaseClient.ts
+++ b/seed/ts-sdk/no-environment/src/BaseClient.ts
@@ -67,6 +67,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/no-environment/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/no-environment/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/no-environment/src/core/auth/index.ts
+++ b/seed/ts-sdk/no-environment/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/oauth-client-credentials-custom/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials-custom/src/BaseClient.ts
@@ -68,6 +68,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new OAuthAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new OAuthAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/oauth-client-credentials-custom/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/oauth-client-credentials-custom/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/oauth-client-credentials-custom/src/core/auth/index.ts
+++ b/seed/ts-sdk/oauth-client-credentials-custom/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/oauth-client-credentials-default/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials-default/src/BaseClient.ts
@@ -68,6 +68,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new OAuthAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new OAuthAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/oauth-client-credentials-default/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/oauth-client-credentials-default/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/oauth-client-credentials-default/src/core/auth/index.ts
+++ b/seed/ts-sdk/oauth-client-credentials-default/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/src/BaseClient.ts
@@ -68,6 +68,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new OAuthAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new OAuthAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/src/core/auth/index.ts
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/BaseClient.ts
@@ -68,6 +68,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new OAuthAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new OAuthAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/core/auth/index.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/BaseClient.ts
@@ -68,6 +68,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new OAuthAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new OAuthAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/core/auth/index.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/oauth-client-credentials-with-variables/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials-with-variables/src/BaseClient.ts
@@ -69,6 +69,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new OAuthAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new OAuthAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/oauth-client-credentials-with-variables/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/oauth-client-credentials-with-variables/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/oauth-client-credentials-with-variables/src/core/auth/index.ts
+++ b/seed/ts-sdk/oauth-client-credentials-with-variables/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/oauth-client-credentials/no-custom-config/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials/no-custom-config/src/BaseClient.ts
@@ -68,6 +68,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new OAuthAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new OAuthAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/oauth-client-credentials/no-custom-config/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/oauth-client-credentials/no-custom-config/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/oauth-client-credentials/no-custom-config/src/core/auth/index.ts
+++ b/seed/ts-sdk/oauth-client-credentials/no-custom-config/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/oauth-client-credentials/serde/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials/serde/src/BaseClient.ts
@@ -68,6 +68,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new OAuthAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new OAuthAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/oauth-client-credentials/serde/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/oauth-client-credentials/serde/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/oauth-client-credentials/serde/src/core/auth/index.ts
+++ b/seed/ts-sdk/oauth-client-credentials/serde/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/pagination-custom/src/BaseClient.ts
+++ b/seed/ts-sdk/pagination-custom/src/BaseClient.ts
@@ -67,6 +67,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/pagination-custom/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/pagination-custom/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/pagination-custom/src/core/auth/index.ts
+++ b/seed/ts-sdk/pagination-custom/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/pagination/no-custom-config/src/BaseClient.ts
+++ b/seed/ts-sdk/pagination/no-custom-config/src/BaseClient.ts
@@ -67,6 +67,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/pagination/no-custom-config/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/pagination/no-custom-config/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/pagination/no-custom-config/src/core/auth/index.ts
+++ b/seed/ts-sdk/pagination/no-custom-config/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/pagination/page-index-semantics/src/BaseClient.ts
+++ b/seed/ts-sdk/pagination/page-index-semantics/src/BaseClient.ts
@@ -67,6 +67,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/pagination/page-index-semantics/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/pagination/page-index-semantics/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/pagination/page-index-semantics/src/core/auth/index.ts
+++ b/seed/ts-sdk/pagination/page-index-semantics/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/simple-api/allow-custom-fetcher/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/allow-custom-fetcher/src/BaseClient.ts
@@ -69,6 +69,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/simple-api/allow-custom-fetcher/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/simple-api/allow-custom-fetcher/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/simple-api/allow-custom-fetcher/src/core/auth/index.ts
+++ b/seed/ts-sdk/simple-api/allow-custom-fetcher/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/simple-api/allow-extra-fields/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/allow-extra-fields/src/BaseClient.ts
@@ -68,6 +68,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/simple-api/allow-extra-fields/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/simple-api/allow-extra-fields/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/simple-api/allow-extra-fields/src/core/auth/index.ts
+++ b/seed/ts-sdk/simple-api/allow-extra-fields/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/simple-api/bundle/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/bundle/src/BaseClient.ts
@@ -68,6 +68,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/simple-api/bundle/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/simple-api/bundle/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/simple-api/bundle/src/core/auth/index.ts
+++ b/seed/ts-sdk/simple-api/bundle/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/simple-api/custom-package-json/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/custom-package-json/src/BaseClient.ts
@@ -68,6 +68,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/simple-api/custom-package-json/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/simple-api/custom-package-json/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/simple-api/custom-package-json/src/core/auth/index.ts
+++ b/seed/ts-sdk/simple-api/custom-package-json/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/simple-api/jsr/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/jsr/src/BaseClient.ts
@@ -68,6 +68,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/simple-api/jsr/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/simple-api/jsr/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/simple-api/jsr/src/core/auth/index.ts
+++ b/seed/ts-sdk/simple-api/jsr/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/simple-api/legacy-exports/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/legacy-exports/src/BaseClient.ts
@@ -68,6 +68,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/simple-api/legacy-exports/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/simple-api/legacy-exports/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider";
+import type { AuthRequest } from "./AuthRequest";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/simple-api/legacy-exports/src/core/auth/index.ts
+++ b/seed/ts-sdk/simple-api/legacy-exports/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider";
 export type { AuthRequest } from "./AuthRequest";
 export { BasicAuth } from "./BasicAuth";
 export { BearerToken } from "./BearerToken";
+export { NoOpAuthProvider } from "./NoOpAuthProvider";

--- a/seed/ts-sdk/simple-api/no-custom-config/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/no-custom-config/src/BaseClient.ts
@@ -68,6 +68,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/simple-api/no-custom-config/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/simple-api/no-custom-config/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/simple-api/no-custom-config/src/core/auth/index.ts
+++ b/seed/ts-sdk/simple-api/no-custom-config/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/simple-api/no-linter/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/no-linter/src/BaseClient.ts
@@ -69,6 +69,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/simple-api/no-linter/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/simple-api/no-linter/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/simple-api/no-linter/src/core/auth/index.ts
+++ b/seed/ts-sdk/simple-api/no-linter/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/simple-api/no-scripts/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/no-scripts/src/BaseClient.ts
@@ -64,6 +64,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider()
+    };
 }

--- a/seed/ts-sdk/simple-api/no-scripts/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/simple-api/no-scripts/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/simple-api/no-scripts/src/core/auth/index.ts
+++ b/seed/ts-sdk/simple-api/no-scripts/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/simple-api/oidc-token/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/oidc-token/src/BaseClient.ts
@@ -68,6 +68,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/simple-api/oidc-token/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/simple-api/oidc-token/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/simple-api/oidc-token/src/core/auth/index.ts
+++ b/seed/ts-sdk/simple-api/oidc-token/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/simple-api/omit-fern-headers/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/omit-fern-headers/src/BaseClient.ts
@@ -54,6 +54,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/simple-api/omit-fern-headers/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/simple-api/omit-fern-headers/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/simple-api/omit-fern-headers/src/core/auth/index.ts
+++ b/seed/ts-sdk/simple-api/omit-fern-headers/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/simple-api/use-oxfmt/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/use-oxfmt/src/BaseClient.ts
@@ -68,6 +68,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/simple-api/use-oxfmt/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/simple-api/use-oxfmt/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/simple-api/use-oxfmt/src/core/auth/index.ts
+++ b/seed/ts-sdk/simple-api/use-oxfmt/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/simple-api/use-oxlint/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/use-oxlint/src/BaseClient.ts
@@ -69,6 +69,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/simple-api/use-oxlint/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/simple-api/use-oxlint/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/simple-api/use-oxlint/src/core/auth/index.ts
+++ b/seed/ts-sdk/simple-api/use-oxlint/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/simple-api/use-prettier-no-linter/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/use-prettier-no-linter/src/BaseClient.ts
@@ -69,6 +69,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/simple-api/use-prettier-no-linter/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/simple-api/use-prettier-no-linter/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/simple-api/use-prettier-no-linter/src/core/auth/index.ts
+++ b/seed/ts-sdk/simple-api/use-prettier-no-linter/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/simple-api/use-prettier/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/use-prettier/src/BaseClient.ts
@@ -68,6 +68,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/simple-api/use-prettier/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/simple-api/use-prettier/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/simple-api/use-prettier/src/core/auth/index.ts
+++ b/seed/ts-sdk/simple-api/use-prettier/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/simple-api/use-yarn/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/use-yarn/src/BaseClient.ts
@@ -68,6 +68,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/simple-api/use-yarn/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/simple-api/use-yarn/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/simple-api/use-yarn/src/core/auth/index.ts
+++ b/seed/ts-sdk/simple-api/use-yarn/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/single-url-environment-default/src/BaseClient.ts
+++ b/seed/ts-sdk/single-url-environment-default/src/BaseClient.ts
@@ -68,6 +68,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/single-url-environment-default/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/single-url-environment-default/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/single-url-environment-default/src/core/auth/index.ts
+++ b/seed/ts-sdk/single-url-environment-default/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/single-url-environment-no-default/src/BaseClient.ts
+++ b/seed/ts-sdk/single-url-environment-no-default/src/BaseClient.ts
@@ -68,6 +68,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/single-url-environment-no-default/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/single-url-environment-no-default/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/single-url-environment-no-default/src/core/auth/index.ts
+++ b/seed/ts-sdk/single-url-environment-no-default/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/trace/exhaustive/src/BaseClient.ts
+++ b/seed/ts-sdk/trace/exhaustive/src/BaseClient.ts
@@ -73,6 +73,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/trace/exhaustive/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/trace/exhaustive/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/trace/exhaustive/src/core/auth/index.ts
+++ b/seed/ts-sdk/trace/exhaustive/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/trace/no-custom-config/src/BaseClient.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/BaseClient.ts
@@ -73,6 +73,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/trace/no-custom-config/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/trace/no-custom-config/src/core/auth/index.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/trace/serde-no-throwing/src/BaseClient.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/src/BaseClient.ts
@@ -73,6 +73,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/trace/serde-no-throwing/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/trace/serde-no-throwing/src/core/auth/index.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/trace/serde/src/BaseClient.ts
+++ b/seed/ts-sdk/trace/serde/src/BaseClient.ts
@@ -73,6 +73,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/trace/serde/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/trace/serde/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/trace/serde/src/core/auth/index.ts
+++ b/seed/ts-sdk/trace/serde/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/ts-express-casing/src/BaseClient.ts
+++ b/seed/ts-sdk/ts-express-casing/src/BaseClient.ts
@@ -67,6 +67,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/ts-express-casing/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/ts-express-casing/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/ts-express-casing/src/core/auth/index.ts
+++ b/seed/ts-sdk/ts-express-casing/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/websocket-bearer-auth/websockets/src/BaseClient.ts
+++ b/seed/ts-sdk/websocket-bearer-auth/websockets/src/BaseClient.ts
@@ -67,6 +67,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new BearerAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/websocket-bearer-auth/websockets/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/websocket-bearer-auth/websockets/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/websocket-bearer-auth/websockets/src/core/auth/index.ts
+++ b/seed/ts-sdk/websocket-bearer-auth/websockets/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";

--- a/seed/ts-sdk/websocket-inferred-auth/websockets/src/BaseClient.ts
+++ b/seed/ts-sdk/websocket-inferred-auth/websockets/src/BaseClient.ts
@@ -70,6 +70,16 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
-    normalized.authProvider ??= new InferredAuthProvider(options);
+    const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
+    normalized.authProvider ??= new InferredAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;
+}
+
+function withNoOpAuthProvider<T extends BaseClientOptions>(
+    options: NormalizedClientOptions<T>,
+): NormalizedClientOptionsWithAuth<T> {
+    return {
+        ...options,
+        authProvider: new core.NoOpAuthProvider(),
+    };
 }

--- a/seed/ts-sdk/websocket-inferred-auth/websockets/src/core/auth/NoOpAuthProvider.ts
+++ b/seed/ts-sdk/websocket-inferred-auth/websockets/src/core/auth/NoOpAuthProvider.ts
@@ -1,0 +1,8 @@
+import type { AuthProvider } from "./AuthProvider.js";
+import type { AuthRequest } from "./AuthRequest.js";
+
+export class NoOpAuthProvider implements AuthProvider {
+    public getAuthRequest(): Promise<AuthRequest> {
+        return Promise.resolve({ headers: {} });
+    }
+}

--- a/seed/ts-sdk/websocket-inferred-auth/websockets/src/core/auth/index.ts
+++ b/seed/ts-sdk/websocket-inferred-auth/websockets/src/core/auth/index.ts
@@ -2,3 +2,4 @@ export type { AuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";
+export { NoOpAuthProvider } from "./NoOpAuthProvider.js";


### PR DESCRIPTION
## Description
Avoid infinite recursion when an auth client is incorrectly configured to use itself for authentication.
To circumvent the infinite recursion, auth providers receive a no-op auth provider when constructing themselves.

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated
- [x] Manual testing completed
