### PR TITLE
chore(deps): update express

### DIFF
--- a/packages/cli/docs-preview/package.json
+++ b/packages/cli/docs-preview/package.json
@@ -45,7 +45,7 @@
     "cli-progress": "^3.12.0",
     "cors": "^2.8.5",
     "decompress": "^4.2.1",
-    "express": "^4.21.2",
+    "express": "^4.22.0",
     "gray-matter": "^4.0.3",
     "tmp-promise": "^3.0.3",
     "uuid": "^9.0.1",

--- a/packages/cli/ete-tests/package.json
+++ b/packages/cli/ete-tests/package.json
@@ -38,7 +38,7 @@
     "@fern-api/logger": "workspace:*",
     "@fern-api/logging-execa": "workspace:*",
     "execa": "^5.1.1",
-    "express": "^4.21.2",
+    "express": "^4.22.0",
     "js-yaml": "^4.1.1",
     "node-fetch": "2.7.0",
     "openapi-types": "^12.1.3",

--- a/packages/cli/mock/package.json
+++ b/packages/cli/mock/package.json
@@ -35,7 +35,7 @@
     "@fern-api/ir-sdk": "workspace:*",
     "@fern-api/task-context": "workspace:*",
     "@types/lodash-es": "^4.17.12",
-    "express": "^4.21.2",
+    "express": "^4.22.0",
     "get-port": "^7.1.0",
     "lodash-es": "^4.17.21",
     "url-join": "^5.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5421,8 +5421,8 @@ importers:
         specifier: ^4.2.1
         version: 4.2.1
       express:
-        specifier: ^4.21.2
-        version: 4.21.2
+        specifier: ^4.22.0
+        version: 4.22.1
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
@@ -5603,8 +5603,8 @@ importers:
         specifier: ^5.1.1
         version: 5.1.1
       express:
-        specifier: ^4.21.2
-        version: 4.21.2
+        specifier: ^4.22.0
+        version: 4.22.1
       js-yaml:
         specifier: ^4.1.1
         version: 4.1.1
@@ -6730,8 +6730,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       express:
-        specifier: ^4.21.2
-        version: 4.21.2
+        specifier: ^4.22.0
+        version: 4.22.1
       get-port:
         specifier: ^7.1.0
         version: 7.1.0
@@ -12402,8 +12402,8 @@ packages:
     resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  express@4.21.2:
-    resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
+  express@4.22.1:
+    resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
     engines: {node: '>= 0.10.0'}
 
   extend-shallow@2.0.1:
@@ -20803,7 +20803,7 @@ snapshots:
       jest-message-util: 29.7.0
       jest-util: 29.7.0
 
-  express@4.21.2:
+  express@4.22.1:
     dependencies:
       accepts: 1.3.8
       array-flatten: 1.1.1
@@ -20832,7 +20832,7 @@ snapshots:
       send: 0.19.0
       serve-static: 1.16.2
       setprototypeof: 1.2.0
-      statuses: 2.0.1
+      statuses: 2.0.2
       type-is: 1.6.18
       utils-merge: 1.0.1
       vary: 1.1.2
@@ -24214,8 +24214,7 @@ snapshots:
 
   statuses@2.0.1: {}
 
-  statuses@2.0.2:
-    optional: true
+  statuses@2.0.2: {}
 
   std-env@3.10.0: {}
 


### PR DESCRIPTION
## Description
Update express to resolve dependabot alert: https://github.com/fern-api/fern/security/dependabot/788

## Changes Made
Bump min version from 4.21.2 to 4.22.0

## Testing
CI
