### PR TITLE
fix(python): fix wire test generation for literal params and file uploads

### DIFF
--- a/generators/python-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/python-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -856,8 +856,12 @@ export class EndpointSnippetGenerator {
     }): python.NamedValue[] {
         const args: python.NamedValue[] = [];
 
+        const nonLiteralPathParameters = namedParameters.filter(
+            (parameter) => !this.resolvesToLiteralType(parameter.typeReference)
+        );
+
         const pathParameters = this.context.associateByWireValue({
-            parameters: namedParameters,
+            parameters: nonLiteralPathParameters,
             values: snippet.pathParameters ?? {},
 
             // Path parameters are distributed across the client constructor

--- a/generators/python-v2/dynamic-snippets/src/__test__/__snapshots__/DynamicSnippetsGenerator.test.ts.snap
+++ b/generators/python-v2/dynamic-snippets/src/__test__/__snapshots__/DynamicSnippetsGenerator.test.ts.snap
@@ -119,7 +119,6 @@ client.service.create_movie(
     title="The Boy and the Heron",
     from="Hayao Miyazaki",
     rating=8,
-    type="movie",
     tag="development",
     metadata={
         "actors": [
@@ -272,7 +271,8 @@ client = Acme()
 
 client.service.post(
     file="Hello, world!",
-    file_list=["First", "Second"]
+    file_list=["First", "Second"],
+    maybe_file="example_maybe_file"
 )
 "
 `;

--- a/generators/python-v2/dynamic-snippets/src/context/FilePropertyMapper.ts
+++ b/generators/python-v2/dynamic-snippets/src/context/FilePropertyMapper.ts
@@ -77,10 +77,12 @@ export class FilePropertyMapper {
         property: FernIr.dynamic.FileUploadRequestBodyProperty.File_;
         record: Record<string, unknown>;
     }): python.TypeInstantiation {
-        const fileValue = this.context.getSingleFileValue({ property, record });
+        let fileValue = this.context.getSingleFileValue({ property, record });
+
         if (fileValue == null) {
-            return python.TypeInstantiation.nop();
+            fileValue = `example_${property.wireValue ?? "file"}`;
         }
+
         return this.context.getFileFromString(fileValue);
     }
 

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
 
+- version: 4.41.6
+  changelogEntry:
+    - summary: |
+        Fix Python wire test generation to drop literal-only params and fill in required file arguments so tests match the generated SDK signatures.
+      type: fix
+  createdAt: "2025-12-03"
+  irVersion: 61
+
 - version: 4.41.5
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description
Linear ticket: Closes 
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
<!-- Provide a clear and concise description of the changes made in this PR -->

Fxes a few issues in the Python dynamic snippets and wire test generation pipeline where tests were calling SDK methods with parameters that do not exist or omitting required ones.

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Updated `EndpointSnippetGenerator` and `FilePropertyMapper` to correctly handle literal params and file upload arguments.

## Testing
<!-- Describe how you tested these changes -->
- [ ] Unit tests added/updated
- [x] Manual testing completed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Skips literal parameters in generated snippets, keeps optional object bodies as a single request arg, auto-fills example file names for uploads, and disambiguates path/body name collisions.
> 
> - **Python dynamic snippets**:
>   - **Parameter handling**:
>     - Exclude parameters/properties that resolve to `literal` types from path and body args (`resolvesToLiteralType`).
>     - Prevent flattening of optional/nullable named object bodies; pass as single `request` arg.
>     - Disambiguate name collisions between path params and body properties by suffixing path names with `_`.
>   - **File uploads**:
>     - Provide default example file names (e.g., `example_<wireValue>`) when a single file value is missing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9682db4ec564056829f5ffdb629106c4991ebe3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->