### PR TITLE
fix(ruby): fix root client generation for inferred auth

### DIFF
--- a/generators/ruby-v2/sdk/src/root-client/RootClientGenerator.ts
+++ b/generators/ruby-v2/sdk/src/root-client/RootClientGenerator.ts
@@ -103,28 +103,98 @@ export class RootClientGenerator extends FileGenerator<RubyFile, SdkCustomConfig
 
     private getInferredAuthInitializationStatement(scheme: InferredAuthScheme): ruby.AstNode {
         const inferredParams = this.getParametersForInferredAuth(scheme);
+
+        // Get the auth service/endpoint info to determine the auth client class
+        const tokenEndpointReference = scheme.tokenEndpoint.endpoint;
+        const service = this.context.ir.services[tokenEndpointReference.serviceId];
+        const subpackageId = service?.name.fernFilepath.packagePath[0]?.pascalCase.safeName ?? "Auth";
+
         return ruby.codeblock((writer) => {
+            // Create an unauthenticated raw client for the auth endpoint
+            writer.writeLine(`# Create an unauthenticated client for the auth endpoint`);
+            writer.write(`auth_raw_client = `);
+            writer.writeNode(this.context.getRawClientClassReference());
+            writer.writeLine(`.new(`);
+            writer.indent();
+            writer.writeLine(`base_url: base_url,`);
+            writer.writeLine(`headers: {`);
+            writer.indent();
+
+            // Add X-Fern-Language header
+            const hasParams = inferredParams.length > 0;
+            writer.writeLine(`"X-Fern-Language": "Ruby"${hasParams ? "," : ""}`);
+
+            // Add any header-based auth params to the auth client headers
+            for (let i = 0; i < inferredParams.length; i++) {
+                const param = inferredParams[i];
+                if (param == null) {
+                    continue;
+                }
+                const headerName = this.snakeToHeaderCase(param.snakeName);
+                const isLast = i === inferredParams.length - 1;
+                writer.writeLine(`"${headerName}": ${param.snakeName}${isLast ? "" : ","}`);
+            }
+
+            writer.dedent();
+            writer.writeLine(`}`);
+            writer.dedent();
+            writer.writeLine(`)`);
+            writer.newLine();
+
+            // Create the auth client
+            writer.writeLine(`# Create the auth client for token retrieval`);
+            writer.write(`auth_client = `);
+            writer.writeNode(
+                ruby.classReference({
+                    name: "Client",
+                    modules: [this.context.getRootModule().name, subpackageId],
+                    fullyQualified: true
+                })
+            );
+            writer.writeLine(`.new(client: auth_raw_client)`);
+            writer.newLine();
+
+            // Create the auth provider with auth_client and options
+            writer.writeLine(`# Create the auth provider with the auth client and credentials`);
             writer.write(`@auth_provider = `);
             writer.writeNode(this.getInferredAuthProviderClassReference());
             writer.writeLine(`.new(`);
             writer.indent();
+            writer.writeLine(`auth_client: auth_client,`);
+            writer.write(`options: { `);
             for (let i = 0; i < inferredParams.length; i++) {
                 const param = inferredParams[i];
                 if (param == null) {
                     continue;
                 }
                 const isLast = i === inferredParams.length - 1;
-                writer.writeLine(`${param.snakeName}: ${param.snakeName}${isLast ? "" : ","}`);
+                writer.write(`${param.snakeName}: ${param.snakeName}${isLast ? "" : ", "}`);
             }
+            writer.writeLine(` }`);
             writer.dedent();
             writer.writeLine(`)`);
         });
     }
 
+    private snakeToHeaderCase(snakeName: string): string {
+        // Convert snake_case to X-Header-Case (e.g., api_key -> X-Api-Key)
+        // If the name already starts with x_, don't add another X- prefix
+        const parts = snakeName.split("_");
+        const startsWithX = parts[0]?.toLowerCase() === "x";
+
+        if (startsWithX) {
+            // x_api_key -> X-Api-Key (use existing x as the X- prefix)
+            return parts.map((part) => part.charAt(0).toUpperCase() + part.slice(1)).join("-");
+        } else {
+            // api_key -> X-Api-Key (add X- prefix)
+            return "X-" + parts.map((part) => part.charAt(0).toUpperCase() + part.slice(1)).join("-");
+        }
+    }
+
     private getInferredAuthProviderClassReference(): ruby.ClassReference {
         return ruby.classReference({
             name: "InferredAuthProvider",
-            modules: [this.context.getRootModule().name],
+            modules: [this.context.getRootModule().name, "Internal"],
             fullyQualified: true
         });
     }

--- a/generators/ruby-v2/sdk/versions.yml
+++ b/generators/ruby-v2/sdk/versions.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.0.0-rc52
+  createdAt: "2025-11-29"
+  changelogEntry:
+    - type: fix
+      summary: |
+        Fix root client generation for inferred auth. The client now correctly creates an
+        unauthenticated client for the auth endpoint, passes auth_client and options to
+        InferredAuthProvider, and uses the correct Internal namespace.
+  irVersion: 61
+
 - version: 1.0.0-rc51
   createdAt: "2025-11-29"
   changelogEntry:

--- a/seed/ruby-sdk-v2/inferred-auth-explicit/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-explicit/lib/seed/client.rb
@@ -10,11 +10,25 @@ module Seed
     #
     # @return [void]
     def initialize(base_url:, client_id:, client_secret:, x_api_key:, scope: nil)
