### PR TITLE
fix(java): handle array responses in paginated endpoints

### DIFF
--- a/seed/java-sdk/java-pagination-deep-cursor-path/java-pagination-deep-cursor-path/src/main/java/com/seed/deepCursorPath/resources/deepcursorpath/AsyncRawDeepCursorPathClient.java
+++ b/seed/java-sdk/java-pagination-deep-cursor-path/java-pagination-deep-cursor-path/src/main/java/com/seed/deepCursorPath/resources/deepcursorpath/AsyncRawDeepCursorPathClient.java
@@ -4,7 +4,6 @@
 package com.seed.deepCursorPath.resources.deepcursorpath;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.seed.deepCursorPath.core.ClientOptions;
 import com.seed.deepCursorPath.core.MediaTypes;
@@ -88,17 +87,10 @@ public class AsyncRawDeepCursorPathClient {
                         JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                         com.seed.deepCursorPath.resources.deepcursorpath.types.Response parsedResponse;
                         if (responseNode.isArray()) {
-                            List<String> items = ObjectMappers.JSON_MAPPER.convertValue(
-                                    responseNode, new TypeReference<List<String>>() {});
-                            parsedResponse = com.seed
-                                    .deepCursorPath
-                                    .resources
-                                    .deepcursorpath
-                                    .types
-                                    .Response
-                                    .builder()
-                                    .results(items)
-                                    .build();
+                            JsonNode wrapper =
+                                    ObjectMappers.JSON_MAPPER.createObjectNode().set("results", responseNode);
+                            parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                                    wrapper, com.seed.deepCursorPath.resources.deepcursorpath.types.Response.class);
                         } else {
                             parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
                                     responseNode,
@@ -191,17 +183,10 @@ public class AsyncRawDeepCursorPathClient {
                         JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                         com.seed.deepCursorPath.resources.deepcursorpath.types.Response parsedResponse;
                         if (responseNode.isArray()) {
-                            List<String> items = ObjectMappers.JSON_MAPPER.convertValue(
-                                    responseNode, new TypeReference<List<String>>() {});
-                            parsedResponse = com.seed
-                                    .deepCursorPath
-                                    .resources
-                                    .deepcursorpath
-                                    .types
-                                    .Response
-                                    .builder()
-                                    .results(items)
-                                    .build();
+                            JsonNode wrapper =
+                                    ObjectMappers.JSON_MAPPER.createObjectNode().set("results", responseNode);
+                            parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                                    wrapper, com.seed.deepCursorPath.resources.deepcursorpath.types.Response.class);
                         } else {
                             parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
                                     responseNode,
@@ -293,17 +278,10 @@ public class AsyncRawDeepCursorPathClient {
                         JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                         com.seed.deepCursorPath.resources.deepcursorpath.types.Response parsedResponse;
                         if (responseNode.isArray()) {
-                            List<String> items = ObjectMappers.JSON_MAPPER.convertValue(
-                                    responseNode, new TypeReference<List<String>>() {});
-                            parsedResponse = com.seed
-                                    .deepCursorPath
-                                    .resources
-                                    .deepcursorpath
-                                    .types
-                                    .Response
-                                    .builder()
-                                    .results(items)
-                                    .build();
+                            JsonNode wrapper =
+                                    ObjectMappers.JSON_MAPPER.createObjectNode().set("results", responseNode);
+                            parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                                    wrapper, com.seed.deepCursorPath.resources.deepcursorpath.types.Response.class);
                         } else {
                             parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
                                     responseNode,

--- a/seed/java-sdk/java-pagination-deep-cursor-path/java-pagination-deep-cursor-path/src/main/java/com/seed/deepCursorPath/resources/deepcursorpath/AsyncRawDeepCursorPathClient.java
+++ b/seed/java-sdk/java-pagination-deep-cursor-path/java-pagination-deep-cursor-path/src/main/java/com/seed/deepCursorPath/resources/deepcursorpath/AsyncRawDeepCursorPathClient.java
@@ -4,6 +4,8 @@
 package com.seed.deepCursorPath.resources.deepcursorpath;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.seed.deepCursorPath.core.ClientOptions;
 import com.seed.deepCursorPath.core.MediaTypes;
 import com.seed.deepCursorPath.core.ObjectMappers;
@@ -83,10 +85,25 @@ public class AsyncRawDeepCursorPathClient {
                 try (ResponseBody responseBody = response.body()) {
                     String responseBodyString = responseBody != null ? responseBody.string() : "{}";
                     if (response.isSuccessful()) {
-                        com.seed.deepCursorPath.resources.deepcursorpath.types.Response parsedResponse =
-                                ObjectMappers.JSON_MAPPER.readValue(
-                                        responseBodyString,
-                                        com.seed.deepCursorPath.resources.deepcursorpath.types.Response.class);
+                        JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                        com.seed.deepCursorPath.resources.deepcursorpath.types.Response parsedResponse;
+                        if (responseNode.isArray()) {
+                            List<String> items = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, new TypeReference<List<String>>() {});
+                            parsedResponse = com.seed
+                                    .deepCursorPath
+                                    .resources
+                                    .deepcursorpath
+                                    .types
+                                    .Response
+                                    .builder()
+                                    .results(items)
+                                    .build();
+                        } else {
+                            parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode,
+                                    com.seed.deepCursorPath.resources.deepcursorpath.types.Response.class);
+                        }
                         Optional<String> startingAfter = parsedResponse.getStartingAfter();
                         Optional<D> d = request.getB()
                                 .map(B::getC)
@@ -171,10 +188,25 @@ public class AsyncRawDeepCursorPathClient {
                 try (ResponseBody responseBody = response.body()) {
                     String responseBodyString = responseBody != null ? responseBody.string() : "{}";
                     if (response.isSuccessful()) {
-                        com.seed.deepCursorPath.resources.deepcursorpath.types.Response parsedResponse =
-                                ObjectMappers.JSON_MAPPER.readValue(
-                                        responseBodyString,
-                                        com.seed.deepCursorPath.resources.deepcursorpath.types.Response.class);
+                        JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                        com.seed.deepCursorPath.resources.deepcursorpath.types.Response parsedResponse;
+                        if (responseNode.isArray()) {
+                            List<String> items = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, new TypeReference<List<String>>() {});
+                            parsedResponse = com.seed
+                                    .deepCursorPath
+                                    .resources
+                                    .deepcursorpath
+                                    .types
+                                    .Response
+                                    .builder()
+                                    .results(items)
+                                    .build();
+                        } else {
+                            parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode,
+                                    com.seed.deepCursorPath.resources.deepcursorpath.types.Response.class);
+                        }
                         Optional<String> startingAfter = parsedResponse.getStartingAfter();
                         IndirectionRequired indirection = IndirectionRequired.builder()
                                 .from(com.seed.deepCursorPath.resources.deepcursorpath.types.IndirectionRequired)
@@ -258,10 +290,25 @@ public class AsyncRawDeepCursorPathClient {
                 try (ResponseBody responseBody = response.body()) {
                     String responseBodyString = responseBody != null ? responseBody.string() : "{}";
                     if (response.isSuccessful()) {
-                        com.seed.deepCursorPath.resources.deepcursorpath.types.Response parsedResponse =
-                                ObjectMappers.JSON_MAPPER.readValue(
-                                        responseBodyString,
-                                        com.seed.deepCursorPath.resources.deepcursorpath.types.Response.class);
+                        JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                        com.seed.deepCursorPath.resources.deepcursorpath.types.Response parsedResponse;
+                        if (responseNode.isArray()) {
+                            List<String> items = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, new TypeReference<List<String>>() {});
+                            parsedResponse = com.seed
+                                    .deepCursorPath
+                                    .resources
+                                    .deepcursorpath
+                                    .types
+                                    .Response
+                                    .builder()
+                                    .results(items)
+                                    .build();
+                        } else {
+                            parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode,
+                                    com.seed.deepCursorPath.resources.deepcursorpath.types.Response.class);
+                        }
                         Optional<String> startingAfter = parsedResponse.getStartingAfter();
                         Optional<InlineD> b = request.getB()
                                 .map(B::getC)

--- a/seed/java-sdk/java-pagination-deep-cursor-path/java-pagination-deep-cursor-path/src/main/java/com/seed/deepCursorPath/resources/deepcursorpath/RawDeepCursorPathClient.java
+++ b/seed/java-sdk/java-pagination-deep-cursor-path/java-pagination-deep-cursor-path/src/main/java/com/seed/deepCursorPath/resources/deepcursorpath/RawDeepCursorPathClient.java
@@ -4,7 +4,6 @@
 package com.seed.deepCursorPath.resources.deepcursorpath;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.seed.deepCursorPath.core.ClientOptions;
 import com.seed.deepCursorPath.core.MediaTypes;
@@ -79,17 +78,10 @@ public class RawDeepCursorPathClient {
                 JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                 com.seed.deepCursorPath.resources.deepcursorpath.types.Response parsedResponse;
                 if (responseNode.isArray()) {
-                    List<String> items =
-                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<String>>() {});
-                    parsedResponse = com.seed
-                            .deepCursorPath
-                            .resources
-                            .deepcursorpath
-                            .types
-                            .Response
-                            .builder()
-                            .results(items)
-                            .build();
+                    JsonNode wrapper =
+                            ObjectMappers.JSON_MAPPER.createObjectNode().set("results", responseNode);
+                    parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                            wrapper, com.seed.deepCursorPath.resources.deepcursorpath.types.Response.class);
                 } else {
                     parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
                             responseNode, com.seed.deepCursorPath.resources.deepcursorpath.types.Response.class);
@@ -154,17 +146,10 @@ public class RawDeepCursorPathClient {
                 JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                 com.seed.deepCursorPath.resources.deepcursorpath.types.Response parsedResponse;
                 if (responseNode.isArray()) {
-                    List<String> items =
-                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<String>>() {});
-                    parsedResponse = com.seed
-                            .deepCursorPath
-                            .resources
-                            .deepcursorpath
-                            .types
-                            .Response
-                            .builder()
-                            .results(items)
-                            .build();
+                    JsonNode wrapper =
+                            ObjectMappers.JSON_MAPPER.createObjectNode().set("results", responseNode);
+                    parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                            wrapper, com.seed.deepCursorPath.resources.deepcursorpath.types.Response.class);
                 } else {
                     parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
                             responseNode, com.seed.deepCursorPath.resources.deepcursorpath.types.Response.class);
@@ -232,17 +217,10 @@ public class RawDeepCursorPathClient {
                 JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                 com.seed.deepCursorPath.resources.deepcursorpath.types.Response parsedResponse;
                 if (responseNode.isArray()) {
-                    List<String> items =
-                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<String>>() {});
-                    parsedResponse = com.seed
-                            .deepCursorPath
-                            .resources
-                            .deepcursorpath
-                            .types
-                            .Response
-                            .builder()
-                            .results(items)
-                            .build();
+                    JsonNode wrapper =
+                            ObjectMappers.JSON_MAPPER.createObjectNode().set("results", responseNode);
+                    parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                            wrapper, com.seed.deepCursorPath.resources.deepcursorpath.types.Response.class);
                 } else {
                     parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
                             responseNode, com.seed.deepCursorPath.resources.deepcursorpath.types.Response.class);

--- a/seed/java-sdk/java-pagination-deep-cursor-path/java-pagination-deep-cursor-path/src/main/java/com/seed/deepCursorPath/resources/deepcursorpath/RawDeepCursorPathClient.java
+++ b/seed/java-sdk/java-pagination-deep-cursor-path/java-pagination-deep-cursor-path/src/main/java/com/seed/deepCursorPath/resources/deepcursorpath/RawDeepCursorPathClient.java
@@ -4,6 +4,8 @@
 package com.seed.deepCursorPath.resources.deepcursorpath;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.seed.deepCursorPath.core.ClientOptions;
 import com.seed.deepCursorPath.core.MediaTypes;
 import com.seed.deepCursorPath.core.ObjectMappers;
@@ -74,10 +76,24 @@ public class RawDeepCursorPathClient {
             ResponseBody responseBody = response.body();
             String responseBodyString = responseBody != null ? responseBody.string() : "{}";
             if (response.isSuccessful()) {
-                com.seed.deepCursorPath.resources.deepcursorpath.types.Response parsedResponse =
-                        ObjectMappers.JSON_MAPPER.readValue(
-                                responseBodyString,
-                                com.seed.deepCursorPath.resources.deepcursorpath.types.Response.class);
+                JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                com.seed.deepCursorPath.resources.deepcursorpath.types.Response parsedResponse;
+                if (responseNode.isArray()) {
+                    List<String> items =
+                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<String>>() {});
+                    parsedResponse = com.seed
+                            .deepCursorPath
+                            .resources
+                            .deepcursorpath
+                            .types
+                            .Response
+                            .builder()
+                            .results(items)
+                            .build();
+                } else {
+                    parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                            responseNode, com.seed.deepCursorPath.resources.deepcursorpath.types.Response.class);
+                }
                 Optional<String> startingAfter = parsedResponse.getStartingAfter();
                 Optional<D> d = request.getB().map(B::getC).flatMap(C::getD).map((D d_) -> D.builder()
                         .from(d_)
@@ -135,10 +151,24 @@ public class RawDeepCursorPathClient {
             ResponseBody responseBody = response.body();
             String responseBodyString = responseBody != null ? responseBody.string() : "{}";
             if (response.isSuccessful()) {
-                com.seed.deepCursorPath.resources.deepcursorpath.types.Response parsedResponse =
-                        ObjectMappers.JSON_MAPPER.readValue(
-                                responseBodyString,
-                                com.seed.deepCursorPath.resources.deepcursorpath.types.Response.class);
+                JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                com.seed.deepCursorPath.resources.deepcursorpath.types.Response parsedResponse;
+                if (responseNode.isArray()) {
+                    List<String> items =
+                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<String>>() {});
+                    parsedResponse = com.seed
+                            .deepCursorPath
+                            .resources
+                            .deepcursorpath
+                            .types
+                            .Response
+                            .builder()
+                            .results(items)
+                            .build();
+                } else {
+                    parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                            responseNode, com.seed.deepCursorPath.resources.deepcursorpath.types.Response.class);
+                }
                 Optional<String> startingAfter = parsedResponse.getStartingAfter();
                 IndirectionRequired indirection = IndirectionRequired.builder()
                         .from(com.seed.deepCursorPath.resources.deepcursorpath.types.IndirectionRequired)
@@ -199,10 +229,24 @@ public class RawDeepCursorPathClient {
             ResponseBody responseBody = response.body();
             String responseBodyString = responseBody != null ? responseBody.string() : "{}";
             if (response.isSuccessful()) {
-                com.seed.deepCursorPath.resources.deepcursorpath.types.Response parsedResponse =
-                        ObjectMappers.JSON_MAPPER.readValue(
-                                responseBodyString,
-                                com.seed.deepCursorPath.resources.deepcursorpath.types.Response.class);
+                JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                com.seed.deepCursorPath.resources.deepcursorpath.types.Response parsedResponse;
+                if (responseNode.isArray()) {
+                    List<String> items =
+                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<String>>() {});
+                    parsedResponse = com.seed
+                            .deepCursorPath
+                            .resources
+                            .deepcursorpath
+                            .types
+                            .Response
+                            .builder()
+                            .results(items)
+                            .build();
+                } else {
+                    parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                            responseNode, com.seed.deepCursorPath.resources.deepcursorpath.types.Response.class);
+                }
                 Optional<String> startingAfter = parsedResponse.getStartingAfter();
                 Optional<InlineD> b = request.getB()
                         .map(B::getC)

--- a/seed/java-sdk/java-pagination-deep-cursor-path/wire-tests/src/main/java/com/seed/deepCursorPath/resources/deepcursorpath/AsyncRawDeepCursorPathClient.java
+++ b/seed/java-sdk/java-pagination-deep-cursor-path/wire-tests/src/main/java/com/seed/deepCursorPath/resources/deepcursorpath/AsyncRawDeepCursorPathClient.java
@@ -4,7 +4,6 @@
 package com.seed.deepCursorPath.resources.deepcursorpath;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.seed.deepCursorPath.core.ClientOptions;
 import com.seed.deepCursorPath.core.MediaTypes;
@@ -88,17 +87,10 @@ public class AsyncRawDeepCursorPathClient {
                         JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                         com.seed.deepCursorPath.resources.deepcursorpath.types.Response parsedResponse;
                         if (responseNode.isArray()) {
-                            List<String> items = ObjectMappers.JSON_MAPPER.convertValue(
-                                    responseNode, new TypeReference<List<String>>() {});
-                            parsedResponse = com.seed
-                                    .deepCursorPath
-                                    .resources
-                                    .deepcursorpath
-                                    .types
-                                    .Response
-                                    .builder()
-                                    .results(items)
-                                    .build();
+                            JsonNode wrapper =
+                                    ObjectMappers.JSON_MAPPER.createObjectNode().set("results", responseNode);
+                            parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                                    wrapper, com.seed.deepCursorPath.resources.deepcursorpath.types.Response.class);
                         } else {
                             parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
                                     responseNode,
@@ -191,17 +183,10 @@ public class AsyncRawDeepCursorPathClient {
                         JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                         com.seed.deepCursorPath.resources.deepcursorpath.types.Response parsedResponse;
                         if (responseNode.isArray()) {
-                            List<String> items = ObjectMappers.JSON_MAPPER.convertValue(
-                                    responseNode, new TypeReference<List<String>>() {});
-                            parsedResponse = com.seed
-                                    .deepCursorPath
-                                    .resources
-                                    .deepcursorpath
-                                    .types
-                                    .Response
-                                    .builder()
-                                    .results(items)
-                                    .build();
+                            JsonNode wrapper =
+                                    ObjectMappers.JSON_MAPPER.createObjectNode().set("results", responseNode);
+                            parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                                    wrapper, com.seed.deepCursorPath.resources.deepcursorpath.types.Response.class);
                         } else {
                             parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
                                     responseNode,
@@ -293,17 +278,10 @@ public class AsyncRawDeepCursorPathClient {
                         JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                         com.seed.deepCursorPath.resources.deepcursorpath.types.Response parsedResponse;
                         if (responseNode.isArray()) {
-                            List<String> items = ObjectMappers.JSON_MAPPER.convertValue(
-                                    responseNode, new TypeReference<List<String>>() {});
-                            parsedResponse = com.seed
-                                    .deepCursorPath
-                                    .resources
-                                    .deepcursorpath
-                                    .types
-                                    .Response
-                                    .builder()
-                                    .results(items)
-                                    .build();
+                            JsonNode wrapper =
+                                    ObjectMappers.JSON_MAPPER.createObjectNode().set("results", responseNode);
+                            parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                                    wrapper, com.seed.deepCursorPath.resources.deepcursorpath.types.Response.class);
                         } else {
                             parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
                                     responseNode,

--- a/seed/java-sdk/java-pagination-deep-cursor-path/wire-tests/src/main/java/com/seed/deepCursorPath/resources/deepcursorpath/AsyncRawDeepCursorPathClient.java
+++ b/seed/java-sdk/java-pagination-deep-cursor-path/wire-tests/src/main/java/com/seed/deepCursorPath/resources/deepcursorpath/AsyncRawDeepCursorPathClient.java
@@ -4,6 +4,8 @@
 package com.seed.deepCursorPath.resources.deepcursorpath;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.seed.deepCursorPath.core.ClientOptions;
 import com.seed.deepCursorPath.core.MediaTypes;
 import com.seed.deepCursorPath.core.ObjectMappers;
@@ -83,10 +85,25 @@ public class AsyncRawDeepCursorPathClient {
                 try (ResponseBody responseBody = response.body()) {
                     String responseBodyString = responseBody != null ? responseBody.string() : "{}";
                     if (response.isSuccessful()) {
-                        com.seed.deepCursorPath.resources.deepcursorpath.types.Response parsedResponse =
-                                ObjectMappers.JSON_MAPPER.readValue(
-                                        responseBodyString,
-                                        com.seed.deepCursorPath.resources.deepcursorpath.types.Response.class);
+                        JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                        com.seed.deepCursorPath.resources.deepcursorpath.types.Response parsedResponse;
+                        if (responseNode.isArray()) {
+                            List<String> items = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, new TypeReference<List<String>>() {});
+                            parsedResponse = com.seed
+                                    .deepCursorPath
+                                    .resources
+                                    .deepcursorpath
+                                    .types
+                                    .Response
+                                    .builder()
+                                    .results(items)
+                                    .build();
+                        } else {
+                            parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode,
+                                    com.seed.deepCursorPath.resources.deepcursorpath.types.Response.class);
+                        }
                         Optional<String> startingAfter = parsedResponse.getStartingAfter();
                         Optional<D> d = request.getB()
                                 .map(B::getC)
@@ -171,10 +188,25 @@ public class AsyncRawDeepCursorPathClient {
                 try (ResponseBody responseBody = response.body()) {
                     String responseBodyString = responseBody != null ? responseBody.string() : "{}";
                     if (response.isSuccessful()) {
-                        com.seed.deepCursorPath.resources.deepcursorpath.types.Response parsedResponse =
-                                ObjectMappers.JSON_MAPPER.readValue(
-                                        responseBodyString,
-                                        com.seed.deepCursorPath.resources.deepcursorpath.types.Response.class);
+                        JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                        com.seed.deepCursorPath.resources.deepcursorpath.types.Response parsedResponse;
+                        if (responseNode.isArray()) {
+                            List<String> items = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, new TypeReference<List<String>>() {});
+                            parsedResponse = com.seed
+                                    .deepCursorPath
+                                    .resources
+                                    .deepcursorpath
+                                    .types
+                                    .Response
+                                    .builder()
+                                    .results(items)
+                                    .build();
+                        } else {
+                            parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode,
+                                    com.seed.deepCursorPath.resources.deepcursorpath.types.Response.class);
+                        }
                         Optional<String> startingAfter = parsedResponse.getStartingAfter();
                         IndirectionRequired indirection = IndirectionRequired.builder()
                                 .from(com.seed.deepCursorPath.resources.deepcursorpath.types.IndirectionRequired)
@@ -258,10 +290,25 @@ public class AsyncRawDeepCursorPathClient {
                 try (ResponseBody responseBody = response.body()) {
                     String responseBodyString = responseBody != null ? responseBody.string() : "{}";
                     if (response.isSuccessful()) {
-                        com.seed.deepCursorPath.resources.deepcursorpath.types.Response parsedResponse =
-                                ObjectMappers.JSON_MAPPER.readValue(
-                                        responseBodyString,
-                                        com.seed.deepCursorPath.resources.deepcursorpath.types.Response.class);
+                        JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                        com.seed.deepCursorPath.resources.deepcursorpath.types.Response parsedResponse;
+                        if (responseNode.isArray()) {
+                            List<String> items = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, new TypeReference<List<String>>() {});
+                            parsedResponse = com.seed
+                                    .deepCursorPath
+                                    .resources
+                                    .deepcursorpath
+                                    .types
+                                    .Response
+                                    .builder()
+                                    .results(items)
+                                    .build();
+                        } else {
+                            parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode,
+                                    com.seed.deepCursorPath.resources.deepcursorpath.types.Response.class);
+                        }
                         Optional<String> startingAfter = parsedResponse.getStartingAfter();
                         Optional<InlineD> b = request.getB()
                                 .map(B::getC)

--- a/seed/java-sdk/java-pagination-deep-cursor-path/wire-tests/src/main/java/com/seed/deepCursorPath/resources/deepcursorpath/RawDeepCursorPathClient.java
+++ b/seed/java-sdk/java-pagination-deep-cursor-path/wire-tests/src/main/java/com/seed/deepCursorPath/resources/deepcursorpath/RawDeepCursorPathClient.java
@@ -4,7 +4,6 @@
 package com.seed.deepCursorPath.resources.deepcursorpath;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.seed.deepCursorPath.core.ClientOptions;
 import com.seed.deepCursorPath.core.MediaTypes;
@@ -79,17 +78,10 @@ public class RawDeepCursorPathClient {
                 JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                 com.seed.deepCursorPath.resources.deepcursorpath.types.Response parsedResponse;
                 if (responseNode.isArray()) {
-                    List<String> items =
-                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<String>>() {});
-                    parsedResponse = com.seed
-                            .deepCursorPath
-                            .resources
-                            .deepcursorpath
-                            .types
-                            .Response
-                            .builder()
-                            .results(items)
-                            .build();
+                    JsonNode wrapper =
+                            ObjectMappers.JSON_MAPPER.createObjectNode().set("results", responseNode);
+                    parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                            wrapper, com.seed.deepCursorPath.resources.deepcursorpath.types.Response.class);
                 } else {
                     parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
                             responseNode, com.seed.deepCursorPath.resources.deepcursorpath.types.Response.class);
@@ -154,17 +146,10 @@ public class RawDeepCursorPathClient {
                 JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                 com.seed.deepCursorPath.resources.deepcursorpath.types.Response parsedResponse;
                 if (responseNode.isArray()) {
-                    List<String> items =
-                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<String>>() {});
-                    parsedResponse = com.seed
-                            .deepCursorPath
-                            .resources
-                            .deepcursorpath
-                            .types
-                            .Response
-                            .builder()
-                            .results(items)
-                            .build();
+                    JsonNode wrapper =
+                            ObjectMappers.JSON_MAPPER.createObjectNode().set("results", responseNode);
+                    parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                            wrapper, com.seed.deepCursorPath.resources.deepcursorpath.types.Response.class);
                 } else {
                     parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
                             responseNode, com.seed.deepCursorPath.resources.deepcursorpath.types.Response.class);
@@ -232,17 +217,10 @@ public class RawDeepCursorPathClient {
                 JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                 com.seed.deepCursorPath.resources.deepcursorpath.types.Response parsedResponse;
                 if (responseNode.isArray()) {
-                    List<String> items =
-                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<String>>() {});
-                    parsedResponse = com.seed
-                            .deepCursorPath
-                            .resources
-                            .deepcursorpath
-                            .types
-                            .Response
-                            .builder()
-                            .results(items)
-                            .build();
+                    JsonNode wrapper =
+                            ObjectMappers.JSON_MAPPER.createObjectNode().set("results", responseNode);
+                    parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                            wrapper, com.seed.deepCursorPath.resources.deepcursorpath.types.Response.class);
                 } else {
                     parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
                             responseNode, com.seed.deepCursorPath.resources.deepcursorpath.types.Response.class);

--- a/seed/java-sdk/java-pagination-deep-cursor-path/wire-tests/src/main/java/com/seed/deepCursorPath/resources/deepcursorpath/RawDeepCursorPathClient.java
+++ b/seed/java-sdk/java-pagination-deep-cursor-path/wire-tests/src/main/java/com/seed/deepCursorPath/resources/deepcursorpath/RawDeepCursorPathClient.java
@@ -4,6 +4,8 @@
 package com.seed.deepCursorPath.resources.deepcursorpath;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.seed.deepCursorPath.core.ClientOptions;
 import com.seed.deepCursorPath.core.MediaTypes;
 import com.seed.deepCursorPath.core.ObjectMappers;
@@ -74,10 +76,24 @@ public class RawDeepCursorPathClient {
             ResponseBody responseBody = response.body();
             String responseBodyString = responseBody != null ? responseBody.string() : "{}";
             if (response.isSuccessful()) {
-                com.seed.deepCursorPath.resources.deepcursorpath.types.Response parsedResponse =
-                        ObjectMappers.JSON_MAPPER.readValue(
-                                responseBodyString,
-                                com.seed.deepCursorPath.resources.deepcursorpath.types.Response.class);
+                JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                com.seed.deepCursorPath.resources.deepcursorpath.types.Response parsedResponse;
+                if (responseNode.isArray()) {
+                    List<String> items =
+                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<String>>() {});
+                    parsedResponse = com.seed
+                            .deepCursorPath
+                            .resources
+                            .deepcursorpath
+                            .types
+                            .Response
+                            .builder()
+                            .results(items)
+                            .build();
+                } else {
+                    parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                            responseNode, com.seed.deepCursorPath.resources.deepcursorpath.types.Response.class);
+                }
                 Optional<String> startingAfter = parsedResponse.getStartingAfter();
                 Optional<D> d = request.getB().map(B::getC).flatMap(C::getD).map((D d_) -> D.builder()
                         .from(d_)
@@ -135,10 +151,24 @@ public class RawDeepCursorPathClient {
             ResponseBody responseBody = response.body();
             String responseBodyString = responseBody != null ? responseBody.string() : "{}";
             if (response.isSuccessful()) {
-                com.seed.deepCursorPath.resources.deepcursorpath.types.Response parsedResponse =
-                        ObjectMappers.JSON_MAPPER.readValue(
-                                responseBodyString,
-                                com.seed.deepCursorPath.resources.deepcursorpath.types.Response.class);
+                JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                com.seed.deepCursorPath.resources.deepcursorpath.types.Response parsedResponse;
+                if (responseNode.isArray()) {
+                    List<String> items =
+                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<String>>() {});
+                    parsedResponse = com.seed
+                            .deepCursorPath
+                            .resources
+                            .deepcursorpath
+                            .types
+                            .Response
+                            .builder()
+                            .results(items)
+                            .build();
+                } else {
+                    parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                            responseNode, com.seed.deepCursorPath.resources.deepcursorpath.types.Response.class);
+                }
                 Optional<String> startingAfter = parsedResponse.getStartingAfter();
                 IndirectionRequired indirection = IndirectionRequired.builder()
                         .from(com.seed.deepCursorPath.resources.deepcursorpath.types.IndirectionRequired)
@@ -199,10 +229,24 @@ public class RawDeepCursorPathClient {
             ResponseBody responseBody = response.body();
             String responseBodyString = responseBody != null ? responseBody.string() : "{}";
             if (response.isSuccessful()) {
-                com.seed.deepCursorPath.resources.deepcursorpath.types.Response parsedResponse =
-                        ObjectMappers.JSON_MAPPER.readValue(
-                                responseBodyString,
-                                com.seed.deepCursorPath.resources.deepcursorpath.types.Response.class);
+                JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                com.seed.deepCursorPath.resources.deepcursorpath.types.Response parsedResponse;
+                if (responseNode.isArray()) {
+                    List<String> items =
+                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<String>>() {});
+                    parsedResponse = com.seed
+                            .deepCursorPath
+                            .resources
+                            .deepcursorpath
+                            .types
+                            .Response
+                            .builder()
+                            .results(items)
+                            .build();
+                } else {
+                    parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                            responseNode, com.seed.deepCursorPath.resources.deepcursorpath.types.Response.class);
+                }
                 Optional<String> startingAfter = parsedResponse.getStartingAfter();
                 Optional<InlineD> b = request.getB()
                         .map(B::getC)

--- a/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/complex/AsyncRawComplexClient.java
+++ b/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/complex/AsyncRawComplexClient.java
@@ -4,7 +4,6 @@
 package com.seed.pagination.resources.complex;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.seed.pagination.core.ClientOptions;
 import com.seed.pagination.core.MediaTypes;
@@ -84,11 +83,10 @@ public class AsyncRawComplexClient {
                         JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                         PaginatedConversationResponse parsedResponse;
                         if (responseNode.isArray()) {
-                            List<Conversation> items = ObjectMappers.JSON_MAPPER.convertValue(
-                                    responseNode, new TypeReference<List<Conversation>>() {});
-                            parsedResponse = PaginatedConversationResponse.builder()
-                                    .conversations(items)
-                                    .build();
+                            JsonNode wrapper =
+                                    ObjectMappers.JSON_MAPPER.createObjectNode().set("conversations", responseNode);
+                            parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                                    wrapper, PaginatedConversationResponse.class);
                         } else {
                             parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
                                     responseNode, PaginatedConversationResponse.class);

--- a/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/complex/RawComplexClient.java
+++ b/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/complex/RawComplexClient.java
@@ -4,6 +4,8 @@
 package com.seed.pagination.resources.complex;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.seed.pagination.core.ClientOptions;
 import com.seed.pagination.core.MediaTypes;
 import com.seed.pagination.core.ObjectMappers;
@@ -69,8 +71,18 @@ public class RawComplexClient {
             ResponseBody responseBody = response.body();
             String responseBodyString = responseBody != null ? responseBody.string() : "{}";
             if (response.isSuccessful()) {
-                PaginatedConversationResponse parsedResponse =
-                        ObjectMappers.JSON_MAPPER.readValue(responseBodyString, PaginatedConversationResponse.class);
+                JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                PaginatedConversationResponse parsedResponse;
+                if (responseNode.isArray()) {
+                    List<Conversation> items = ObjectMappers.JSON_MAPPER.convertValue(
+                            responseNode, new TypeReference<List<Conversation>>() {});
+                    parsedResponse = PaginatedConversationResponse.builder()
+                            .conversations(items)
+                            .build();
+                } else {
+                    parsedResponse =
+                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, PaginatedConversationResponse.class);
+                }
                 Optional<String> startingAfter = parsedResponse
                         .getPages()
                         .flatMap(CursorPages::getNext)

--- a/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/complex/RawComplexClient.java
+++ b/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/complex/RawComplexClient.java
@@ -4,7 +4,6 @@
 package com.seed.pagination.resources.complex;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.seed.pagination.core.ClientOptions;
 import com.seed.pagination.core.MediaTypes;
@@ -74,11 +73,10 @@ public class RawComplexClient {
                 JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                 PaginatedConversationResponse parsedResponse;
                 if (responseNode.isArray()) {
-                    List<Conversation> items = ObjectMappers.JSON_MAPPER.convertValue(
-                            responseNode, new TypeReference<List<Conversation>>() {});
-                    parsedResponse = PaginatedConversationResponse.builder()
-                            .conversations(items)
-                            .build();
+                    JsonNode wrapper =
+                            ObjectMappers.JSON_MAPPER.createObjectNode().set("conversations", responseNode);
+                    parsedResponse =
+                            ObjectMappers.JSON_MAPPER.convertValue(wrapper, PaginatedConversationResponse.class);
                 } else {
                     parsedResponse =
                             ObjectMappers.JSON_MAPPER.convertValue(responseNode, PaginatedConversationResponse.class);

--- a/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/AsyncRawInlineUsersClient.java
+++ b/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/AsyncRawInlineUsersClient.java
@@ -4,6 +4,8 @@
 package com.seed.pagination.resources.inlineusers.inlineusers;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.seed.pagination.core.ClientOptions;
 import com.seed.pagination.core.MediaTypes;
 import com.seed.pagination.core.ObjectMappers;
@@ -109,8 +111,18 @@ public class AsyncRawInlineUsersClient {
                 try (ResponseBody responseBody = response.body()) {
                     String responseBodyString = responseBody != null ? responseBody.string() : "{}";
                     if (response.isSuccessful()) {
-                        ListUsersPaginationResponse parsedResponse = ObjectMappers.JSON_MAPPER.readValue(
-                                responseBodyString, ListUsersPaginationResponse.class);
+                        JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                        ListUsersPaginationResponse parsedResponse;
+                        if (responseNode.isArray()) {
+                            List<User> items = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, new TypeReference<List<User>>() {});
+                            parsedResponse = ListUsersPaginationResponse.builder()
+                                    .users(items)
+                                    .build();
+                        } else {
+                            parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, ListUsersPaginationResponse.class);
+                        }
                         Optional<String> startingAfter =
                                 parsedResponse.getPage().flatMap(Page::getNext).map(NextPage::getStartingAfter);
                         ListUsersCursorPaginationRequest nextRequest = ListUsersCursorPaginationRequest.builder()
@@ -185,8 +197,18 @@ public class AsyncRawInlineUsersClient {
                 try (ResponseBody responseBody = response.body()) {
                     String responseBodyString = responseBody != null ? responseBody.string() : "{}";
                     if (response.isSuccessful()) {
-                        ListUsersMixedTypePaginationResponse parsedResponse = ObjectMappers.JSON_MAPPER.readValue(
-                                responseBodyString, ListUsersMixedTypePaginationResponse.class);
+                        JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                        ListUsersMixedTypePaginationResponse parsedResponse;
+                        if (responseNode.isArray()) {
+                            List<User> items = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, new TypeReference<List<User>>() {});
+                            parsedResponse = ListUsersMixedTypePaginationResponse.builder()
+                                    .users(items)
+                                    .build();
+                        } else {
+                            parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, ListUsersMixedTypePaginationResponse.class);
+                        }
                         String startingAfter = parsedResponse.getNext();
                         ListUsersMixedTypeCursorPaginationRequest nextRequest =
                                 ListUsersMixedTypeCursorPaginationRequest.builder()
@@ -266,8 +288,18 @@ public class AsyncRawInlineUsersClient {
                 try (ResponseBody responseBody = response.body()) {
                     String responseBodyString = responseBody != null ? responseBody.string() : "{}";
                     if (response.isSuccessful()) {
-                        ListUsersPaginationResponse parsedResponse = ObjectMappers.JSON_MAPPER.readValue(
-                                responseBodyString, ListUsersPaginationResponse.class);
+                        JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                        ListUsersPaginationResponse parsedResponse;
+                        if (responseNode.isArray()) {
+                            List<User> items = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, new TypeReference<List<User>>() {});
+                            parsedResponse = ListUsersPaginationResponse.builder()
+                                    .users(items)
+                                    .build();
+                        } else {
+                            parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, ListUsersPaginationResponse.class);
+                        }
                         Optional<String> startingAfter =
                                 parsedResponse.getPage().flatMap(Page::getNext).map(NextPage::getStartingAfter);
                         Optional<WithCursor> pagination = request.getPagination()
@@ -360,8 +392,18 @@ public class AsyncRawInlineUsersClient {
                 try (ResponseBody responseBody = response.body()) {
                     String responseBodyString = responseBody != null ? responseBody.string() : "{}";
                     if (response.isSuccessful()) {
-                        ListUsersPaginationResponse parsedResponse = ObjectMappers.JSON_MAPPER.readValue(
-                                responseBodyString, ListUsersPaginationResponse.class);
+                        JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                        ListUsersPaginationResponse parsedResponse;
+                        if (responseNode.isArray()) {
+                            List<User> items = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, new TypeReference<List<User>>() {});
+                            parsedResponse = ListUsersPaginationResponse.builder()
+                                    .users(items)
+                                    .build();
+                        } else {
+                            parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, ListUsersPaginationResponse.class);
+                        }
                         int newPageNumber = request.getPage()
                                 .map((Integer page) -> page + 1)
                                 .orElse(1);
@@ -449,8 +491,18 @@ public class AsyncRawInlineUsersClient {
                 try (ResponseBody responseBody = response.body()) {
                     String responseBodyString = responseBody != null ? responseBody.string() : "{}";
                     if (response.isSuccessful()) {
-                        ListUsersPaginationResponse parsedResponse = ObjectMappers.JSON_MAPPER.readValue(
-                                responseBodyString, ListUsersPaginationResponse.class);
+                        JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                        ListUsersPaginationResponse parsedResponse;
+                        if (responseNode.isArray()) {
+                            List<User> items = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, new TypeReference<List<User>>() {});
+                            parsedResponse = ListUsersPaginationResponse.builder()
+                                    .users(items)
+                                    .build();
+                        } else {
+                            parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, ListUsersPaginationResponse.class);
+                        }
                         double newPageNumber = request.getPage()
                                 .map((Double page) -> page + 1.0)
                                 .orElse(1.0);
@@ -532,8 +584,18 @@ public class AsyncRawInlineUsersClient {
                 try (ResponseBody responseBody = response.body()) {
                     String responseBodyString = responseBody != null ? responseBody.string() : "{}";
                     if (response.isSuccessful()) {
-                        ListUsersPaginationResponse parsedResponse = ObjectMappers.JSON_MAPPER.readValue(
-                                responseBodyString, ListUsersPaginationResponse.class);
+                        JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                        ListUsersPaginationResponse parsedResponse;
+                        if (responseNode.isArray()) {
+                            List<User> items = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, new TypeReference<List<User>>() {});
+                            parsedResponse = ListUsersPaginationResponse.builder()
+                                    .users(items)
+                                    .build();
+                        } else {
+                            parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, ListUsersPaginationResponse.class);
+                        }
                         int newPageNumber = request.getPagination()
                                 .flatMap(WithPage::getPage)
                                 .map((Integer page) -> page + 1)
@@ -624,8 +686,18 @@ public class AsyncRawInlineUsersClient {
                 try (ResponseBody responseBody = response.body()) {
                     String responseBodyString = responseBody != null ? responseBody.string() : "{}";
                     if (response.isSuccessful()) {
-                        ListUsersPaginationResponse parsedResponse = ObjectMappers.JSON_MAPPER.readValue(
-                                responseBodyString, ListUsersPaginationResponse.class);
+                        JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                        ListUsersPaginationResponse parsedResponse;
+                        if (responseNode.isArray()) {
+                            List<User> items = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, new TypeReference<List<User>>() {});
+                            parsedResponse = ListUsersPaginationResponse.builder()
+                                    .users(items)
+                                    .build();
+                        } else {
+                            parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, ListUsersPaginationResponse.class);
+                        }
                         int newPageNumber = request.getPage()
                                 .map((Integer page) -> page + 1)
                                 .orElse(1);
@@ -711,8 +783,18 @@ public class AsyncRawInlineUsersClient {
                 try (ResponseBody responseBody = response.body()) {
                     String responseBodyString = responseBody != null ? responseBody.string() : "{}";
                     if (response.isSuccessful()) {
-                        ListUsersPaginationResponse parsedResponse = ObjectMappers.JSON_MAPPER.readValue(
-                                responseBodyString, ListUsersPaginationResponse.class);
+                        JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                        ListUsersPaginationResponse parsedResponse;
+                        if (responseNode.isArray()) {
+                            List<User> items = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, new TypeReference<List<User>>() {});
+                            parsedResponse = ListUsersPaginationResponse.builder()
+                                    .users(items)
+                                    .build();
+                        } else {
+                            parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, ListUsersPaginationResponse.class);
+                        }
                         int newPageNumber = request.getPage()
                                 .map((Integer page) -> page + 1)
                                 .orElse(1);
@@ -788,8 +870,18 @@ public class AsyncRawInlineUsersClient {
                 try (ResponseBody responseBody = response.body()) {
                     String responseBodyString = responseBody != null ? responseBody.string() : "{}";
                     if (response.isSuccessful()) {
-                        ListUsersExtendedResponse parsedResponse = ObjectMappers.JSON_MAPPER.readValue(
-                                responseBodyString, ListUsersExtendedResponse.class);
+                        JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                        ListUsersExtendedResponse parsedResponse;
+                        if (responseNode.isArray()) {
+                            List<User> items = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, new TypeReference<List<User>>() {});
+                            parsedResponse = ListUsersExtendedResponse.builder()
+                                    .users(items)
+                                    .build();
+                        } else {
+                            parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, ListUsersExtendedResponse.class);
+                        }
                         Optional<UUID> startingAfter = parsedResponse.getNext();
                         ListUsersExtendedRequest nextRequest = ListUsersExtendedRequest.builder()
                                 .from(request)
@@ -865,8 +957,18 @@ public class AsyncRawInlineUsersClient {
                 try (ResponseBody responseBody = response.body()) {
                     String responseBodyString = responseBody != null ? responseBody.string() : "{}";
                     if (response.isSuccessful()) {
-                        ListUsersExtendedOptionalListResponse parsedResponse = ObjectMappers.JSON_MAPPER.readValue(
-                                responseBodyString, ListUsersExtendedOptionalListResponse.class);
+                        JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                        ListUsersExtendedOptionalListResponse parsedResponse;
+                        if (responseNode.isArray()) {
+                            Optional<List<User>> items = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, new TypeReference<Optional<List<User>>>() {});
+                            parsedResponse = ListUsersExtendedOptionalListResponse.builder()
+                                    .users(items)
+                                    .build();
+                        } else {
+                            parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, ListUsersExtendedOptionalListResponse.class);
+                        }
                         Optional<UUID> startingAfter = parsedResponse.getNext();
                         ListUsersExtendedRequestForOptionalData nextRequest =
                                 ListUsersExtendedRequestForOptionalData.builder()
@@ -940,8 +1042,16 @@ public class AsyncRawInlineUsersClient {
                 try (ResponseBody responseBody = response.body()) {
                     String responseBodyString = responseBody != null ? responseBody.string() : "{}";
                     if (response.isSuccessful()) {
-                        UsernameCursor parsedResponse =
-                                ObjectMappers.JSON_MAPPER.readValue(responseBodyString, UsernameCursor.class);
+                        JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                        UsernameCursor parsedResponse;
+                        if (responseNode.isArray()) {
+                            List<String> items = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, new TypeReference<List<String>>() {});
+                            parsedResponse =
+                                    UsernameCursor.builder().data(items).build();
+                        } else {
+                            parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(responseNode, UsernameCursor.class);
+                        }
                         Optional<String> startingAfter =
                                 parsedResponse.getCursor().getAfter();
                         ListUsernamesRequest nextRequest = ListUsernamesRequest.builder()
@@ -1016,8 +1126,17 @@ public class AsyncRawInlineUsersClient {
                 try (ResponseBody responseBody = response.body()) {
                     String responseBodyString = responseBody != null ? responseBody.string() : "{}";
                     if (response.isSuccessful()) {
-                        UsernameContainer parsedResponse =
-                                ObjectMappers.JSON_MAPPER.readValue(responseBodyString, UsernameContainer.class);
+                        JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                        UsernameContainer parsedResponse;
+                        if (responseNode.isArray()) {
+                            List<String> items = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, new TypeReference<List<String>>() {});
+                            parsedResponse =
+                                    UsernameContainer.builder().results(items).build();
+                        } else {
+                            parsedResponse =
+                                    ObjectMappers.JSON_MAPPER.convertValue(responseNode, UsernameContainer.class);
+                        }
                         int newPageNumber = request.getOffset()
                                 .map((Integer page) -> page + 1)
                                 .orElse(1);

--- a/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/AsyncRawInlineUsersClient.java
+++ b/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/AsyncRawInlineUsersClient.java
@@ -4,7 +4,6 @@
 package com.seed.pagination.resources.inlineusers.inlineusers;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.seed.pagination.core.ClientOptions;
 import com.seed.pagination.core.MediaTypes;
@@ -114,11 +113,10 @@ public class AsyncRawInlineUsersClient {
                         JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                         ListUsersPaginationResponse parsedResponse;
                         if (responseNode.isArray()) {
-                            List<User> items = ObjectMappers.JSON_MAPPER.convertValue(
-                                    responseNode, new TypeReference<List<User>>() {});
-                            parsedResponse = ListUsersPaginationResponse.builder()
-                                    .users(items)
-                                    .build();
+                            JsonNode wrapper =
+                                    ObjectMappers.JSON_MAPPER.createObjectNode().set("users", responseNode);
+                            parsedResponse =
+                                    ObjectMappers.JSON_MAPPER.convertValue(wrapper, ListUsersPaginationResponse.class);
                         } else {
                             parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
                                     responseNode, ListUsersPaginationResponse.class);
@@ -200,11 +198,10 @@ public class AsyncRawInlineUsersClient {
                         JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                         ListUsersMixedTypePaginationResponse parsedResponse;
                         if (responseNode.isArray()) {
-                            List<User> items = ObjectMappers.JSON_MAPPER.convertValue(
-                                    responseNode, new TypeReference<List<User>>() {});
-                            parsedResponse = ListUsersMixedTypePaginationResponse.builder()
-                                    .users(items)
-                                    .build();
+                            JsonNode wrapper =
+                                    ObjectMappers.JSON_MAPPER.createObjectNode().set("users", responseNode);
+                            parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                                    wrapper, ListUsersMixedTypePaginationResponse.class);
                         } else {
                             parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
                                     responseNode, ListUsersMixedTypePaginationResponse.class);
@@ -291,11 +288,10 @@ public class AsyncRawInlineUsersClient {
                         JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                         ListUsersPaginationResponse parsedResponse;
                         if (responseNode.isArray()) {
-                            List<User> items = ObjectMappers.JSON_MAPPER.convertValue(
-                                    responseNode, new TypeReference<List<User>>() {});
-                            parsedResponse = ListUsersPaginationResponse.builder()
-                                    .users(items)
-                                    .build();
+                            JsonNode wrapper =
+                                    ObjectMappers.JSON_MAPPER.createObjectNode().set("users", responseNode);
+                            parsedResponse =
+                                    ObjectMappers.JSON_MAPPER.convertValue(wrapper, ListUsersPaginationResponse.class);
                         } else {
                             parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
                                     responseNode, ListUsersPaginationResponse.class);
@@ -395,11 +391,10 @@ public class AsyncRawInlineUsersClient {
                         JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                         ListUsersPaginationResponse parsedResponse;
                         if (responseNode.isArray()) {
-                            List<User> items = ObjectMappers.JSON_MAPPER.convertValue(
-                                    responseNode, new TypeReference<List<User>>() {});
-                            parsedResponse = ListUsersPaginationResponse.builder()
-                                    .users(items)
-                                    .build();
+                            JsonNode wrapper =
+                                    ObjectMappers.JSON_MAPPER.createObjectNode().set("users", responseNode);
+                            parsedResponse =
+                                    ObjectMappers.JSON_MAPPER.convertValue(wrapper, ListUsersPaginationResponse.class);
                         } else {
                             parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
                                     responseNode, ListUsersPaginationResponse.class);
@@ -494,11 +489,10 @@ public class AsyncRawInlineUsersClient {
                         JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                         ListUsersPaginationResponse parsedResponse;
                         if (responseNode.isArray()) {
-                            List<User> items = ObjectMappers.JSON_MAPPER.convertValue(
-                                    responseNode, new TypeReference<List<User>>() {});
-                            parsedResponse = ListUsersPaginationResponse.builder()
-                                    .users(items)
-                                    .build();
+                            JsonNode wrapper =
+                                    ObjectMappers.JSON_MAPPER.createObjectNode().set("users", responseNode);
+                            parsedResponse =
+                                    ObjectMappers.JSON_MAPPER.convertValue(wrapper, ListUsersPaginationResponse.class);
                         } else {
                             parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
                                     responseNode, ListUsersPaginationResponse.class);
@@ -587,11 +581,10 @@ public class AsyncRawInlineUsersClient {
                         JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                         ListUsersPaginationResponse parsedResponse;
                         if (responseNode.isArray()) {
-                            List<User> items = ObjectMappers.JSON_MAPPER.convertValue(
-                                    responseNode, new TypeReference<List<User>>() {});
-                            parsedResponse = ListUsersPaginationResponse.builder()
-                                    .users(items)
-                                    .build();
+                            JsonNode wrapper =
+                                    ObjectMappers.JSON_MAPPER.createObjectNode().set("users", responseNode);
+                            parsedResponse =
+                                    ObjectMappers.JSON_MAPPER.convertValue(wrapper, ListUsersPaginationResponse.class);
                         } else {
                             parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
                                     responseNode, ListUsersPaginationResponse.class);
@@ -689,11 +682,10 @@ public class AsyncRawInlineUsersClient {
                         JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                         ListUsersPaginationResponse parsedResponse;
                         if (responseNode.isArray()) {
-                            List<User> items = ObjectMappers.JSON_MAPPER.convertValue(
-                                    responseNode, new TypeReference<List<User>>() {});
-                            parsedResponse = ListUsersPaginationResponse.builder()
-                                    .users(items)
-                                    .build();
+                            JsonNode wrapper =
+                                    ObjectMappers.JSON_MAPPER.createObjectNode().set("users", responseNode);
+                            parsedResponse =
+                                    ObjectMappers.JSON_MAPPER.convertValue(wrapper, ListUsersPaginationResponse.class);
                         } else {
                             parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
                                     responseNode, ListUsersPaginationResponse.class);
@@ -786,11 +778,10 @@ public class AsyncRawInlineUsersClient {
                         JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                         ListUsersPaginationResponse parsedResponse;
                         if (responseNode.isArray()) {
-                            List<User> items = ObjectMappers.JSON_MAPPER.convertValue(
-                                    responseNode, new TypeReference<List<User>>() {});
-                            parsedResponse = ListUsersPaginationResponse.builder()
-                                    .users(items)
-                                    .build();
+                            JsonNode wrapper =
+                                    ObjectMappers.JSON_MAPPER.createObjectNode().set("users", responseNode);
+                            parsedResponse =
+                                    ObjectMappers.JSON_MAPPER.convertValue(wrapper, ListUsersPaginationResponse.class);
                         } else {
                             parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
                                     responseNode, ListUsersPaginationResponse.class);
@@ -873,11 +864,10 @@ public class AsyncRawInlineUsersClient {
                         JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                         ListUsersExtendedResponse parsedResponse;
                         if (responseNode.isArray()) {
-                            List<User> items = ObjectMappers.JSON_MAPPER.convertValue(
-                                    responseNode, new TypeReference<List<User>>() {});
-                            parsedResponse = ListUsersExtendedResponse.builder()
-                                    .users(items)
-                                    .build();
+                            JsonNode wrapper =
+                                    ObjectMappers.JSON_MAPPER.createObjectNode().set("users", responseNode);
+                            parsedResponse =
+                                    ObjectMappers.JSON_MAPPER.convertValue(wrapper, ListUsersExtendedResponse.class);
                         } else {
                             parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
                                     responseNode, ListUsersExtendedResponse.class);
@@ -960,11 +950,10 @@ public class AsyncRawInlineUsersClient {
                         JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                         ListUsersExtendedOptionalListResponse parsedResponse;
                         if (responseNode.isArray()) {
-                            Optional<List<User>> items = ObjectMappers.JSON_MAPPER.convertValue(
-                                    responseNode, new TypeReference<Optional<List<User>>>() {});
-                            parsedResponse = ListUsersExtendedOptionalListResponse.builder()
-                                    .users(items)
-                                    .build();
+                            JsonNode wrapper =
+                                    ObjectMappers.JSON_MAPPER.createObjectNode().set("users", responseNode);
+                            parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                                    wrapper, ListUsersExtendedOptionalListResponse.class);
                         } else {
                             parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
                                     responseNode, ListUsersExtendedOptionalListResponse.class);
@@ -1045,10 +1034,9 @@ public class AsyncRawInlineUsersClient {
                         JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                         UsernameCursor parsedResponse;
                         if (responseNode.isArray()) {
-                            List<String> items = ObjectMappers.JSON_MAPPER.convertValue(
-                                    responseNode, new TypeReference<List<String>>() {});
-                            parsedResponse =
-                                    UsernameCursor.builder().data(items).build();
+                            JsonNode wrapper =
+                                    ObjectMappers.JSON_MAPPER.createObjectNode().set("data", responseNode);
+                            parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(wrapper, UsernameCursor.class);
                         } else {
                             parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(responseNode, UsernameCursor.class);
                         }
@@ -1129,10 +1117,9 @@ public class AsyncRawInlineUsersClient {
                         JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                         UsernameContainer parsedResponse;
                         if (responseNode.isArray()) {
-                            List<String> items = ObjectMappers.JSON_MAPPER.convertValue(
-                                    responseNode, new TypeReference<List<String>>() {});
-                            parsedResponse =
-                                    UsernameContainer.builder().results(items).build();
+                            JsonNode wrapper =
+                                    ObjectMappers.JSON_MAPPER.createObjectNode().set("results", responseNode);
+                            parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(wrapper, UsernameContainer.class);
                         } else {
                             parsedResponse =
                                     ObjectMappers.JSON_MAPPER.convertValue(responseNode, UsernameContainer.class);

--- a/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/RawInlineUsersClient.java
+++ b/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/RawInlineUsersClient.java
@@ -4,7 +4,6 @@
 package com.seed.pagination.resources.inlineusers.inlineusers;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.seed.pagination.core.ClientOptions;
 import com.seed.pagination.core.MediaTypes;
@@ -106,10 +105,9 @@ public class RawInlineUsersClient {
                 JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                 ListUsersPaginationResponse parsedResponse;
                 if (responseNode.isArray()) {
-                    List<User> items =
-                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<User>>() {});
-                    parsedResponse =
-                            ListUsersPaginationResponse.builder().users(items).build();
+                    JsonNode wrapper =
+                            ObjectMappers.JSON_MAPPER.createObjectNode().set("users", responseNode);
+                    parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(wrapper, ListUsersPaginationResponse.class);
                 } else {
                     parsedResponse =
                             ObjectMappers.JSON_MAPPER.convertValue(responseNode, ListUsersPaginationResponse.class);
@@ -172,11 +170,10 @@ public class RawInlineUsersClient {
                 JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                 ListUsersMixedTypePaginationResponse parsedResponse;
                 if (responseNode.isArray()) {
-                    List<User> items =
-                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<User>>() {});
-                    parsedResponse = ListUsersMixedTypePaginationResponse.builder()
-                            .users(items)
-                            .build();
+                    JsonNode wrapper =
+                            ObjectMappers.JSON_MAPPER.createObjectNode().set("users", responseNode);
+                    parsedResponse =
+                            ObjectMappers.JSON_MAPPER.convertValue(wrapper, ListUsersMixedTypePaginationResponse.class);
                 } else {
                     parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
                             responseNode, ListUsersMixedTypePaginationResponse.class);
@@ -246,10 +243,9 @@ public class RawInlineUsersClient {
                 JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                 ListUsersPaginationResponse parsedResponse;
                 if (responseNode.isArray()) {
-                    List<User> items =
-                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<User>>() {});
-                    parsedResponse =
-                            ListUsersPaginationResponse.builder().users(items).build();
+                    JsonNode wrapper =
+                            ObjectMappers.JSON_MAPPER.createObjectNode().set("users", responseNode);
+                    parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(wrapper, ListUsersPaginationResponse.class);
                 } else {
                     parsedResponse =
                             ObjectMappers.JSON_MAPPER.convertValue(responseNode, ListUsersPaginationResponse.class);
@@ -329,10 +325,9 @@ public class RawInlineUsersClient {
                 JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                 ListUsersPaginationResponse parsedResponse;
                 if (responseNode.isArray()) {
-                    List<User> items =
-                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<User>>() {});
-                    parsedResponse =
-                            ListUsersPaginationResponse.builder().users(items).build();
+                    JsonNode wrapper =
+                            ObjectMappers.JSON_MAPPER.createObjectNode().set("users", responseNode);
+                    parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(wrapper, ListUsersPaginationResponse.class);
                 } else {
                     parsedResponse =
                             ObjectMappers.JSON_MAPPER.convertValue(responseNode, ListUsersPaginationResponse.class);
@@ -406,10 +401,9 @@ public class RawInlineUsersClient {
                 JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                 ListUsersPaginationResponse parsedResponse;
                 if (responseNode.isArray()) {
-                    List<User> items =
-                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<User>>() {});
-                    parsedResponse =
-                            ListUsersPaginationResponse.builder().users(items).build();
+                    JsonNode wrapper =
+                            ObjectMappers.JSON_MAPPER.createObjectNode().set("users", responseNode);
+                    parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(wrapper, ListUsersPaginationResponse.class);
                 } else {
                     parsedResponse =
                             ObjectMappers.JSON_MAPPER.convertValue(responseNode, ListUsersPaginationResponse.class);
@@ -476,10 +470,9 @@ public class RawInlineUsersClient {
                 JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                 ListUsersPaginationResponse parsedResponse;
                 if (responseNode.isArray()) {
-                    List<User> items =
-                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<User>>() {});
-                    parsedResponse =
-                            ListUsersPaginationResponse.builder().users(items).build();
+                    JsonNode wrapper =
+                            ObjectMappers.JSON_MAPPER.createObjectNode().set("users", responseNode);
+                    parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(wrapper, ListUsersPaginationResponse.class);
                 } else {
                     parsedResponse =
                             ObjectMappers.JSON_MAPPER.convertValue(responseNode, ListUsersPaginationResponse.class);
@@ -555,10 +548,9 @@ public class RawInlineUsersClient {
                 JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                 ListUsersPaginationResponse parsedResponse;
                 if (responseNode.isArray()) {
-                    List<User> items =
-                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<User>>() {});
-                    parsedResponse =
-                            ListUsersPaginationResponse.builder().users(items).build();
+                    JsonNode wrapper =
+                            ObjectMappers.JSON_MAPPER.createObjectNode().set("users", responseNode);
+                    parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(wrapper, ListUsersPaginationResponse.class);
                 } else {
                     parsedResponse =
                             ObjectMappers.JSON_MAPPER.convertValue(responseNode, ListUsersPaginationResponse.class);
@@ -628,10 +620,9 @@ public class RawInlineUsersClient {
                 JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                 ListUsersPaginationResponse parsedResponse;
                 if (responseNode.isArray()) {
-                    List<User> items =
-                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<User>>() {});
-                    parsedResponse =
-                            ListUsersPaginationResponse.builder().users(items).build();
+                    JsonNode wrapper =
+                            ObjectMappers.JSON_MAPPER.createObjectNode().set("users", responseNode);
+                    parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(wrapper, ListUsersPaginationResponse.class);
                 } else {
                     parsedResponse =
                             ObjectMappers.JSON_MAPPER.convertValue(responseNode, ListUsersPaginationResponse.class);
@@ -694,10 +685,9 @@ public class RawInlineUsersClient {
                 JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                 ListUsersExtendedResponse parsedResponse;
                 if (responseNode.isArray()) {
-                    List<User> items =
-                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<User>>() {});
-                    parsedResponse =
-                            ListUsersExtendedResponse.builder().users(items).build();
+                    JsonNode wrapper =
+                            ObjectMappers.JSON_MAPPER.createObjectNode().set("users", responseNode);
+                    parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(wrapper, ListUsersExtendedResponse.class);
                 } else {
                     parsedResponse =
                             ObjectMappers.JSON_MAPPER.convertValue(responseNode, ListUsersExtendedResponse.class);
@@ -759,11 +749,10 @@ public class RawInlineUsersClient {
                 JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                 ListUsersExtendedOptionalListResponse parsedResponse;
                 if (responseNode.isArray()) {
-                    Optional<List<User>> items = ObjectMappers.JSON_MAPPER.convertValue(
-                            responseNode, new TypeReference<Optional<List<User>>>() {});
-                    parsedResponse = ListUsersExtendedOptionalListResponse.builder()
-                            .users(items)
-                            .build();
+                    JsonNode wrapper =
+                            ObjectMappers.JSON_MAPPER.createObjectNode().set("users", responseNode);
+                    parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                            wrapper, ListUsersExtendedOptionalListResponse.class);
                 } else {
                     parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
                             responseNode, ListUsersExtendedOptionalListResponse.class);
@@ -825,9 +814,9 @@ public class RawInlineUsersClient {
                 JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                 UsernameCursor parsedResponse;
                 if (responseNode.isArray()) {
-                    List<String> items =
-                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<String>>() {});
-                    parsedResponse = UsernameCursor.builder().data(items).build();
+                    JsonNode wrapper =
+                            ObjectMappers.JSON_MAPPER.createObjectNode().set("data", responseNode);
+                    parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(wrapper, UsernameCursor.class);
                 } else {
                     parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(responseNode, UsernameCursor.class);
                 }
@@ -887,9 +876,9 @@ public class RawInlineUsersClient {
                 JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                 UsernameContainer parsedResponse;
                 if (responseNode.isArray()) {
-                    List<String> items =
-                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<String>>() {});
-                    parsedResponse = UsernameContainer.builder().results(items).build();
+                    JsonNode wrapper =
+                            ObjectMappers.JSON_MAPPER.createObjectNode().set("results", responseNode);
+                    parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(wrapper, UsernameContainer.class);
                 } else {
                     parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(responseNode, UsernameContainer.class);
                 }

--- a/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/RawInlineUsersClient.java
+++ b/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/RawInlineUsersClient.java
@@ -4,6 +4,8 @@
 package com.seed.pagination.resources.inlineusers.inlineusers;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.seed.pagination.core.ClientOptions;
 import com.seed.pagination.core.MediaTypes;
 import com.seed.pagination.core.ObjectMappers;
@@ -101,8 +103,17 @@ public class RawInlineUsersClient {
             ResponseBody responseBody = response.body();
             String responseBodyString = responseBody != null ? responseBody.string() : "{}";
             if (response.isSuccessful()) {
-                ListUsersPaginationResponse parsedResponse =
-                        ObjectMappers.JSON_MAPPER.readValue(responseBodyString, ListUsersPaginationResponse.class);
+                JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                ListUsersPaginationResponse parsedResponse;
+                if (responseNode.isArray()) {
+                    List<User> items =
+                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<User>>() {});
+                    parsedResponse =
+                            ListUsersPaginationResponse.builder().users(items).build();
+                } else {
+                    parsedResponse =
+                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, ListUsersPaginationResponse.class);
+                }
                 Optional<String> startingAfter =
                         parsedResponse.getPage().flatMap(Page::getNext).map(NextPage::getStartingAfter);
                 ListUsersCursorPaginationRequest nextRequest = ListUsersCursorPaginationRequest.builder()
@@ -158,8 +169,18 @@ public class RawInlineUsersClient {
             ResponseBody responseBody = response.body();
             String responseBodyString = responseBody != null ? responseBody.string() : "{}";
             if (response.isSuccessful()) {
-                ListUsersMixedTypePaginationResponse parsedResponse = ObjectMappers.JSON_MAPPER.readValue(
-                        responseBodyString, ListUsersMixedTypePaginationResponse.class);
+                JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                ListUsersMixedTypePaginationResponse parsedResponse;
+                if (responseNode.isArray()) {
+                    List<User> items =
+                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<User>>() {});
+                    parsedResponse = ListUsersMixedTypePaginationResponse.builder()
+                            .users(items)
+                            .build();
+                } else {
+                    parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                            responseNode, ListUsersMixedTypePaginationResponse.class);
+                }
                 String startingAfter = parsedResponse.getNext();
                 ListUsersMixedTypeCursorPaginationRequest nextRequest =
                         ListUsersMixedTypeCursorPaginationRequest.builder()
@@ -222,8 +243,17 @@ public class RawInlineUsersClient {
             ResponseBody responseBody = response.body();
             String responseBodyString = responseBody != null ? responseBody.string() : "{}";
             if (response.isSuccessful()) {
-                ListUsersPaginationResponse parsedResponse =
-                        ObjectMappers.JSON_MAPPER.readValue(responseBodyString, ListUsersPaginationResponse.class);
+                JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                ListUsersPaginationResponse parsedResponse;
+                if (responseNode.isArray()) {
+                    List<User> items =
+                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<User>>() {});
+                    parsedResponse =
+                            ListUsersPaginationResponse.builder().users(items).build();
+                } else {
+                    parsedResponse =
+                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, ListUsersPaginationResponse.class);
+                }
                 Optional<String> startingAfter =
                         parsedResponse.getPage().flatMap(Page::getNext).map(NextPage::getStartingAfter);
                 Optional<WithCursor> pagination = request.getPagination()
@@ -296,8 +326,17 @@ public class RawInlineUsersClient {
             ResponseBody responseBody = response.body();
             String responseBodyString = responseBody != null ? responseBody.string() : "{}";
             if (response.isSuccessful()) {
-                ListUsersPaginationResponse parsedResponse =
-                        ObjectMappers.JSON_MAPPER.readValue(responseBodyString, ListUsersPaginationResponse.class);
+                JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                ListUsersPaginationResponse parsedResponse;
+                if (responseNode.isArray()) {
+                    List<User> items =
+                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<User>>() {});
+                    parsedResponse =
+                            ListUsersPaginationResponse.builder().users(items).build();
+                } else {
+                    parsedResponse =
+                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, ListUsersPaginationResponse.class);
+                }
                 int newPageNumber =
                         request.getPage().map((Integer page) -> page + 1).orElse(1);
                 ListUsersOffsetPaginationRequest nextRequest = ListUsersOffsetPaginationRequest.builder()
@@ -364,8 +403,17 @@ public class RawInlineUsersClient {
             ResponseBody responseBody = response.body();
             String responseBodyString = responseBody != null ? responseBody.string() : "{}";
             if (response.isSuccessful()) {
-                ListUsersPaginationResponse parsedResponse =
-                        ObjectMappers.JSON_MAPPER.readValue(responseBodyString, ListUsersPaginationResponse.class);
+                JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                ListUsersPaginationResponse parsedResponse;
+                if (responseNode.isArray()) {
+                    List<User> items =
+                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<User>>() {});
+                    parsedResponse =
+                            ListUsersPaginationResponse.builder().users(items).build();
+                } else {
+                    parsedResponse =
+                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, ListUsersPaginationResponse.class);
+                }
                 double newPageNumber =
                         request.getPage().map((Double page) -> page + 1.0).orElse(1.0);
                 ListUsersDoubleOffsetPaginationRequest nextRequest = ListUsersDoubleOffsetPaginationRequest.builder()
@@ -425,8 +473,17 @@ public class RawInlineUsersClient {
             ResponseBody responseBody = response.body();
             String responseBodyString = responseBody != null ? responseBody.string() : "{}";
             if (response.isSuccessful()) {
-                ListUsersPaginationResponse parsedResponse =
-                        ObjectMappers.JSON_MAPPER.readValue(responseBodyString, ListUsersPaginationResponse.class);
+                JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                ListUsersPaginationResponse parsedResponse;
+                if (responseNode.isArray()) {
+                    List<User> items =
+                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<User>>() {});
+                    parsedResponse =
+                            ListUsersPaginationResponse.builder().users(items).build();
+                } else {
+                    parsedResponse =
+                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, ListUsersPaginationResponse.class);
+                }
                 int newPageNumber = request.getPagination()
                         .flatMap(WithPage::getPage)
                         .map((Integer page) -> page + 1)
@@ -495,8 +552,17 @@ public class RawInlineUsersClient {
             ResponseBody responseBody = response.body();
             String responseBodyString = responseBody != null ? responseBody.string() : "{}";
             if (response.isSuccessful()) {
-                ListUsersPaginationResponse parsedResponse =
-                        ObjectMappers.JSON_MAPPER.readValue(responseBodyString, ListUsersPaginationResponse.class);
+                JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                ListUsersPaginationResponse parsedResponse;
+                if (responseNode.isArray()) {
+                    List<User> items =
+                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<User>>() {});
+                    parsedResponse =
+                            ListUsersPaginationResponse.builder().users(items).build();
+                } else {
+                    parsedResponse =
+                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, ListUsersPaginationResponse.class);
+                }
                 int newPageNumber =
                         request.getPage().map((Integer page) -> page + 1).orElse(1);
                 ListUsersOffsetStepPaginationRequest nextRequest = ListUsersOffsetStepPaginationRequest.builder()
@@ -559,8 +625,17 @@ public class RawInlineUsersClient {
             ResponseBody responseBody = response.body();
             String responseBodyString = responseBody != null ? responseBody.string() : "{}";
             if (response.isSuccessful()) {
-                ListUsersPaginationResponse parsedResponse =
-                        ObjectMappers.JSON_MAPPER.readValue(responseBodyString, ListUsersPaginationResponse.class);
+                JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                ListUsersPaginationResponse parsedResponse;
+                if (responseNode.isArray()) {
+                    List<User> items =
+                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<User>>() {});
+                    parsedResponse =
+                            ListUsersPaginationResponse.builder().users(items).build();
+                } else {
+                    parsedResponse =
+                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, ListUsersPaginationResponse.class);
+                }
                 int newPageNumber =
                         request.getPage().map((Integer page) -> page + 1).orElse(1);
                 ListWithOffsetPaginationHasNextPageRequest nextRequest =
@@ -616,8 +691,17 @@ public class RawInlineUsersClient {
             ResponseBody responseBody = response.body();
             String responseBodyString = responseBody != null ? responseBody.string() : "{}";
             if (response.isSuccessful()) {
-                ListUsersExtendedResponse parsedResponse =
-                        ObjectMappers.JSON_MAPPER.readValue(responseBodyString, ListUsersExtendedResponse.class);
+                JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                ListUsersExtendedResponse parsedResponse;
+                if (responseNode.isArray()) {
+                    List<User> items =
+                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<User>>() {});
+                    parsedResponse =
+                            ListUsersExtendedResponse.builder().users(items).build();
+                } else {
+                    parsedResponse =
+                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, ListUsersExtendedResponse.class);
+                }
                 Optional<UUID> startingAfter = parsedResponse.getNext();
                 ListUsersExtendedRequest nextRequest = ListUsersExtendedRequest.builder()
                         .from(request)
@@ -672,8 +756,18 @@ public class RawInlineUsersClient {
             ResponseBody responseBody = response.body();
             String responseBodyString = responseBody != null ? responseBody.string() : "{}";
             if (response.isSuccessful()) {
-                ListUsersExtendedOptionalListResponse parsedResponse = ObjectMappers.JSON_MAPPER.readValue(
-                        responseBodyString, ListUsersExtendedOptionalListResponse.class);
+                JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                ListUsersExtendedOptionalListResponse parsedResponse;
+                if (responseNode.isArray()) {
+                    Optional<List<User>> items = ObjectMappers.JSON_MAPPER.convertValue(
+                            responseNode, new TypeReference<Optional<List<User>>>() {});
+                    parsedResponse = ListUsersExtendedOptionalListResponse.builder()
+                            .users(items)
+                            .build();
+                } else {
+                    parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                            responseNode, ListUsersExtendedOptionalListResponse.class);
+                }
                 Optional<UUID> startingAfter = parsedResponse.getNext();
                 ListUsersExtendedRequestForOptionalData nextRequest = ListUsersExtendedRequestForOptionalData.builder()
                         .from(request)
@@ -728,8 +822,15 @@ public class RawInlineUsersClient {
             ResponseBody responseBody = response.body();
             String responseBodyString = responseBody != null ? responseBody.string() : "{}";
             if (response.isSuccessful()) {
-                UsernameCursor parsedResponse =
-                        ObjectMappers.JSON_MAPPER.readValue(responseBodyString, UsernameCursor.class);
+                JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                UsernameCursor parsedResponse;
+                if (responseNode.isArray()) {
+                    List<String> items =
+                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<String>>() {});
+                    parsedResponse = UsernameCursor.builder().data(items).build();
+                } else {
+                    parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(responseNode, UsernameCursor.class);
+                }
                 Optional<String> startingAfter = parsedResponse.getCursor().getAfter();
                 ListUsernamesRequest nextRequest = ListUsernamesRequest.builder()
                         .from(request)
@@ -783,8 +884,15 @@ public class RawInlineUsersClient {
             ResponseBody responseBody = response.body();
             String responseBodyString = responseBody != null ? responseBody.string() : "{}";
             if (response.isSuccessful()) {
-                UsernameContainer parsedResponse =
-                        ObjectMappers.JSON_MAPPER.readValue(responseBodyString, UsernameContainer.class);
+                JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                UsernameContainer parsedResponse;
+                if (responseNode.isArray()) {
+                    List<String> items =
+                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<String>>() {});
+                    parsedResponse = UsernameContainer.builder().results(items).build();
+                } else {
+                    parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(responseNode, UsernameContainer.class);
+                }
                 int newPageNumber =
                         request.getOffset().map((Integer page) -> page + 1).orElse(1);
                 ListWithGlobalConfigRequest nextRequest = ListWithGlobalConfigRequest.builder()

--- a/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/users/AsyncRawUsersClient.java
+++ b/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/users/AsyncRawUsersClient.java
@@ -4,7 +4,6 @@
 package com.seed.pagination.resources.users;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.seed.pagination.core.ClientOptions;
 import com.seed.pagination.core.MediaTypes;
@@ -114,11 +113,10 @@ public class AsyncRawUsersClient {
                         JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                         ListUsersPaginationResponse parsedResponse;
                         if (responseNode.isArray()) {
-                            List<User> items = ObjectMappers.JSON_MAPPER.convertValue(
-                                    responseNode, new TypeReference<List<User>>() {});
-                            parsedResponse = ListUsersPaginationResponse.builder()
-                                    .data(items)
-                                    .build();
+                            JsonNode wrapper =
+                                    ObjectMappers.JSON_MAPPER.createObjectNode().set("data", responseNode);
+                            parsedResponse =
+                                    ObjectMappers.JSON_MAPPER.convertValue(wrapper, ListUsersPaginationResponse.class);
                         } else {
                             parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
                                     responseNode, ListUsersPaginationResponse.class);
@@ -200,11 +198,10 @@ public class AsyncRawUsersClient {
                         JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                         ListUsersMixedTypePaginationResponse parsedResponse;
                         if (responseNode.isArray()) {
-                            List<User> items = ObjectMappers.JSON_MAPPER.convertValue(
-                                    responseNode, new TypeReference<List<User>>() {});
-                            parsedResponse = ListUsersMixedTypePaginationResponse.builder()
-                                    .data(items)
-                                    .build();
+                            JsonNode wrapper =
+                                    ObjectMappers.JSON_MAPPER.createObjectNode().set("data", responseNode);
+                            parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                                    wrapper, ListUsersMixedTypePaginationResponse.class);
                         } else {
                             parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
                                     responseNode, ListUsersMixedTypePaginationResponse.class);
@@ -291,11 +288,10 @@ public class AsyncRawUsersClient {
                         JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                         ListUsersPaginationResponse parsedResponse;
                         if (responseNode.isArray()) {
-                            List<User> items = ObjectMappers.JSON_MAPPER.convertValue(
-                                    responseNode, new TypeReference<List<User>>() {});
-                            parsedResponse = ListUsersPaginationResponse.builder()
-                                    .data(items)
-                                    .build();
+                            JsonNode wrapper =
+                                    ObjectMappers.JSON_MAPPER.createObjectNode().set("data", responseNode);
+                            parsedResponse =
+                                    ObjectMappers.JSON_MAPPER.convertValue(wrapper, ListUsersPaginationResponse.class);
                         } else {
                             parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
                                     responseNode, ListUsersPaginationResponse.class);
@@ -395,11 +391,10 @@ public class AsyncRawUsersClient {
                         JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                         ListUsersPaginationResponse parsedResponse;
                         if (responseNode.isArray()) {
-                            List<User> items = ObjectMappers.JSON_MAPPER.convertValue(
-                                    responseNode, new TypeReference<List<User>>() {});
-                            parsedResponse = ListUsersPaginationResponse.builder()
-                                    .data(items)
-                                    .build();
+                            JsonNode wrapper =
+                                    ObjectMappers.JSON_MAPPER.createObjectNode().set("data", responseNode);
+                            parsedResponse =
+                                    ObjectMappers.JSON_MAPPER.convertValue(wrapper, ListUsersPaginationResponse.class);
                         } else {
                             parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
                                     responseNode, ListUsersPaginationResponse.class);
@@ -494,11 +489,10 @@ public class AsyncRawUsersClient {
                         JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                         ListUsersPaginationResponse parsedResponse;
                         if (responseNode.isArray()) {
-                            List<User> items = ObjectMappers.JSON_MAPPER.convertValue(
-                                    responseNode, new TypeReference<List<User>>() {});
-                            parsedResponse = ListUsersPaginationResponse.builder()
-                                    .data(items)
-                                    .build();
+                            JsonNode wrapper =
+                                    ObjectMappers.JSON_MAPPER.createObjectNode().set("data", responseNode);
+                            parsedResponse =
+                                    ObjectMappers.JSON_MAPPER.convertValue(wrapper, ListUsersPaginationResponse.class);
                         } else {
                             parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
                                     responseNode, ListUsersPaginationResponse.class);
@@ -587,11 +581,10 @@ public class AsyncRawUsersClient {
                         JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                         ListUsersPaginationResponse parsedResponse;
                         if (responseNode.isArray()) {
-                            List<User> items = ObjectMappers.JSON_MAPPER.convertValue(
-                                    responseNode, new TypeReference<List<User>>() {});
-                            parsedResponse = ListUsersPaginationResponse.builder()
-                                    .data(items)
-                                    .build();
+                            JsonNode wrapper =
+                                    ObjectMappers.JSON_MAPPER.createObjectNode().set("data", responseNode);
+                            parsedResponse =
+                                    ObjectMappers.JSON_MAPPER.convertValue(wrapper, ListUsersPaginationResponse.class);
                         } else {
                             parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
                                     responseNode, ListUsersPaginationResponse.class);
@@ -689,11 +682,10 @@ public class AsyncRawUsersClient {
                         JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                         ListUsersPaginationResponse parsedResponse;
                         if (responseNode.isArray()) {
-                            List<User> items = ObjectMappers.JSON_MAPPER.convertValue(
-                                    responseNode, new TypeReference<List<User>>() {});
-                            parsedResponse = ListUsersPaginationResponse.builder()
-                                    .data(items)
-                                    .build();
+                            JsonNode wrapper =
+                                    ObjectMappers.JSON_MAPPER.createObjectNode().set("data", responseNode);
+                            parsedResponse =
+                                    ObjectMappers.JSON_MAPPER.convertValue(wrapper, ListUsersPaginationResponse.class);
                         } else {
                             parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
                                     responseNode, ListUsersPaginationResponse.class);
@@ -786,11 +778,10 @@ public class AsyncRawUsersClient {
                         JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                         ListUsersPaginationResponse parsedResponse;
                         if (responseNode.isArray()) {
-                            List<User> items = ObjectMappers.JSON_MAPPER.convertValue(
-                                    responseNode, new TypeReference<List<User>>() {});
-                            parsedResponse = ListUsersPaginationResponse.builder()
-                                    .data(items)
-                                    .build();
+                            JsonNode wrapper =
+                                    ObjectMappers.JSON_MAPPER.createObjectNode().set("data", responseNode);
+                            parsedResponse =
+                                    ObjectMappers.JSON_MAPPER.convertValue(wrapper, ListUsersPaginationResponse.class);
                         } else {
                             parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
                                     responseNode, ListUsersPaginationResponse.class);
@@ -873,11 +864,10 @@ public class AsyncRawUsersClient {
                         JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                         ListUsersExtendedResponse parsedResponse;
                         if (responseNode.isArray()) {
-                            List<User> items = ObjectMappers.JSON_MAPPER.convertValue(
-                                    responseNode, new TypeReference<List<User>>() {});
-                            parsedResponse = ListUsersExtendedResponse.builder()
-                                    .users(items)
-                                    .build();
+                            JsonNode wrapper =
+                                    ObjectMappers.JSON_MAPPER.createObjectNode().set("users", responseNode);
+                            parsedResponse =
+                                    ObjectMappers.JSON_MAPPER.convertValue(wrapper, ListUsersExtendedResponse.class);
                         } else {
                             parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
                                     responseNode, ListUsersExtendedResponse.class);
@@ -960,11 +950,10 @@ public class AsyncRawUsersClient {
                         JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                         ListUsersExtendedOptionalListResponse parsedResponse;
                         if (responseNode.isArray()) {
-                            Optional<List<User>> items = ObjectMappers.JSON_MAPPER.convertValue(
-                                    responseNode, new TypeReference<Optional<List<User>>>() {});
-                            parsedResponse = ListUsersExtendedOptionalListResponse.builder()
-                                    .users(items)
-                                    .build();
+                            JsonNode wrapper =
+                                    ObjectMappers.JSON_MAPPER.createObjectNode().set("users", responseNode);
+                            parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                                    wrapper, ListUsersExtendedOptionalListResponse.class);
                         } else {
                             parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
                                     responseNode, ListUsersExtendedOptionalListResponse.class);
@@ -1045,10 +1034,9 @@ public class AsyncRawUsersClient {
                         JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                         UsernameCursor parsedResponse;
                         if (responseNode.isArray()) {
-                            List<String> items = ObjectMappers.JSON_MAPPER.convertValue(
-                                    responseNode, new TypeReference<List<String>>() {});
-                            parsedResponse =
-                                    UsernameCursor.builder().data(items).build();
+                            JsonNode wrapper =
+                                    ObjectMappers.JSON_MAPPER.createObjectNode().set("data", responseNode);
+                            parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(wrapper, UsernameCursor.class);
                         } else {
                             parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(responseNode, UsernameCursor.class);
                         }
@@ -1129,10 +1117,9 @@ public class AsyncRawUsersClient {
                         JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                         UsernameContainer parsedResponse;
                         if (responseNode.isArray()) {
-                            List<String> items = ObjectMappers.JSON_MAPPER.convertValue(
-                                    responseNode, new TypeReference<List<String>>() {});
-                            parsedResponse =
-                                    UsernameContainer.builder().results(items).build();
+                            JsonNode wrapper =
+                                    ObjectMappers.JSON_MAPPER.createObjectNode().set("results", responseNode);
+                            parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(wrapper, UsernameContainer.class);
                         } else {
                             parsedResponse =
                                     ObjectMappers.JSON_MAPPER.convertValue(responseNode, UsernameContainer.class);

--- a/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/users/AsyncRawUsersClient.java
+++ b/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/users/AsyncRawUsersClient.java
@@ -4,6 +4,8 @@
 package com.seed.pagination.resources.users;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.seed.pagination.core.ClientOptions;
 import com.seed.pagination.core.MediaTypes;
 import com.seed.pagination.core.ObjectMappers;
@@ -109,8 +111,18 @@ public class AsyncRawUsersClient {
                 try (ResponseBody responseBody = response.body()) {
                     String responseBodyString = responseBody != null ? responseBody.string() : "{}";
                     if (response.isSuccessful()) {
-                        ListUsersPaginationResponse parsedResponse = ObjectMappers.JSON_MAPPER.readValue(
-                                responseBodyString, ListUsersPaginationResponse.class);
+                        JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                        ListUsersPaginationResponse parsedResponse;
+                        if (responseNode.isArray()) {
+                            List<User> items = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, new TypeReference<List<User>>() {});
+                            parsedResponse = ListUsersPaginationResponse.builder()
+                                    .data(items)
+                                    .build();
+                        } else {
+                            parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, ListUsersPaginationResponse.class);
+                        }
                         Optional<String> startingAfter =
                                 parsedResponse.getPage().flatMap(Page::getNext).map(NextPage::getStartingAfter);
                         ListUsersCursorPaginationRequest nextRequest = ListUsersCursorPaginationRequest.builder()
@@ -185,8 +197,18 @@ public class AsyncRawUsersClient {
                 try (ResponseBody responseBody = response.body()) {
                     String responseBodyString = responseBody != null ? responseBody.string() : "{}";
                     if (response.isSuccessful()) {
-                        ListUsersMixedTypePaginationResponse parsedResponse = ObjectMappers.JSON_MAPPER.readValue(
-                                responseBodyString, ListUsersMixedTypePaginationResponse.class);
+                        JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                        ListUsersMixedTypePaginationResponse parsedResponse;
+                        if (responseNode.isArray()) {
+                            List<User> items = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, new TypeReference<List<User>>() {});
+                            parsedResponse = ListUsersMixedTypePaginationResponse.builder()
+                                    .data(items)
+                                    .build();
+                        } else {
+                            parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, ListUsersMixedTypePaginationResponse.class);
+                        }
                         String startingAfter = parsedResponse.getNext();
                         ListUsersMixedTypeCursorPaginationRequest nextRequest =
                                 ListUsersMixedTypeCursorPaginationRequest.builder()
@@ -266,8 +288,18 @@ public class AsyncRawUsersClient {
                 try (ResponseBody responseBody = response.body()) {
                     String responseBodyString = responseBody != null ? responseBody.string() : "{}";
                     if (response.isSuccessful()) {
-                        ListUsersPaginationResponse parsedResponse = ObjectMappers.JSON_MAPPER.readValue(
-                                responseBodyString, ListUsersPaginationResponse.class);
+                        JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                        ListUsersPaginationResponse parsedResponse;
+                        if (responseNode.isArray()) {
+                            List<User> items = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, new TypeReference<List<User>>() {});
+                            parsedResponse = ListUsersPaginationResponse.builder()
+                                    .data(items)
+                                    .build();
+                        } else {
+                            parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, ListUsersPaginationResponse.class);
+                        }
                         Optional<String> startingAfter =
                                 parsedResponse.getPage().flatMap(Page::getNext).map(NextPage::getStartingAfter);
                         Optional<WithCursor> pagination = request.getPagination()
@@ -360,8 +392,18 @@ public class AsyncRawUsersClient {
                 try (ResponseBody responseBody = response.body()) {
                     String responseBodyString = responseBody != null ? responseBody.string() : "{}";
                     if (response.isSuccessful()) {
-                        ListUsersPaginationResponse parsedResponse = ObjectMappers.JSON_MAPPER.readValue(
-                                responseBodyString, ListUsersPaginationResponse.class);
+                        JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                        ListUsersPaginationResponse parsedResponse;
+                        if (responseNode.isArray()) {
+                            List<User> items = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, new TypeReference<List<User>>() {});
+                            parsedResponse = ListUsersPaginationResponse.builder()
+                                    .data(items)
+                                    .build();
+                        } else {
+                            parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, ListUsersPaginationResponse.class);
+                        }
                         int newPageNumber = request.getPage()
                                 .map((Integer page) -> page + 1)
                                 .orElse(1);
@@ -449,8 +491,18 @@ public class AsyncRawUsersClient {
                 try (ResponseBody responseBody = response.body()) {
                     String responseBodyString = responseBody != null ? responseBody.string() : "{}";
                     if (response.isSuccessful()) {
-                        ListUsersPaginationResponse parsedResponse = ObjectMappers.JSON_MAPPER.readValue(
-                                responseBodyString, ListUsersPaginationResponse.class);
+                        JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                        ListUsersPaginationResponse parsedResponse;
+                        if (responseNode.isArray()) {
+                            List<User> items = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, new TypeReference<List<User>>() {});
+                            parsedResponse = ListUsersPaginationResponse.builder()
+                                    .data(items)
+                                    .build();
+                        } else {
+                            parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, ListUsersPaginationResponse.class);
+                        }
                         double newPageNumber = request.getPage()
                                 .map((Double page) -> page + 1.0)
                                 .orElse(1.0);
@@ -532,8 +584,18 @@ public class AsyncRawUsersClient {
                 try (ResponseBody responseBody = response.body()) {
                     String responseBodyString = responseBody != null ? responseBody.string() : "{}";
                     if (response.isSuccessful()) {
-                        ListUsersPaginationResponse parsedResponse = ObjectMappers.JSON_MAPPER.readValue(
-                                responseBodyString, ListUsersPaginationResponse.class);
+                        JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                        ListUsersPaginationResponse parsedResponse;
+                        if (responseNode.isArray()) {
+                            List<User> items = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, new TypeReference<List<User>>() {});
+                            parsedResponse = ListUsersPaginationResponse.builder()
+                                    .data(items)
+                                    .build();
+                        } else {
+                            parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, ListUsersPaginationResponse.class);
+                        }
                         int newPageNumber = request.getPagination()
                                 .flatMap(WithPage::getPage)
                                 .map((Integer page) -> page + 1)
@@ -624,8 +686,18 @@ public class AsyncRawUsersClient {
                 try (ResponseBody responseBody = response.body()) {
                     String responseBodyString = responseBody != null ? responseBody.string() : "{}";
                     if (response.isSuccessful()) {
-                        ListUsersPaginationResponse parsedResponse = ObjectMappers.JSON_MAPPER.readValue(
-                                responseBodyString, ListUsersPaginationResponse.class);
+                        JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                        ListUsersPaginationResponse parsedResponse;
+                        if (responseNode.isArray()) {
+                            List<User> items = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, new TypeReference<List<User>>() {});
+                            parsedResponse = ListUsersPaginationResponse.builder()
+                                    .data(items)
+                                    .build();
+                        } else {
+                            parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, ListUsersPaginationResponse.class);
+                        }
                         int newPageNumber = request.getPage()
                                 .map((Integer page) -> page + 1)
                                 .orElse(1);
@@ -711,8 +783,18 @@ public class AsyncRawUsersClient {
                 try (ResponseBody responseBody = response.body()) {
                     String responseBodyString = responseBody != null ? responseBody.string() : "{}";
                     if (response.isSuccessful()) {
-                        ListUsersPaginationResponse parsedResponse = ObjectMappers.JSON_MAPPER.readValue(
-                                responseBodyString, ListUsersPaginationResponse.class);
+                        JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                        ListUsersPaginationResponse parsedResponse;
+                        if (responseNode.isArray()) {
+                            List<User> items = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, new TypeReference<List<User>>() {});
+                            parsedResponse = ListUsersPaginationResponse.builder()
+                                    .data(items)
+                                    .build();
+                        } else {
+                            parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, ListUsersPaginationResponse.class);
+                        }
                         int newPageNumber = request.getPage()
                                 .map((Integer page) -> page + 1)
                                 .orElse(1);
@@ -788,8 +870,18 @@ public class AsyncRawUsersClient {
                 try (ResponseBody responseBody = response.body()) {
                     String responseBodyString = responseBody != null ? responseBody.string() : "{}";
                     if (response.isSuccessful()) {
-                        ListUsersExtendedResponse parsedResponse = ObjectMappers.JSON_MAPPER.readValue(
-                                responseBodyString, ListUsersExtendedResponse.class);
+                        JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                        ListUsersExtendedResponse parsedResponse;
+                        if (responseNode.isArray()) {
+                            List<User> items = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, new TypeReference<List<User>>() {});
+                            parsedResponse = ListUsersExtendedResponse.builder()
+                                    .users(items)
+                                    .build();
+                        } else {
+                            parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, ListUsersExtendedResponse.class);
+                        }
                         Optional<UUID> startingAfter = parsedResponse.getNext();
                         ListUsersExtendedRequest nextRequest = ListUsersExtendedRequest.builder()
                                 .from(request)
@@ -865,8 +957,18 @@ public class AsyncRawUsersClient {
                 try (ResponseBody responseBody = response.body()) {
                     String responseBodyString = responseBody != null ? responseBody.string() : "{}";
                     if (response.isSuccessful()) {
-                        ListUsersExtendedOptionalListResponse parsedResponse = ObjectMappers.JSON_MAPPER.readValue(
-                                responseBodyString, ListUsersExtendedOptionalListResponse.class);
+                        JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                        ListUsersExtendedOptionalListResponse parsedResponse;
+                        if (responseNode.isArray()) {
+                            Optional<List<User>> items = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, new TypeReference<Optional<List<User>>>() {});
+                            parsedResponse = ListUsersExtendedOptionalListResponse.builder()
+                                    .users(items)
+                                    .build();
+                        } else {
+                            parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, ListUsersExtendedOptionalListResponse.class);
+                        }
                         Optional<UUID> startingAfter = parsedResponse.getNext();
                         ListUsersExtendedRequestForOptionalData nextRequest =
                                 ListUsersExtendedRequestForOptionalData.builder()
@@ -940,8 +1042,16 @@ public class AsyncRawUsersClient {
                 try (ResponseBody responseBody = response.body()) {
                     String responseBodyString = responseBody != null ? responseBody.string() : "{}";
                     if (response.isSuccessful()) {
-                        UsernameCursor parsedResponse =
-                                ObjectMappers.JSON_MAPPER.readValue(responseBodyString, UsernameCursor.class);
+                        JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                        UsernameCursor parsedResponse;
+                        if (responseNode.isArray()) {
+                            List<String> items = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, new TypeReference<List<String>>() {});
+                            parsedResponse =
+                                    UsernameCursor.builder().data(items).build();
+                        } else {
+                            parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(responseNode, UsernameCursor.class);
+                        }
                         Optional<String> startingAfter =
                                 parsedResponse.getCursor().getAfter();
                         ListUsernamesRequest nextRequest = ListUsernamesRequest.builder()
@@ -1016,8 +1126,17 @@ public class AsyncRawUsersClient {
                 try (ResponseBody responseBody = response.body()) {
                     String responseBodyString = responseBody != null ? responseBody.string() : "{}";
                     if (response.isSuccessful()) {
-                        UsernameContainer parsedResponse =
-                                ObjectMappers.JSON_MAPPER.readValue(responseBodyString, UsernameContainer.class);
+                        JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                        UsernameContainer parsedResponse;
+                        if (responseNode.isArray()) {
+                            List<String> items = ObjectMappers.JSON_MAPPER.convertValue(
+                                    responseNode, new TypeReference<List<String>>() {});
+                            parsedResponse =
+                                    UsernameContainer.builder().results(items).build();
+                        } else {
+                            parsedResponse =
+                                    ObjectMappers.JSON_MAPPER.convertValue(responseNode, UsernameContainer.class);
+                        }
                         int newPageNumber = request.getOffset()
                                 .map((Integer page) -> page + 1)
                                 .orElse(1);

--- a/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/users/RawUsersClient.java
+++ b/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/users/RawUsersClient.java
@@ -4,6 +4,8 @@
 package com.seed.pagination.resources.users;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.seed.pagination.core.ClientOptions;
 import com.seed.pagination.core.MediaTypes;
 import com.seed.pagination.core.ObjectMappers;
@@ -101,8 +103,17 @@ public class RawUsersClient {
             ResponseBody responseBody = response.body();
             String responseBodyString = responseBody != null ? responseBody.string() : "{}";
             if (response.isSuccessful()) {
-                ListUsersPaginationResponse parsedResponse =
-                        ObjectMappers.JSON_MAPPER.readValue(responseBodyString, ListUsersPaginationResponse.class);
+                JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                ListUsersPaginationResponse parsedResponse;
+                if (responseNode.isArray()) {
+                    List<User> items =
+                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<User>>() {});
+                    parsedResponse =
+                            ListUsersPaginationResponse.builder().data(items).build();
+                } else {
+                    parsedResponse =
+                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, ListUsersPaginationResponse.class);
+                }
                 Optional<String> startingAfter =
                         parsedResponse.getPage().flatMap(Page::getNext).map(NextPage::getStartingAfter);
                 ListUsersCursorPaginationRequest nextRequest = ListUsersCursorPaginationRequest.builder()
@@ -158,8 +169,18 @@ public class RawUsersClient {
             ResponseBody responseBody = response.body();
             String responseBodyString = responseBody != null ? responseBody.string() : "{}";
             if (response.isSuccessful()) {
-                ListUsersMixedTypePaginationResponse parsedResponse = ObjectMappers.JSON_MAPPER.readValue(
-                        responseBodyString, ListUsersMixedTypePaginationResponse.class);
+                JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                ListUsersMixedTypePaginationResponse parsedResponse;
+                if (responseNode.isArray()) {
+                    List<User> items =
+                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<User>>() {});
+                    parsedResponse = ListUsersMixedTypePaginationResponse.builder()
+                            .data(items)
+                            .build();
+                } else {
+                    parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                            responseNode, ListUsersMixedTypePaginationResponse.class);
+                }
                 String startingAfter = parsedResponse.getNext();
                 ListUsersMixedTypeCursorPaginationRequest nextRequest =
                         ListUsersMixedTypeCursorPaginationRequest.builder()
@@ -222,8 +243,17 @@ public class RawUsersClient {
             ResponseBody responseBody = response.body();
             String responseBodyString = responseBody != null ? responseBody.string() : "{}";
             if (response.isSuccessful()) {
-                ListUsersPaginationResponse parsedResponse =
-                        ObjectMappers.JSON_MAPPER.readValue(responseBodyString, ListUsersPaginationResponse.class);
+                JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                ListUsersPaginationResponse parsedResponse;
+                if (responseNode.isArray()) {
+                    List<User> items =
+                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<User>>() {});
+                    parsedResponse =
+                            ListUsersPaginationResponse.builder().data(items).build();
+                } else {
+                    parsedResponse =
+                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, ListUsersPaginationResponse.class);
+                }
                 Optional<String> startingAfter =
                         parsedResponse.getPage().flatMap(Page::getNext).map(NextPage::getStartingAfter);
                 Optional<WithCursor> pagination = request.getPagination()
@@ -296,8 +326,17 @@ public class RawUsersClient {
             ResponseBody responseBody = response.body();
             String responseBodyString = responseBody != null ? responseBody.string() : "{}";
             if (response.isSuccessful()) {
-                ListUsersPaginationResponse parsedResponse =
-                        ObjectMappers.JSON_MAPPER.readValue(responseBodyString, ListUsersPaginationResponse.class);
+                JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                ListUsersPaginationResponse parsedResponse;
+                if (responseNode.isArray()) {
+                    List<User> items =
+                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<User>>() {});
+                    parsedResponse =
+                            ListUsersPaginationResponse.builder().data(items).build();
+                } else {
+                    parsedResponse =
+                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, ListUsersPaginationResponse.class);
+                }
                 int newPageNumber =
                         request.getPage().map((Integer page) -> page + 1).orElse(1);
                 ListUsersOffsetPaginationRequest nextRequest = ListUsersOffsetPaginationRequest.builder()
@@ -364,8 +403,17 @@ public class RawUsersClient {
             ResponseBody responseBody = response.body();
             String responseBodyString = responseBody != null ? responseBody.string() : "{}";
             if (response.isSuccessful()) {
-                ListUsersPaginationResponse parsedResponse =
-                        ObjectMappers.JSON_MAPPER.readValue(responseBodyString, ListUsersPaginationResponse.class);
+                JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                ListUsersPaginationResponse parsedResponse;
+                if (responseNode.isArray()) {
+                    List<User> items =
+                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<User>>() {});
+                    parsedResponse =
+                            ListUsersPaginationResponse.builder().data(items).build();
+                } else {
+                    parsedResponse =
+                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, ListUsersPaginationResponse.class);
+                }
                 double newPageNumber =
                         request.getPage().map((Double page) -> page + 1.0).orElse(1.0);
                 ListUsersDoubleOffsetPaginationRequest nextRequest = ListUsersDoubleOffsetPaginationRequest.builder()
@@ -425,8 +473,17 @@ public class RawUsersClient {
             ResponseBody responseBody = response.body();
             String responseBodyString = responseBody != null ? responseBody.string() : "{}";
             if (response.isSuccessful()) {
-                ListUsersPaginationResponse parsedResponse =
-                        ObjectMappers.JSON_MAPPER.readValue(responseBodyString, ListUsersPaginationResponse.class);
+                JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                ListUsersPaginationResponse parsedResponse;
+                if (responseNode.isArray()) {
+                    List<User> items =
+                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<User>>() {});
+                    parsedResponse =
+                            ListUsersPaginationResponse.builder().data(items).build();
+                } else {
+                    parsedResponse =
+                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, ListUsersPaginationResponse.class);
+                }
                 int newPageNumber = request.getPagination()
                         .flatMap(WithPage::getPage)
                         .map((Integer page) -> page + 1)
@@ -495,8 +552,17 @@ public class RawUsersClient {
             ResponseBody responseBody = response.body();
             String responseBodyString = responseBody != null ? responseBody.string() : "{}";
             if (response.isSuccessful()) {
-                ListUsersPaginationResponse parsedResponse =
-                        ObjectMappers.JSON_MAPPER.readValue(responseBodyString, ListUsersPaginationResponse.class);
+                JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                ListUsersPaginationResponse parsedResponse;
+                if (responseNode.isArray()) {
+                    List<User> items =
+                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<User>>() {});
+                    parsedResponse =
+                            ListUsersPaginationResponse.builder().data(items).build();
+                } else {
+                    parsedResponse =
+                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, ListUsersPaginationResponse.class);
+                }
                 int newPageNumber =
                         request.getPage().map((Integer page) -> page + 1).orElse(1);
                 ListUsersOffsetStepPaginationRequest nextRequest = ListUsersOffsetStepPaginationRequest.builder()
@@ -559,8 +625,17 @@ public class RawUsersClient {
             ResponseBody responseBody = response.body();
             String responseBodyString = responseBody != null ? responseBody.string() : "{}";
             if (response.isSuccessful()) {
-                ListUsersPaginationResponse parsedResponse =
-                        ObjectMappers.JSON_MAPPER.readValue(responseBodyString, ListUsersPaginationResponse.class);
+                JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                ListUsersPaginationResponse parsedResponse;
+                if (responseNode.isArray()) {
+                    List<User> items =
+                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<User>>() {});
+                    parsedResponse =
+                            ListUsersPaginationResponse.builder().data(items).build();
+                } else {
+                    parsedResponse =
+                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, ListUsersPaginationResponse.class);
+                }
                 int newPageNumber =
                         request.getPage().map((Integer page) -> page + 1).orElse(1);
                 ListWithOffsetPaginationHasNextPageRequest nextRequest =
@@ -616,8 +691,17 @@ public class RawUsersClient {
             ResponseBody responseBody = response.body();
             String responseBodyString = responseBody != null ? responseBody.string() : "{}";
             if (response.isSuccessful()) {
-                ListUsersExtendedResponse parsedResponse =
-                        ObjectMappers.JSON_MAPPER.readValue(responseBodyString, ListUsersExtendedResponse.class);
+                JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                ListUsersExtendedResponse parsedResponse;
+                if (responseNode.isArray()) {
+                    List<User> items =
+                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<User>>() {});
+                    parsedResponse =
+                            ListUsersExtendedResponse.builder().users(items).build();
+                } else {
+                    parsedResponse =
+                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, ListUsersExtendedResponse.class);
+                }
                 Optional<UUID> startingAfter = parsedResponse.getNext();
                 ListUsersExtendedRequest nextRequest = ListUsersExtendedRequest.builder()
                         .from(request)
@@ -672,8 +756,18 @@ public class RawUsersClient {
             ResponseBody responseBody = response.body();
             String responseBodyString = responseBody != null ? responseBody.string() : "{}";
             if (response.isSuccessful()) {
-                ListUsersExtendedOptionalListResponse parsedResponse = ObjectMappers.JSON_MAPPER.readValue(
-                        responseBodyString, ListUsersExtendedOptionalListResponse.class);
+                JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                ListUsersExtendedOptionalListResponse parsedResponse;
+                if (responseNode.isArray()) {
+                    Optional<List<User>> items = ObjectMappers.JSON_MAPPER.convertValue(
+                            responseNode, new TypeReference<Optional<List<User>>>() {});
+                    parsedResponse = ListUsersExtendedOptionalListResponse.builder()
+                            .users(items)
+                            .build();
+                } else {
+                    parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                            responseNode, ListUsersExtendedOptionalListResponse.class);
+                }
                 Optional<UUID> startingAfter = parsedResponse.getNext();
                 ListUsersExtendedRequestForOptionalData nextRequest = ListUsersExtendedRequestForOptionalData.builder()
                         .from(request)
@@ -728,8 +822,15 @@ public class RawUsersClient {
             ResponseBody responseBody = response.body();
             String responseBodyString = responseBody != null ? responseBody.string() : "{}";
             if (response.isSuccessful()) {
-                UsernameCursor parsedResponse =
-                        ObjectMappers.JSON_MAPPER.readValue(responseBodyString, UsernameCursor.class);
+                JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                UsernameCursor parsedResponse;
+                if (responseNode.isArray()) {
+                    List<String> items =
+                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<String>>() {});
+                    parsedResponse = UsernameCursor.builder().data(items).build();
+                } else {
+                    parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(responseNode, UsernameCursor.class);
+                }
                 Optional<String> startingAfter = parsedResponse.getCursor().getAfter();
                 ListUsernamesRequest nextRequest = ListUsernamesRequest.builder()
                         .from(request)
@@ -783,8 +884,15 @@ public class RawUsersClient {
             ResponseBody responseBody = response.body();
             String responseBodyString = responseBody != null ? responseBody.string() : "{}";
             if (response.isSuccessful()) {
-                UsernameContainer parsedResponse =
-                        ObjectMappers.JSON_MAPPER.readValue(responseBodyString, UsernameContainer.class);
+                JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
+                UsernameContainer parsedResponse;
+                if (responseNode.isArray()) {
+                    List<String> items =
+                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<String>>() {});
+                    parsedResponse = UsernameContainer.builder().results(items).build();
+                } else {
+                    parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(responseNode, UsernameContainer.class);
+                }
                 int newPageNumber =
                         request.getOffset().map((Integer page) -> page + 1).orElse(1);
                 ListWithGlobalConfigRequest nextRequest = ListWithGlobalConfigRequest.builder()

--- a/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/users/RawUsersClient.java
+++ b/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/users/RawUsersClient.java
@@ -4,7 +4,6 @@
 package com.seed.pagination.resources.users;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.seed.pagination.core.ClientOptions;
 import com.seed.pagination.core.MediaTypes;
@@ -106,10 +105,9 @@ public class RawUsersClient {
                 JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                 ListUsersPaginationResponse parsedResponse;
                 if (responseNode.isArray()) {
-                    List<User> items =
-                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<User>>() {});
-                    parsedResponse =
-                            ListUsersPaginationResponse.builder().data(items).build();
+                    JsonNode wrapper =
+                            ObjectMappers.JSON_MAPPER.createObjectNode().set("data", responseNode);
+                    parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(wrapper, ListUsersPaginationResponse.class);
                 } else {
                     parsedResponse =
                             ObjectMappers.JSON_MAPPER.convertValue(responseNode, ListUsersPaginationResponse.class);
@@ -172,11 +170,10 @@ public class RawUsersClient {
                 JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                 ListUsersMixedTypePaginationResponse parsedResponse;
                 if (responseNode.isArray()) {
-                    List<User> items =
-                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<User>>() {});
-                    parsedResponse = ListUsersMixedTypePaginationResponse.builder()
-                            .data(items)
-                            .build();
+                    JsonNode wrapper =
+                            ObjectMappers.JSON_MAPPER.createObjectNode().set("data", responseNode);
+                    parsedResponse =
+                            ObjectMappers.JSON_MAPPER.convertValue(wrapper, ListUsersMixedTypePaginationResponse.class);
                 } else {
                     parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
                             responseNode, ListUsersMixedTypePaginationResponse.class);
@@ -246,10 +243,9 @@ public class RawUsersClient {
                 JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                 ListUsersPaginationResponse parsedResponse;
                 if (responseNode.isArray()) {
-                    List<User> items =
-                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<User>>() {});
-                    parsedResponse =
-                            ListUsersPaginationResponse.builder().data(items).build();
+                    JsonNode wrapper =
+                            ObjectMappers.JSON_MAPPER.createObjectNode().set("data", responseNode);
+                    parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(wrapper, ListUsersPaginationResponse.class);
                 } else {
                     parsedResponse =
                             ObjectMappers.JSON_MAPPER.convertValue(responseNode, ListUsersPaginationResponse.class);
@@ -329,10 +325,9 @@ public class RawUsersClient {
                 JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                 ListUsersPaginationResponse parsedResponse;
                 if (responseNode.isArray()) {
-                    List<User> items =
-                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<User>>() {});
-                    parsedResponse =
-                            ListUsersPaginationResponse.builder().data(items).build();
+                    JsonNode wrapper =
+                            ObjectMappers.JSON_MAPPER.createObjectNode().set("data", responseNode);
+                    parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(wrapper, ListUsersPaginationResponse.class);
                 } else {
                     parsedResponse =
                             ObjectMappers.JSON_MAPPER.convertValue(responseNode, ListUsersPaginationResponse.class);
@@ -406,10 +401,9 @@ public class RawUsersClient {
                 JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                 ListUsersPaginationResponse parsedResponse;
                 if (responseNode.isArray()) {
-                    List<User> items =
-                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<User>>() {});
-                    parsedResponse =
-                            ListUsersPaginationResponse.builder().data(items).build();
+                    JsonNode wrapper =
+                            ObjectMappers.JSON_MAPPER.createObjectNode().set("data", responseNode);
+                    parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(wrapper, ListUsersPaginationResponse.class);
                 } else {
                     parsedResponse =
                             ObjectMappers.JSON_MAPPER.convertValue(responseNode, ListUsersPaginationResponse.class);
@@ -476,10 +470,9 @@ public class RawUsersClient {
                 JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                 ListUsersPaginationResponse parsedResponse;
                 if (responseNode.isArray()) {
-                    List<User> items =
-                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<User>>() {});
-                    parsedResponse =
-                            ListUsersPaginationResponse.builder().data(items).build();
+                    JsonNode wrapper =
+                            ObjectMappers.JSON_MAPPER.createObjectNode().set("data", responseNode);
+                    parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(wrapper, ListUsersPaginationResponse.class);
                 } else {
                     parsedResponse =
                             ObjectMappers.JSON_MAPPER.convertValue(responseNode, ListUsersPaginationResponse.class);
@@ -555,10 +548,9 @@ public class RawUsersClient {
                 JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                 ListUsersPaginationResponse parsedResponse;
                 if (responseNode.isArray()) {
-                    List<User> items =
-                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<User>>() {});
-                    parsedResponse =
-                            ListUsersPaginationResponse.builder().data(items).build();
+                    JsonNode wrapper =
+                            ObjectMappers.JSON_MAPPER.createObjectNode().set("data", responseNode);
+                    parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(wrapper, ListUsersPaginationResponse.class);
                 } else {
                     parsedResponse =
                             ObjectMappers.JSON_MAPPER.convertValue(responseNode, ListUsersPaginationResponse.class);
@@ -628,10 +620,9 @@ public class RawUsersClient {
                 JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                 ListUsersPaginationResponse parsedResponse;
                 if (responseNode.isArray()) {
-                    List<User> items =
-                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<User>>() {});
-                    parsedResponse =
-                            ListUsersPaginationResponse.builder().data(items).build();
+                    JsonNode wrapper =
+                            ObjectMappers.JSON_MAPPER.createObjectNode().set("data", responseNode);
+                    parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(wrapper, ListUsersPaginationResponse.class);
                 } else {
                     parsedResponse =
                             ObjectMappers.JSON_MAPPER.convertValue(responseNode, ListUsersPaginationResponse.class);
@@ -694,10 +685,9 @@ public class RawUsersClient {
                 JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                 ListUsersExtendedResponse parsedResponse;
                 if (responseNode.isArray()) {
-                    List<User> items =
-                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<User>>() {});
-                    parsedResponse =
-                            ListUsersExtendedResponse.builder().users(items).build();
+                    JsonNode wrapper =
+                            ObjectMappers.JSON_MAPPER.createObjectNode().set("users", responseNode);
+                    parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(wrapper, ListUsersExtendedResponse.class);
                 } else {
                     parsedResponse =
                             ObjectMappers.JSON_MAPPER.convertValue(responseNode, ListUsersExtendedResponse.class);
@@ -759,11 +749,10 @@ public class RawUsersClient {
                 JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                 ListUsersExtendedOptionalListResponse parsedResponse;
                 if (responseNode.isArray()) {
-                    Optional<List<User>> items = ObjectMappers.JSON_MAPPER.convertValue(
-                            responseNode, new TypeReference<Optional<List<User>>>() {});
-                    parsedResponse = ListUsersExtendedOptionalListResponse.builder()
-                            .users(items)
-                            .build();
+                    JsonNode wrapper =
+                            ObjectMappers.JSON_MAPPER.createObjectNode().set("users", responseNode);
+                    parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
+                            wrapper, ListUsersExtendedOptionalListResponse.class);
                 } else {
                     parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(
                             responseNode, ListUsersExtendedOptionalListResponse.class);
@@ -825,9 +814,9 @@ public class RawUsersClient {
                 JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                 UsernameCursor parsedResponse;
                 if (responseNode.isArray()) {
-                    List<String> items =
-                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<String>>() {});
-                    parsedResponse = UsernameCursor.builder().data(items).build();
+                    JsonNode wrapper =
+                            ObjectMappers.JSON_MAPPER.createObjectNode().set("data", responseNode);
+                    parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(wrapper, UsernameCursor.class);
                 } else {
                     parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(responseNode, UsernameCursor.class);
                 }
@@ -887,9 +876,9 @@ public class RawUsersClient {
                 JsonNode responseNode = ObjectMappers.JSON_MAPPER.readTree(responseBodyString);
                 UsernameContainer parsedResponse;
                 if (responseNode.isArray()) {
-                    List<String> items =
-                            ObjectMappers.JSON_MAPPER.convertValue(responseNode, new TypeReference<List<String>>() {});
-                    parsedResponse = UsernameContainer.builder().results(items).build();
+                    JsonNode wrapper =
+                            ObjectMappers.JSON_MAPPER.createObjectNode().set("results", responseNode);
+                    parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(wrapper, UsernameContainer.class);
                 } else {
                     parsedResponse = ObjectMappers.JSON_MAPPER.convertValue(responseNode, UsernameContainer.class);
                 }


### PR DESCRIPTION
## Description
Linear ticket: Closes [FER-7845: \[Java, Auth0\] array issues in paginated endpoints.](https://linear.app/buildwithfern/issue/FER-7845/java-auth0-array-issues-in-paginated-endpoints)
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
<!-- Provide a clear and concise description of the changes made in this PR -->

Some APIs (like Auth0) return different response formats depending on query parameters. For example, `GET /api/v2/clients` returns:
  - An object with pagination metadata when include_totals=true
  - A raw JSON array when include_totals is not set
  
This fix adds defensive parsing that checks the response structure before deserialization. 

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated
- [x] Manual testing completed - checked with auth0 and payroc
