### PR TITLE
fix(ruby): Fix more rubocop violations

### DIFF
--- a/generators/ruby-v2/base/src/asIs/test/unit/internal/iterators/test_cursor_item_iterator.Template.rb
+++ b/generators/ruby-v2/base/src/asIs/test/unit/internal/iterators/test_cursor_item_iterator.Template.rb
@@ -4,9 +4,9 @@ require "minitest/autorun"
 require "stringio"
 require "json"
 require "test_helper"
-require "ostruct"
 
 NUMBERS = (1..65).to_a
+PageResponse = Struct.new(:cards, :next_cursor, keyword_init: true)
 
 class CursorItemIteratorTest < Minitest::Test
   def make_iterator(initial_cursor:)
@@ -16,7 +16,7 @@ class CursorItemIteratorTest < Minitest::Test
       @times_called += 1
       cursor ||= 0
       next_cursor = cursor + 10
-      OpenStruct.new(
+      PageResponse.new(
         cards: NUMBERS[cursor...next_cursor],
         next_cursor: next_cursor < NUMBERS.length ? next_cursor : nil
       )

--- a/generators/ruby-v2/base/src/asIs/test/unit/internal/iterators/test_offset_item_iterator.Template.rb
+++ b/generators/ruby-v2/base/src/asIs/test/unit/internal/iterators/test_offset_item_iterator.Template.rb
@@ -4,8 +4,8 @@ require "minitest/autorun"
 require "stringio"
 require "json"
 require "test_helper"
-require "ostruct"
 
+OffsetPageResponse = Struct.new(:items, :has_next, keyword_init: true)
 TestIteratorConfig = Struct.new(
   :step,
   :has_next_field,
@@ -68,7 +68,7 @@ class OffsetItemIteratorTest < Minitest::Test
         output[config.has_next_field] = slice_end < items.length
       end
 
-      OpenStruct.new(output)
+      OffsetPageResponse.new(**output)
     end
   end
 

--- a/generators/ruby-v2/base/src/project/RubocopFile.ts
+++ b/generators/ruby-v2/base/src/project/RubocopFile.ts
@@ -57,6 +57,12 @@ Metrics/CyclomaticComplexity:
 Metrics/ModuleLength:
   Enabled: false
 
+Layout/LineLength:
+  Enabled: false
+
+Naming/VariableNumber:
+  EnforcedStyle: snake_case
+
 Style/Documentation:
   Enabled: false
 

--- a/generators/ruby-v2/sdk/src/inferred-auth/InferredAuthProviderGenerator.ts
+++ b/generators/ruby-v2/sdk/src/inferred-auth/InferredAuthProviderGenerator.ts
@@ -66,11 +66,11 @@ export class InferredAuthProviderGenerator extends FileGenerator<RubyFile, SdkCu
         // Add initialize method
         class_.addMethod(this.getInitializeMethod());
 
-        // Add get_token method
-        class_.addMethod(this.getGetTokenMethod());
+        // Add token method
+        class_.addMethod(this.getTokenMethod());
 
-        // Add get_auth_headers method
-        class_.addMethod(this.getGetAuthHeadersMethod());
+        // Add auth_headers method
+        class_.addMethod(this.getAuthHeadersMethod());
 
         // Add token_needs_refresh? method if we have an expiry property
         const expiryProperty = this.scheme.tokenEndpoint.expiryProperty;
@@ -141,11 +141,11 @@ export class InferredAuthProviderGenerator extends FileGenerator<RubyFile, SdkCu
         return method;
     }
 
-    private getGetTokenMethod(): ruby.Method {
+    private getTokenMethod(): ruby.Method {
         const expiryProperty = this.scheme.tokenEndpoint.expiryProperty;
 
         const method = ruby.method({
-            name: "get_token",
+            name: "token",
             kind: ruby.MethodKind.Instance,
             docstring:
                 "Returns a cached access token, refreshing if necessary.\nRefreshes the token if it's nil, or if we're within the buffer period before expiration.",
@@ -282,11 +282,11 @@ export class InferredAuthProviderGenerator extends FileGenerator<RubyFile, SdkCu
         return properties;
     }
 
-    private getGetAuthHeadersMethod(): ruby.Method {
+    private getAuthHeadersMethod(): ruby.Method {
         const authenticatedRequestHeaders = this.scheme.tokenEndpoint.authenticatedRequestHeaders;
 
         const method = ruby.method({
-            name: "get_auth_headers",
+            name: "auth_headers",
             kind: ruby.MethodKind.Instance,
             docstring: "Returns the authentication headers to be included in requests.",
             returnType: ruby.Type.hash(ruby.Type.string(), ruby.Type.string())
@@ -294,7 +294,7 @@ export class InferredAuthProviderGenerator extends FileGenerator<RubyFile, SdkCu
 
         method.addStatement(
             ruby.codeblock((writer) => {
-                writer.writeLine("token = get_token");
+                writer.writeLine("access_token = token");
                 writer.writeLine("{");
                 writer.indent();
 
@@ -303,9 +303,9 @@ export class InferredAuthProviderGenerator extends FileGenerator<RubyFile, SdkCu
                     const valuePrefix = header.valuePrefix;
 
                     if (valuePrefix != null) {
-                        writer.writeLine(`"${headerName}" => "${valuePrefix}#{token}",`);
+                        writer.writeLine(`"${headerName}" => "${valuePrefix}#{access_token}",`);
                     } else {
-                        writer.writeLine(`"${headerName}" => token,`);
+                        writer.writeLine(`"${headerName}" => access_token,`);
                     }
                 }
 

--- a/generators/ruby-v2/sdk/src/root-client/RootClientGenerator.ts
+++ b/generators/ruby-v2/sdk/src/root-client/RootClientGenerator.ts
@@ -89,7 +89,7 @@ export class RootClientGenerator extends FileGenerator<RubyFile, SdkCustomConfig
                 writer.write(`headers: `);
                 writer.writeNode(this.getRawClientHeaders());
                 if (inferredAuth != null) {
-                    writer.writeLine(`.merge(@auth_provider.get_auth_headers)`);
+                    writer.writeLine(`.merge(@auth_provider.auth_headers)`);
                 } else {
                     writer.newLine();
                 }

--- a/generators/ruby-v2/sdk/versions.yml
+++ b/generators/ruby-v2/sdk/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.0.0-rc58
+  createdAt: "2025-12-03"
+  changelogEntry:
+    - type: fix
+      summary: |
+        Fix additional RuboCop warnings in generated SDK code:
+        - Disabled Layout/LineLength cop (long type names and require paths are unavoidable)
+        - Set Naming/VariableNumber to snake_case style (allows `last_4`, `address_1`, etc.)
+        - Renamed `get_token` and `get_auth_headers` methods to `token` and `auth_headers`
+        - Replaced OpenStruct with Struct in iterator tests
+  irVersion: 61
+
 - version: 1.0.0-rc57
   createdAt: "2025-12-02"
   changelogEntry:


### PR DESCRIPTION
- Disable Layout/LineLength cop (long type names and require paths are unavoidable)
- Set Naming/VariableNumber to snake_case style (allows `last_4`, `address_1`, etc.)
- Rename `get_token` and `get_auth_headers` methods to `token` and `auth_headers`
- Replace OpenStruct with Struct in iterator tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