-      @auth_provider = Seed::InferredAuthProvider.new(
-        client_id: client_id,
-        client_secret: client_secret,
-        scope: scope,
-        x_api_key: x_api_key
+      # Create an unauthenticated client for the auth endpoint
+      auth_raw_client = Seed::Internal::Http::RawClient.new(
+        base_url: base_url,
+        headers: {
+          "X-Fern-Language": "Ruby",
+          "X-Client-Id": client_id,
+          "X-Client-Secret": client_secret,
+          "X-Scope": scope,
+          "X-Api-Key": x_api_key
+        }
+      )
+
+      # Create the auth client for token retrieval
+      auth_client = Seed::Auth::Client.new(client: auth_raw_client)
+
+      # Create the auth provider with the auth client and credentials
+      @auth_provider = Seed::Internal::InferredAuthProvider.new(
+        auth_client: auth_client,
+        options: { client_id: client_id, client_secret: client_secret, scope: scope, x_api_key: x_api_key }
       )
 
       @raw_client = Seed::Internal::Http::RawClient.new(

--- a/seed/ruby-sdk-v2/inferred-auth-implicit-no-expiry/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit-no-expiry/lib/seed/client.rb
@@ -10,11 +10,25 @@ module Seed
     #
     # @return [void]
     def initialize(base_url:, client_id:, client_secret:, x_api_key:, scope: nil)
-      @auth_provider = Seed::InferredAuthProvider.new(
-        client_id: client_id,
-        client_secret: client_secret,
-        scope: scope,
-        x_api_key: x_api_key
+      # Create an unauthenticated client for the auth endpoint
+      auth_raw_client = Seed::Internal::Http::RawClient.new(
+        base_url: base_url,
+        headers: {
+          "X-Fern-Language": "Ruby",
+          "X-Client-Id": client_id,
+          "X-Client-Secret": client_secret,
+          "X-Scope": scope,
+          "X-Api-Key": x_api_key
+        }
+      )
+
+      # Create the auth client for token retrieval
+      auth_client = Seed::Auth::Client.new(client: auth_raw_client)
+
+      # Create the auth provider with the auth client and credentials
+      @auth_provider = Seed::Internal::InferredAuthProvider.new(
+        auth_client: auth_client,
+        options: { client_id: client_id, client_secret: client_secret, scope: scope, x_api_key: x_api_key }
       )
 
       @raw_client = Seed::Internal::Http::RawClient.new(

--- a/seed/ruby-sdk-v2/inferred-auth-implicit/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit/lib/seed/client.rb
@@ -10,11 +10,25 @@ module Seed
     #
     # @return [void]
     def initialize(base_url:, client_id:, client_secret:, x_api_key:, scope: nil)
-      @auth_provider = Seed::InferredAuthProvider.new(
-        client_id: client_id,
-        client_secret: client_secret,
-        scope: scope,
-        x_api_key: x_api_key
+      # Create an unauthenticated client for the auth endpoint
+      auth_raw_client = Seed::Internal::Http::RawClient.new(
+        base_url: base_url,
+        headers: {
+          "X-Fern-Language": "Ruby",
+          "X-Client-Id": client_id,
+          "X-Client-Secret": client_secret,
+          "X-Scope": scope,
+          "X-Api-Key": x_api_key
+        }
+      )
+
+      # Create the auth client for token retrieval
+      auth_client = Seed::Auth::Client.new(client: auth_raw_client)
+
+      # Create the auth provider with the auth client and credentials
+      @auth_provider = Seed::Internal::InferredAuthProvider.new(
+        auth_client: auth_client,
+        options: { client_id: client_id, client_secret: client_secret, scope: scope, x_api_key: x_api_key }
       )
 
       @raw_client = Seed::Internal::Http::RawClient.new(

--- a/seed/ruby-sdk-v2/websocket-inferred-auth/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/websocket-inferred-auth/lib/seed/client.rb
@@ -10,11 +10,25 @@ module Seed
     #
     # @return [void]
     def initialize(base_url:, client_id:, client_secret:, x_api_key:, scope: nil)
-      @auth_provider = Seed::InferredAuthProvider.new(
-        client_id: client_id,
-        client_secret: client_secret,
-        scope: scope,
-        x_api_key: x_api_key
+      # Create an unauthenticated client for the auth endpoint
+      auth_raw_client = Seed::Internal::Http::RawClient.new(
+        base_url: base_url,
+        headers: {
+          "X-Fern-Language": "Ruby",
+          "X-Client-Id": client_id,
+          "X-Client-Secret": client_secret,
+          "X-Scope": scope,
+          "X-Api-Key": x_api_key
+        }
+      )
+
+      # Create the auth client for token retrieval
+      auth_client = Seed::Auth::Client.new(client: auth_raw_client)
+
+      # Create the auth provider with the auth client and credentials
+      @auth_provider = Seed::Internal::InferredAuthProvider.new(
+        auth_client: auth_client,
+        options: { client_id: client_id, client_secret: client_secret, scope: scope, x_api_key: x_api_key }
       )
 
       @raw_client = Seed::Internal::Http::RawClient.new(


### PR DESCRIPTION
The root client was incorrectly generating the InferredAuthProvider initialization:
- Used wrong namespace (missing Internal)
- Passed credentials directly instead of auth_client and options

Now correctly:
- Creates unauthenticated raw client for auth endpoint
- Creates auth client from the Auth subpackage
- Passes auth_client and options to InferredAuthProvider
- Uses correct Payroc::Internal::InferredAuthProvider namespace
- Adds auth params as headers to the auth client

🤖 Generated with [Claude Code](https://claude.com/claude-code)