### PR TITLE
fix(python): wire tests respect custom client name

### DIFF
--- a/generators/python-v2/sdk/src/SdkCustomConfig.ts
+++ b/generators/python-v2/sdk/src/SdkCustomConfig.ts
@@ -28,9 +28,18 @@ const relativePathSchema = z
     })
     .transform((pathStr) => pathStr.replace(/^\/+|\/+$/g, ""));
 
-export const SdkCustomConfigSchema = z.object({
-    enable_wire_tests: z.boolean().optional(),
-    package_path: relativePathSchema.optional()
-});
+const ClientConfigSchema = z
+    .object({
+        class_name: z.string().optional()
+    })
+    .passthrough();
+
+export const SdkCustomConfigSchema = z
+    .object({
+        enable_wire_tests: z.boolean().optional(),
+        package_path: relativePathSchema.optional(),
+        client: ClientConfigSchema.optional()
+    })
+    .passthrough();
 
 export type SdkCustomConfigSchema = z.infer<typeof SdkCustomConfigSchema>;

--- a/generators/python-v2/sdk/src/wire-tests/WireTestGenerator.ts
+++ b/generators/python-v2/sdk/src/wire-tests/WireTestGenerator.ts
@@ -446,6 +446,12 @@ export class WireTestGenerator {
     }
 
     private getClientClassName(): string {
+        // Use custom client class name if specified
+        if (this.context.customConfig.client?.class_name) {
+            return this.context.customConfig.client.class_name;
+        }
+
+        // Otherwise, generate from organization and workspace name
         // The client class name follows the pattern: OrganizationWorkspace
         // For seed_exhaustive, it would be SeedExhaustive
         const orgName = this.context.config.organization;

--- a/generators/python-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
+++ b/generators/python-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
@@ -207,9 +207,15 @@ def verify_request_count(
     }
 
     /**
-     * Gets the client class name based on organization and workspace name.
+     * Gets the client class name based on custom config or organization and workspace name.
      */
     private getClientClassName(): string {
+        // Use custom client class name if specified
+        if (this.context.customConfig.client?.class_name) {
+            return this.context.customConfig.client.class_name;
+        }
+
+        // Otherwise, generate from organization and workspace name
         const orgName = this.context.config.organization;
         const workspaceName = this.context.config.workspaceName;
 

--- a/seed/python-sdk/exhaustive/package-path/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/package-path/.fern/metadata.json
@@ -4,6 +4,9 @@
   "generatorVersion": "latest",
   "generatorConfig": {
     "package_path": "matryoshka/doll/structure",
-    "enable_wire_tests": true
+    "enable_wire_tests": true,
+    "client": {
+      "class_name": "Matryoshka"
+    }
   }
 }

--- a/seed/python-sdk/exhaustive/package-path/README.md
+++ b/seed/python-sdk/exhaustive/package-path/README.md
@@ -34,9 +34,9 @@ A full reference for this library is available [here](./reference.md).
 Instantiate and use the client with the following:
 
 ```python
-from seed import SeedExhaustive
+from seed import Matryoshka
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -52,9 +52,9 @@ The SDK also exports an `async` client so that you can make non-blocking calls t
 ```python
 import asyncio
 
-from seed import AsyncSeedExhaustive
+from seed import AsyncMatryoshka
 
-client = AsyncSeedExhaustive(
+client = AsyncMatryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -92,9 +92,9 @@ The SDK provides access to raw response data, including headers, through the `.w
 The `.with_raw_response` property returns a "raw" client that can be used to access the `.headers` and `.data` attributes.
 
 ```python
-from seed import SeedExhaustive
+from seed import Matryoshka
 
-client = SeedExhaustive(
+client = Matryoshka(
     ...,
 )
 response = client.endpoints.container.with_raw_response.get_and_return_list_of_primitives(
@@ -130,9 +130,9 @@ The SDK defaults to a 60 second timeout. You can configure this with a timeout o
 
 ```python
 
-from seed import SeedExhaustive
+from seed import Matryoshka
 
-client = SeedExhaustive(
+client = Matryoshka(
     ...,
     timeout=20.0,
 )
@@ -151,9 +151,9 @@ and transports.
 
 ```python
 import httpx
-from seed import SeedExhaustive
+from seed import Matryoshka
 
-client = SeedExhaustive(
+client = Matryoshka(
     ...,
     httpx_client=httpx.Client(
         proxy="http://my.test.proxy.example.com",

--- a/seed/python-sdk/exhaustive/package-path/reference.md
+++ b/seed/python-sdk/exhaustive/package-path/reference.md
@@ -13,9 +13,9 @@
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed import Matryoshka
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -70,10 +70,10 @@ client.endpoints.container.get_and_return_list_of_primitives(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed import Matryoshka
 from seed.types.object import ObjectWithRequiredField
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -135,9 +135,9 @@ client.endpoints.container.get_and_return_list_of_objects(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed import Matryoshka
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -192,10 +192,10 @@ client.endpoints.container.get_and_return_set_of_primitives(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed import Matryoshka
 from seed.types.object import ObjectWithRequiredField
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -254,9 +254,9 @@ client.endpoints.container.get_and_return_set_of_objects(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed import Matryoshka
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -311,10 +311,10 @@ client.endpoints.container.get_and_return_map_prim_to_prim(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed import Matryoshka
 from seed.types.object import ObjectWithRequiredField
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -373,10 +373,10 @@ client.endpoints.container.get_and_return_map_of_prim_to_object(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed import Matryoshka
 from seed.types.object import ObjectWithRequiredField
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -437,9 +437,9 @@ client.endpoints.container.get_and_return_optional(
 import datetime
 import uuid
 
-from seed import SeedExhaustive
+from seed import Matryoshka
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -611,9 +611,9 @@ client.endpoints.content_type.post_json_patch_content_type(
 import datetime
 import uuid
 
-from seed import SeedExhaustive
+from seed import Matryoshka
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -783,9 +783,9 @@ client.endpoints.content_type.post_json_patch_content_with_charset_type(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed import Matryoshka
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -841,9 +841,9 @@ client.endpoints.enum.get_and_return_enum(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed import Matryoshka
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -898,9 +898,9 @@ client.endpoints.http_methods.test_get(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed import Matryoshka
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -955,9 +955,9 @@ client.endpoints.http_methods.test_post(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed import Matryoshka
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -1024,9 +1024,9 @@ client.endpoints.http_methods.test_put(
 import datetime
 import uuid
 
-from seed import SeedExhaustive
+from seed import Matryoshka
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -1204,9 +1204,9 @@ client.endpoints.http_methods.test_patch(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed import Matryoshka
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -1265,9 +1265,9 @@ client.endpoints.http_methods.test_delete(
 import datetime
 import uuid
 
-from seed import SeedExhaustive
+from seed import Matryoshka
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -1436,9 +1436,9 @@ client.endpoints.object.get_and_return_with_optional_field(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed import Matryoshka
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -1493,9 +1493,9 @@ client.endpoints.object.get_and_return_with_required_field(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed import Matryoshka
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -1553,10 +1553,10 @@ client.endpoints.object.get_and_return_with_map_of_map(
 import datetime
 import uuid
 
-from seed import SeedExhaustive
+from seed import Matryoshka
 from seed.types.object import ObjectWithOptionalField
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -1643,10 +1643,10 @@ client.endpoints.object.get_and_return_nested_with_optional_field(
 import datetime
 import uuid
 
-from seed import SeedExhaustive
+from seed import Matryoshka
 from seed.types.object import ObjectWithOptionalField
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -1742,13 +1742,13 @@ client.endpoints.object.get_and_return_nested_with_required_field(
 import datetime
 import uuid
 
-from seed import SeedExhaustive
+from seed import Matryoshka
 from seed.types.object import (
     NestedObjectWithRequiredField,
     ObjectWithOptionalField,
 )
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -1867,9 +1867,9 @@ GET with path param
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed import Matryoshka
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -1938,9 +1938,9 @@ GET with path param
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed import Matryoshka
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -2009,9 +2009,9 @@ GET with query param
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed import Matryoshka
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -2089,9 +2089,9 @@ GET with multiple of same query param
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed import Matryoshka
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -2169,9 +2169,9 @@ GET with path and query params
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed import Matryoshka
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -2249,9 +2249,9 @@ GET with path and query params
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed import Matryoshka
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -2329,9 +2329,9 @@ PUT to update with path param
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed import Matryoshka
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -2409,9 +2409,9 @@ PUT to update with path param
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed import Matryoshka
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -2476,9 +2476,9 @@ client.endpoints.params.modify_with_inline_path(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed import Matryoshka
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -2533,9 +2533,9 @@ client.endpoints.primitive.get_and_return_string(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed import Matryoshka
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -2590,9 +2590,9 @@ client.endpoints.primitive.get_and_return_int(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed import Matryoshka
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -2647,9 +2647,9 @@ client.endpoints.primitive.get_and_return_long(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed import Matryoshka
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -2704,9 +2704,9 @@ client.endpoints.primitive.get_and_return_double(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed import Matryoshka
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -2763,9 +2763,9 @@ client.endpoints.primitive.get_and_return_bool(
 ```python
 import datetime
 
-from seed import SeedExhaustive
+from seed import Matryoshka
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -2824,9 +2824,9 @@ client.endpoints.primitive.get_and_return_datetime(
 ```python
 import datetime
 
-from seed import SeedExhaustive
+from seed import Matryoshka
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -2885,9 +2885,9 @@ client.endpoints.primitive.get_and_return_date(
 ```python
 import uuid
 
-from seed import SeedExhaustive
+from seed import Matryoshka
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -2944,9 +2944,9 @@ client.endpoints.primitive.get_and_return_uuid(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed import Matryoshka
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -3002,9 +3002,9 @@ client.endpoints.primitive.get_and_return_base_64(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed import Matryoshka
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -3060,10 +3060,10 @@ client.endpoints.put.add(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed import Matryoshka
 from seed.types.union import Animal_Dog
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -3122,9 +3122,9 @@ client.endpoints.union.get_and_return_union(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed import Matryoshka
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -3169,9 +3169,9 @@ client.endpoints.urls.with_mixed_case()
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed import Matryoshka
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -3216,9 +3216,9 @@ client.endpoints.urls.no_ending_slash()
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed import Matryoshka
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -3263,9 +3263,9 @@ client.endpoints.urls.with_ending_slash()
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed import Matryoshka
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -3328,10 +3328,10 @@ POST with custom object in request body, response is an object
 import datetime
 import uuid
 
-from seed import SeedExhaustive
+from seed import Matryoshka
 from seed.types.object import ObjectWithOptionalField
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -3439,9 +3439,9 @@ POST request with no auth
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed import Matryoshka
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -3497,9 +3497,9 @@ client.no_auth.post_with_no_auth(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed import Matryoshka
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -3544,9 +3544,9 @@ client.no_req_body.get_with_no_request_body()
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed import Matryoshka
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )
@@ -3592,9 +3592,9 @@ client.no_req_body.post_with_no_request_body()
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed import Matryoshka
 
-client = SeedExhaustive(
+client = Matryoshka(
     token="YOUR_TOKEN",
     base_url="https://yourhost.com/path/to/api",
 )

--- a/seed/python-sdk/exhaustive/package-path/snippet.json
+++ b/seed/python-sdk/exhaustive/package-path/snippet.json
@@ -9,8 +9,8 @@
                 "identifier_override": "endpoint_endpoints/container.getAndReturnListOfPrimitives"
             },
             "snippet": {
-                "sync_client": "from seed import SeedExhaustive\n\nclient = SeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.container.get_and_return_list_of_primitives(\n    request=[\"string\", \"string\"],\n)\n",
-                "async_client": "import asyncio\n\nfrom seed import AsyncSeedExhaustive\n\nclient = AsyncSeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.container.get_and_return_list_of_primitives(\n        request=[\"string\", \"string\"],\n    )\n\n\nasyncio.run(main())\n",
+                "sync_client": "from seed import Matryoshka\n\nclient = Matryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.container.get_and_return_list_of_primitives(\n    request=[\"string\", \"string\"],\n)\n",
+                "async_client": "import asyncio\n\nfrom seed import AsyncMatryoshka\n\nclient = AsyncMatryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.container.get_and_return_list_of_primitives(\n        request=[\"string\", \"string\"],\n    )\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -22,8 +22,8 @@
                 "identifier_override": "endpoint_endpoints/container.getAndReturnListOfObjects"
             },
             "snippet": {
-                "sync_client": "from seed import SeedExhaustive\nfrom seed.types.object import ObjectWithRequiredField\n\nclient = SeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.container.get_and_return_list_of_objects(\n    request=[\n        ObjectWithRequiredField(\n            string=\"string\",\n        ),\n        ObjectWithRequiredField(\n            string=\"string\",\n        ),\n    ],\n)\n",
-                "async_client": "import asyncio\n\nfrom seed import AsyncSeedExhaustive\nfrom seed.types.object import ObjectWithRequiredField\n\nclient = AsyncSeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.container.get_and_return_list_of_objects(\n        request=[\n            ObjectWithRequiredField(\n                string=\"string\",\n            ),\n            ObjectWithRequiredField(\n                string=\"string\",\n            ),\n        ],\n    )\n\n\nasyncio.run(main())\n",
+                "sync_client": "from seed import Matryoshka\nfrom seed.types.object import ObjectWithRequiredField\n\nclient = Matryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.container.get_and_return_list_of_objects(\n    request=[\n        ObjectWithRequiredField(\n            string=\"string\",\n        ),\n        ObjectWithRequiredField(\n            string=\"string\",\n        ),\n    ],\n)\n",
+                "async_client": "import asyncio\n\nfrom seed import AsyncMatryoshka\nfrom seed.types.object import ObjectWithRequiredField\n\nclient = AsyncMatryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.container.get_and_return_list_of_objects(\n        request=[\n            ObjectWithRequiredField(\n                string=\"string\",\n            ),\n            ObjectWithRequiredField(\n                string=\"string\",\n            ),\n        ],\n    )\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -35,8 +35,8 @@
                 "identifier_override": "endpoint_endpoints/container.getAndReturnSetOfPrimitives"
             },
             "snippet": {
-                "sync_client": "from seed import SeedExhaustive\n\nclient = SeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.container.get_and_return_set_of_primitives(\n    request={\"string\"},\n)\n",
-                "async_client": "import asyncio\n\nfrom seed import AsyncSeedExhaustive\n\nclient = AsyncSeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.container.get_and_return_set_of_primitives(\n        request={\"string\"},\n    )\n\n\nasyncio.run(main())\n",
+                "sync_client": "from seed import Matryoshka\n\nclient = Matryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.container.get_and_return_set_of_primitives(\n    request={\"string\"},\n)\n",
+                "async_client": "import asyncio\n\nfrom seed import AsyncMatryoshka\n\nclient = AsyncMatryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.container.get_and_return_set_of_primitives(\n        request={\"string\"},\n    )\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -48,8 +48,8 @@
                 "identifier_override": "endpoint_endpoints/container.getAndReturnSetOfObjects"
             },
             "snippet": {
-                "sync_client": "from seed import SeedExhaustive\nfrom seed.types.object import ObjectWithRequiredField\n\nclient = SeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.container.get_and_return_set_of_objects(\n    request=[\n        ObjectWithRequiredField(\n            string=\"string\",\n        )\n    ],\n)\n",
-                "async_client": "import asyncio\n\nfrom seed import AsyncSeedExhaustive\nfrom seed.types.object import ObjectWithRequiredField\n\nclient = AsyncSeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.container.get_and_return_set_of_objects(\n        request=[\n            ObjectWithRequiredField(\n                string=\"string\",\n            )\n        ],\n    )\n\n\nasyncio.run(main())\n",
+                "sync_client": "from seed import Matryoshka\nfrom seed.types.object import ObjectWithRequiredField\n\nclient = Matryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.container.get_and_return_set_of_objects(\n    request=[\n        ObjectWithRequiredField(\n            string=\"string\",\n        )\n    ],\n)\n",
+                "async_client": "import asyncio\n\nfrom seed import AsyncMatryoshka\nfrom seed.types.object import ObjectWithRequiredField\n\nclient = AsyncMatryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.container.get_and_return_set_of_objects(\n        request=[\n            ObjectWithRequiredField(\n                string=\"string\",\n            )\n        ],\n    )\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -61,8 +61,8 @@
                 "identifier_override": "endpoint_endpoints/container.getAndReturnMapPrimToPrim"
             },
             "snippet": {
-                "sync_client": "from seed import SeedExhaustive\n\nclient = SeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.container.get_and_return_map_prim_to_prim(\n    request={\"string\": \"string\"},\n)\n",
-                "async_client": "import asyncio\n\nfrom seed import AsyncSeedExhaustive\n\nclient = AsyncSeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.container.get_and_return_map_prim_to_prim(\n        request={\"string\": \"string\"},\n    )\n\n\nasyncio.run(main())\n",
+                "sync_client": "from seed import Matryoshka\n\nclient = Matryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.container.get_and_return_map_prim_to_prim(\n    request={\"string\": \"string\"},\n)\n",
+                "async_client": "import asyncio\n\nfrom seed import AsyncMatryoshka\n\nclient = AsyncMatryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.container.get_and_return_map_prim_to_prim(\n        request={\"string\": \"string\"},\n    )\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -74,8 +74,8 @@
                 "identifier_override": "endpoint_endpoints/container.getAndReturnMapOfPrimToObject"
             },
             "snippet": {
-                "sync_client": "from seed import SeedExhaustive\nfrom seed.types.object import ObjectWithRequiredField\n\nclient = SeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.container.get_and_return_map_of_prim_to_object(\n    request={\n        \"string\": ObjectWithRequiredField(\n            string=\"string\",\n        )\n    },\n)\n",
-                "async_client": "import asyncio\n\nfrom seed import AsyncSeedExhaustive\nfrom seed.types.object import ObjectWithRequiredField\n\nclient = AsyncSeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.container.get_and_return_map_of_prim_to_object(\n        request={\n            \"string\": ObjectWithRequiredField(\n                string=\"string\",\n            )\n        },\n    )\n\n\nasyncio.run(main())\n",
+                "sync_client": "from seed import Matryoshka\nfrom seed.types.object import ObjectWithRequiredField\n\nclient = Matryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.container.get_and_return_map_of_prim_to_object(\n    request={\n        \"string\": ObjectWithRequiredField(\n            string=\"string\",\n        )\n    },\n)\n",
+                "async_client": "import asyncio\n\nfrom seed import AsyncMatryoshka\nfrom seed.types.object import ObjectWithRequiredField\n\nclient = AsyncMatryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.container.get_and_return_map_of_prim_to_object(\n        request={\n            \"string\": ObjectWithRequiredField(\n                string=\"string\",\n            )\n        },\n    )\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -87,8 +87,8 @@
                 "identifier_override": "endpoint_endpoints/container.getAndReturnOptional"
             },
             "snippet": {
-                "sync_client": "from seed import SeedExhaustive\nfrom seed.types.object import ObjectWithRequiredField\n\nclient = SeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.container.get_and_return_optional(\n    request=ObjectWithRequiredField(\n        string=\"string\",\n    ),\n)\n",
-                "async_client": "import asyncio\n\nfrom seed import AsyncSeedExhaustive\nfrom seed.types.object import ObjectWithRequiredField\n\nclient = AsyncSeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.container.get_and_return_optional(\n        request=ObjectWithRequiredField(\n            string=\"string\",\n        ),\n    )\n\n\nasyncio.run(main())\n",
+                "sync_client": "from seed import Matryoshka\nfrom seed.types.object import ObjectWithRequiredField\n\nclient = Matryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.container.get_and_return_optional(\n    request=ObjectWithRequiredField(\n        string=\"string\",\n    ),\n)\n",
+                "async_client": "import asyncio\n\nfrom seed import AsyncMatryoshka\nfrom seed.types.object import ObjectWithRequiredField\n\nclient = AsyncMatryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.container.get_and_return_optional(\n        request=ObjectWithRequiredField(\n            string=\"string\",\n        ),\n    )\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -100,8 +100,8 @@
                 "identifier_override": "endpoint_endpoints/content-type.postJsonPatchContentType"
             },
             "snippet": {
-                "sync_client": "import datetime\nimport uuid\n\nfrom seed import SeedExhaustive\n\nclient = SeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.content_type.post_json_patch_content_type(\n    string=\"string\",\n    integer=1,\n    long_=1000000,\n    double=1.1,\n    bool_=True,\n    datetime=datetime.datetime.fromisoformat(\n        \"2024-01-15 09:30:00+00:00\",\n    ),\n    date=datetime.date.fromisoformat(\n        \"2023-01-15\",\n    ),\n    uuid_=uuid.UUID(\n        \"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32\",\n    ),\n    base_64=\"SGVsbG8gd29ybGQh\",\n    list_=[\"list\", \"list\"],\n    set_={\"set\"},\n    map_={1: \"map\"},\n    bigint=1000000,\n)\n",
-                "async_client": "import asyncio\nimport datetime\nimport uuid\n\nfrom seed import AsyncSeedExhaustive\n\nclient = AsyncSeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.content_type.post_json_patch_content_type(\n        string=\"string\",\n        integer=1,\n        long_=1000000,\n        double=1.1,\n        bool_=True,\n        datetime=datetime.datetime.fromisoformat(\n            \"2024-01-15 09:30:00+00:00\",\n        ),\n        date=datetime.date.fromisoformat(\n            \"2023-01-15\",\n        ),\n        uuid_=uuid.UUID(\n            \"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32\",\n        ),\n        base_64=\"SGVsbG8gd29ybGQh\",\n        list_=[\"list\", \"list\"],\n        set_={\"set\"},\n        map_={1: \"map\"},\n        bigint=1000000,\n    )\n\n\nasyncio.run(main())\n",
+                "sync_client": "import datetime\nimport uuid\n\nfrom seed import Matryoshka\n\nclient = Matryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.content_type.post_json_patch_content_type(\n    string=\"string\",\n    integer=1,\n    long_=1000000,\n    double=1.1,\n    bool_=True,\n    datetime=datetime.datetime.fromisoformat(\n        \"2024-01-15 09:30:00+00:00\",\n    ),\n    date=datetime.date.fromisoformat(\n        \"2023-01-15\",\n    ),\n    uuid_=uuid.UUID(\n        \"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32\",\n    ),\n    base_64=\"SGVsbG8gd29ybGQh\",\n    list_=[\"list\", \"list\"],\n    set_={\"set\"},\n    map_={1: \"map\"},\n    bigint=1000000,\n)\n",
+                "async_client": "import asyncio\nimport datetime\nimport uuid\n\nfrom seed import AsyncMatryoshka\n\nclient = AsyncMatryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.content_type.post_json_patch_content_type(\n        string=\"string\",\n        integer=1,\n        long_=1000000,\n        double=1.1,\n        bool_=True,\n        datetime=datetime.datetime.fromisoformat(\n            \"2024-01-15 09:30:00+00:00\",\n        ),\n        date=datetime.date.fromisoformat(\n            \"2023-01-15\",\n        ),\n        uuid_=uuid.UUID(\n            \"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32\",\n        ),\n        base_64=\"SGVsbG8gd29ybGQh\",\n        list_=[\"list\", \"list\"],\n        set_={\"set\"},\n        map_={1: \"map\"},\n        bigint=1000000,\n    )\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -113,8 +113,8 @@
                 "identifier_override": "endpoint_endpoints/content-type.postJsonPatchContentWithCharsetType"
             },
             "snippet": {
-                "sync_client": "import datetime\nimport uuid\n\nfrom seed import SeedExhaustive\n\nclient = SeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.content_type.post_json_patch_content_with_charset_type(\n    string=\"string\",\n    integer=1,\n    long_=1000000,\n    double=1.1,\n    bool_=True,\n    datetime=datetime.datetime.fromisoformat(\n        \"2024-01-15 09:30:00+00:00\",\n    ),\n    date=datetime.date.fromisoformat(\n        \"2023-01-15\",\n    ),\n    uuid_=uuid.UUID(\n        \"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32\",\n    ),\n    base_64=\"SGVsbG8gd29ybGQh\",\n    list_=[\"list\", \"list\"],\n    set_={\"set\"},\n    map_={1: \"map\"},\n    bigint=1000000,\n)\n",
-                "async_client": "import asyncio\nimport datetime\nimport uuid\n\nfrom seed import AsyncSeedExhaustive\n\nclient = AsyncSeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.content_type.post_json_patch_content_with_charset_type(\n        string=\"string\",\n        integer=1,\n        long_=1000000,\n        double=1.1,\n        bool_=True,\n        datetime=datetime.datetime.fromisoformat(\n            \"2024-01-15 09:30:00+00:00\",\n        ),\n        date=datetime.date.fromisoformat(\n            \"2023-01-15\",\n        ),\n        uuid_=uuid.UUID(\n            \"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32\",\n        ),\n        base_64=\"SGVsbG8gd29ybGQh\",\n        list_=[\"list\", \"list\"],\n        set_={\"set\"},\n        map_={1: \"map\"},\n        bigint=1000000,\n    )\n\n\nasyncio.run(main())\n",
+                "sync_client": "import datetime\nimport uuid\n\nfrom seed import Matryoshka\n\nclient = Matryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.content_type.post_json_patch_content_with_charset_type(\n    string=\"string\",\n    integer=1,\n    long_=1000000,\n    double=1.1,\n    bool_=True,\n    datetime=datetime.datetime.fromisoformat(\n        \"2024-01-15 09:30:00+00:00\",\n    ),\n    date=datetime.date.fromisoformat(\n        \"2023-01-15\",\n    ),\n    uuid_=uuid.UUID(\n        \"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32\",\n    ),\n    base_64=\"SGVsbG8gd29ybGQh\",\n    list_=[\"list\", \"list\"],\n    set_={\"set\"},\n    map_={1: \"map\"},\n    bigint=1000000,\n)\n",
+                "async_client": "import asyncio\nimport datetime\nimport uuid\n\nfrom seed import AsyncMatryoshka\n\nclient = AsyncMatryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.content_type.post_json_patch_content_with_charset_type(\n        string=\"string\",\n        integer=1,\n        long_=1000000,\n        double=1.1,\n        bool_=True,\n        datetime=datetime.datetime.fromisoformat(\n            \"2024-01-15 09:30:00+00:00\",\n        ),\n        date=datetime.date.fromisoformat(\n            \"2023-01-15\",\n        ),\n        uuid_=uuid.UUID(\n            \"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32\",\n        ),\n        base_64=\"SGVsbG8gd29ybGQh\",\n        list_=[\"list\", \"list\"],\n        set_={\"set\"},\n        map_={1: \"map\"},\n        bigint=1000000,\n    )\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -126,8 +126,8 @@
                 "identifier_override": "endpoint_endpoints/enum.getAndReturnEnum"
             },
             "snippet": {
-                "sync_client": "from seed import SeedExhaustive\n\nclient = SeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.enum.get_and_return_enum(\n    request=\"SUNNY\",\n)\n",
-                "async_client": "import asyncio\n\nfrom seed import AsyncSeedExhaustive\n\nclient = AsyncSeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.enum.get_and_return_enum(\n        request=\"SUNNY\",\n    )\n\n\nasyncio.run(main())\n",
+                "sync_client": "from seed import Matryoshka\n\nclient = Matryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.enum.get_and_return_enum(\n    request=\"SUNNY\",\n)\n",
+                "async_client": "import asyncio\n\nfrom seed import AsyncMatryoshka\n\nclient = AsyncMatryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.enum.get_and_return_enum(\n        request=\"SUNNY\",\n    )\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -139,8 +139,8 @@
                 "identifier_override": "endpoint_endpoints/http-methods.testGet"
             },
             "snippet": {
-                "sync_client": "from seed import SeedExhaustive\n\nclient = SeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.http_methods.test_get(\n    id=\"id\",\n)\n",
-                "async_client": "import asyncio\n\nfrom seed import AsyncSeedExhaustive\n\nclient = AsyncSeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.http_methods.test_get(\n        id=\"id\",\n    )\n\n\nasyncio.run(main())\n",
+                "sync_client": "from seed import Matryoshka\n\nclient = Matryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.http_methods.test_get(\n    id=\"id\",\n)\n",
+                "async_client": "import asyncio\n\nfrom seed import AsyncMatryoshka\n\nclient = AsyncMatryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.http_methods.test_get(\n        id=\"id\",\n    )\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -152,8 +152,8 @@
                 "identifier_override": "endpoint_endpoints/http-methods.testPost"
             },
             "snippet": {
-                "sync_client": "from seed import SeedExhaustive\n\nclient = SeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.http_methods.test_post(\n    string=\"string\",\n)\n",
-                "async_client": "import asyncio\n\nfrom seed import AsyncSeedExhaustive\n\nclient = AsyncSeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.http_methods.test_post(\n        string=\"string\",\n    )\n\n\nasyncio.run(main())\n",
+                "sync_client": "from seed import Matryoshka\n\nclient = Matryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.http_methods.test_post(\n    string=\"string\",\n)\n",
+                "async_client": "import asyncio\n\nfrom seed import AsyncMatryoshka\n\nclient = AsyncMatryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.http_methods.test_post(\n        string=\"string\",\n    )\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -165,8 +165,8 @@
                 "identifier_override": "endpoint_endpoints/http-methods.testPut"
             },
             "snippet": {
-                "sync_client": "from seed import SeedExhaustive\n\nclient = SeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.http_methods.test_put(\n    id=\"id\",\n    string=\"string\",\n)\n",
-                "async_client": "import asyncio\n\nfrom seed import AsyncSeedExhaustive\n\nclient = AsyncSeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.http_methods.test_put(\n        id=\"id\",\n        string=\"string\",\n    )\n\n\nasyncio.run(main())\n",
+                "sync_client": "from seed import Matryoshka\n\nclient = Matryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.http_methods.test_put(\n    id=\"id\",\n    string=\"string\",\n)\n",
+                "async_client": "import asyncio\n\nfrom seed import AsyncMatryoshka\n\nclient = AsyncMatryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.http_methods.test_put(\n        id=\"id\",\n        string=\"string\",\n    )\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -178,8 +178,8 @@
                 "identifier_override": "endpoint_endpoints/http-methods.testPatch"
             },
             "snippet": {
-                "sync_client": "import datetime\nimport uuid\n\nfrom seed import SeedExhaustive\n\nclient = SeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.http_methods.test_patch(\n    id=\"id\",\n    string=\"string\",\n    integer=1,\n    long_=1000000,\n    double=1.1,\n    bool_=True,\n    datetime=datetime.datetime.fromisoformat(\n        \"2024-01-15 09:30:00+00:00\",\n    ),\n    date=datetime.date.fromisoformat(\n        \"2023-01-15\",\n    ),\n    uuid_=uuid.UUID(\n        \"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32\",\n    ),\n    base_64=\"SGVsbG8gd29ybGQh\",\n    list_=[\"list\", \"list\"],\n    set_={\"set\"},\n    map_={1: \"map\"},\n    bigint=1000000,\n)\n",
-                "async_client": "import asyncio\nimport datetime\nimport uuid\n\nfrom seed import AsyncSeedExhaustive\n\nclient = AsyncSeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.http_methods.test_patch(\n        id=\"id\",\n        string=\"string\",\n        integer=1,\n        long_=1000000,\n        double=1.1,\n        bool_=True,\n        datetime=datetime.datetime.fromisoformat(\n            \"2024-01-15 09:30:00+00:00\",\n        ),\n        date=datetime.date.fromisoformat(\n            \"2023-01-15\",\n        ),\n        uuid_=uuid.UUID(\n            \"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32\",\n        ),\n        base_64=\"SGVsbG8gd29ybGQh\",\n        list_=[\"list\", \"list\"],\n        set_={\"set\"},\n        map_={1: \"map\"},\n        bigint=1000000,\n    )\n\n\nasyncio.run(main())\n",
+                "sync_client": "import datetime\nimport uuid\n\nfrom seed import Matryoshka\n\nclient = Matryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.http_methods.test_patch(\n    id=\"id\",\n    string=\"string\",\n    integer=1,\n    long_=1000000,\n    double=1.1,\n    bool_=True,\n    datetime=datetime.datetime.fromisoformat(\n        \"2024-01-15 09:30:00+00:00\",\n    ),\n    date=datetime.date.fromisoformat(\n        \"2023-01-15\",\n    ),\n    uuid_=uuid.UUID(\n        \"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32\",\n    ),\n    base_64=\"SGVsbG8gd29ybGQh\",\n    list_=[\"list\", \"list\"],\n    set_={\"set\"},\n    map_={1: \"map\"},\n    bigint=1000000,\n)\n",
+                "async_client": "import asyncio\nimport datetime\nimport uuid\n\nfrom seed import AsyncMatryoshka\n\nclient = AsyncMatryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.http_methods.test_patch(\n        id=\"id\",\n        string=\"string\",\n        integer=1,\n        long_=1000000,\n        double=1.1,\n        bool_=True,\n        datetime=datetime.datetime.fromisoformat(\n            \"2024-01-15 09:30:00+00:00\",\n        ),\n        date=datetime.date.fromisoformat(\n            \"2023-01-15\",\n        ),\n        uuid_=uuid.UUID(\n            \"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32\",\n        ),\n        base_64=\"SGVsbG8gd29ybGQh\",\n        list_=[\"list\", \"list\"],\n        set_={\"set\"},\n        map_={1: \"map\"},\n        bigint=1000000,\n    )\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -191,8 +191,8 @@
                 "identifier_override": "endpoint_endpoints/http-methods.testDelete"
             },
             "snippet": {
-                "sync_client": "from seed import SeedExhaustive\n\nclient = SeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.http_methods.test_delete(\n    id=\"id\",\n)\n",
-                "async_client": "import asyncio\n\nfrom seed import AsyncSeedExhaustive\n\nclient = AsyncSeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.http_methods.test_delete(\n        id=\"id\",\n    )\n\n\nasyncio.run(main())\n",
+                "sync_client": "from seed import Matryoshka\n\nclient = Matryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.http_methods.test_delete(\n    id=\"id\",\n)\n",
+                "async_client": "import asyncio\n\nfrom seed import AsyncMatryoshka\n\nclient = AsyncMatryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.http_methods.test_delete(\n        id=\"id\",\n    )\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -204,8 +204,8 @@
                 "identifier_override": "endpoint_endpoints/object.getAndReturnWithOptionalField"
             },
             "snippet": {
-                "sync_client": "import datetime\nimport uuid\n\nfrom seed import SeedExhaustive\n\nclient = SeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.object.get_and_return_with_optional_field(\n    string=\"string\",\n    integer=1,\n    long_=1000000,\n    double=1.1,\n    bool_=True,\n    datetime=datetime.datetime.fromisoformat(\n        \"2024-01-15 09:30:00+00:00\",\n    ),\n    date=datetime.date.fromisoformat(\n        \"2023-01-15\",\n    ),\n    uuid_=uuid.UUID(\n        \"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32\",\n    ),\n    base_64=\"SGVsbG8gd29ybGQh\",\n    list_=[\"list\", \"list\"],\n    set_={\"set\"},\n    map_={1: \"map\"},\n    bigint=1000000,\n)\n",
-                "async_client": "import asyncio\nimport datetime\nimport uuid\n\nfrom seed import AsyncSeedExhaustive\n\nclient = AsyncSeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.object.get_and_return_with_optional_field(\n        string=\"string\",\n        integer=1,\n        long_=1000000,\n        double=1.1,\n        bool_=True,\n        datetime=datetime.datetime.fromisoformat(\n            \"2024-01-15 09:30:00+00:00\",\n        ),\n        date=datetime.date.fromisoformat(\n            \"2023-01-15\",\n        ),\n        uuid_=uuid.UUID(\n            \"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32\",\n        ),\n        base_64=\"SGVsbG8gd29ybGQh\",\n        list_=[\"list\", \"list\"],\n        set_={\"set\"},\n        map_={1: \"map\"},\n        bigint=1000000,\n    )\n\n\nasyncio.run(main())\n",
+                "sync_client": "import datetime\nimport uuid\n\nfrom seed import Matryoshka\n\nclient = Matryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.object.get_and_return_with_optional_field(\n    string=\"string\",\n    integer=1,\n    long_=1000000,\n    double=1.1,\n    bool_=True,\n    datetime=datetime.datetime.fromisoformat(\n        \"2024-01-15 09:30:00+00:00\",\n    ),\n    date=datetime.date.fromisoformat(\n        \"2023-01-15\",\n    ),\n    uuid_=uuid.UUID(\n        \"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32\",\n    ),\n    base_64=\"SGVsbG8gd29ybGQh\",\n    list_=[\"list\", \"list\"],\n    set_={\"set\"},\n    map_={1: \"map\"},\n    bigint=1000000,\n)\n",
+                "async_client": "import asyncio\nimport datetime\nimport uuid\n\nfrom seed import AsyncMatryoshka\n\nclient = AsyncMatryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.object.get_and_return_with_optional_field(\n        string=\"string\",\n        integer=1,\n        long_=1000000,\n        double=1.1,\n        bool_=True,\n        datetime=datetime.datetime.fromisoformat(\n            \"2024-01-15 09:30:00+00:00\",\n        ),\n        date=datetime.date.fromisoformat(\n            \"2023-01-15\",\n        ),\n        uuid_=uuid.UUID(\n            \"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32\",\n        ),\n        base_64=\"SGVsbG8gd29ybGQh\",\n        list_=[\"list\", \"list\"],\n        set_={\"set\"},\n        map_={1: \"map\"},\n        bigint=1000000,\n    )\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -217,8 +217,8 @@
                 "identifier_override": "endpoint_endpoints/object.getAndReturnWithRequiredField"
             },
             "snippet": {
-                "sync_client": "from seed import SeedExhaustive\n\nclient = SeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.object.get_and_return_with_required_field(\n    string=\"string\",\n)\n",
-                "async_client": "import asyncio\n\nfrom seed import AsyncSeedExhaustive\n\nclient = AsyncSeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.object.get_and_return_with_required_field(\n        string=\"string\",\n    )\n\n\nasyncio.run(main())\n",
+                "sync_client": "from seed import Matryoshka\n\nclient = Matryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.object.get_and_return_with_required_field(\n    string=\"string\",\n)\n",
+                "async_client": "import asyncio\n\nfrom seed import AsyncMatryoshka\n\nclient = AsyncMatryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.object.get_and_return_with_required_field(\n        string=\"string\",\n    )\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -230,8 +230,8 @@
                 "identifier_override": "endpoint_endpoints/object.getAndReturnWithMapOfMap"
             },
             "snippet": {
-                "sync_client": "from seed import SeedExhaustive\n\nclient = SeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.object.get_and_return_with_map_of_map(\n    map_={\"map\": {\"map\": \"map\"}},\n)\n",
-                "async_client": "import asyncio\n\nfrom seed import AsyncSeedExhaustive\n\nclient = AsyncSeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.object.get_and_return_with_map_of_map(\n        map_={\"map\": {\"map\": \"map\"}},\n    )\n\n\nasyncio.run(main())\n",
+                "sync_client": "from seed import Matryoshka\n\nclient = Matryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.object.get_and_return_with_map_of_map(\n    map_={\"map\": {\"map\": \"map\"}},\n)\n",
+                "async_client": "import asyncio\n\nfrom seed import AsyncMatryoshka\n\nclient = AsyncMatryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.object.get_and_return_with_map_of_map(\n        map_={\"map\": {\"map\": \"map\"}},\n    )\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -243,8 +243,8 @@
                 "identifier_override": "endpoint_endpoints/object.getAndReturnNestedWithOptionalField"
             },
             "snippet": {
-                "sync_client": "import datetime\nimport uuid\n\nfrom seed import SeedExhaustive\nfrom seed.types.object import ObjectWithOptionalField\n\nclient = SeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.object.get_and_return_nested_with_optional_field(\n    string=\"string\",\n    nested_object=ObjectWithOptionalField(\n        string=\"string\",\n        integer=1,\n        long_=1000000,\n        double=1.1,\n        bool_=True,\n        datetime=datetime.datetime.fromisoformat(\n            \"2024-01-15 09:30:00+00:00\",\n        ),\n        date=datetime.date.fromisoformat(\n            \"2023-01-15\",\n        ),\n        uuid_=uuid.UUID(\n            \"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32\",\n        ),\n        base_64=\"SGVsbG8gd29ybGQh\",\n        list_=[\"list\", \"list\"],\n        set_={\"set\"},\n        map_={1: \"map\"},\n        bigint=1000000,\n    ),\n)\n",
-                "async_client": "import asyncio\nimport datetime\nimport uuid\n\nfrom seed import AsyncSeedExhaustive\nfrom seed.types.object import ObjectWithOptionalField\n\nclient = AsyncSeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.object.get_and_return_nested_with_optional_field(\n        string=\"string\",\n        nested_object=ObjectWithOptionalField(\n            string=\"string\",\n            integer=1,\n            long_=1000000,\n            double=1.1,\n            bool_=True,\n            datetime=datetime.datetime.fromisoformat(\n                \"2024-01-15 09:30:00+00:00\",\n            ),\n            date=datetime.date.fromisoformat(\n                \"2023-01-15\",\n            ),\n            uuid_=uuid.UUID(\n                \"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32\",\n            ),\n            base_64=\"SGVsbG8gd29ybGQh\",\n            list_=[\"list\", \"list\"],\n            set_={\"set\"},\n            map_={1: \"map\"},\n            bigint=1000000,\n        ),\n    )\n\n\nasyncio.run(main())\n",
+                "sync_client": "import datetime\nimport uuid\n\nfrom seed import Matryoshka\nfrom seed.types.object import ObjectWithOptionalField\n\nclient = Matryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.object.get_and_return_nested_with_optional_field(\n    string=\"string\",\n    nested_object=ObjectWithOptionalField(\n        string=\"string\",\n        integer=1,\n        long_=1000000,\n        double=1.1,\n        bool_=True,\n        datetime=datetime.datetime.fromisoformat(\n            \"2024-01-15 09:30:00+00:00\",\n        ),\n        date=datetime.date.fromisoformat(\n            \"2023-01-15\",\n        ),\n        uuid_=uuid.UUID(\n            \"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32\",\n        ),\n        base_64=\"SGVsbG8gd29ybGQh\",\n        list_=[\"list\", \"list\"],\n        set_={\"set\"},\n        map_={1: \"map\"},\n        bigint=1000000,\n    ),\n)\n",
+                "async_client": "import asyncio\nimport datetime\nimport uuid\n\nfrom seed import AsyncMatryoshka\nfrom seed.types.object import ObjectWithOptionalField\n\nclient = AsyncMatryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.object.get_and_return_nested_with_optional_field(\n        string=\"string\",\n        nested_object=ObjectWithOptionalField(\n            string=\"string\",\n            integer=1,\n            long_=1000000,\n            double=1.1,\n            bool_=True,\n            datetime=datetime.datetime.fromisoformat(\n                \"2024-01-15 09:30:00+00:00\",\n            ),\n            date=datetime.date.fromisoformat(\n                \"2023-01-15\",\n            ),\n            uuid_=uuid.UUID(\n                \"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32\",\n            ),\n            base_64=\"SGVsbG8gd29ybGQh\",\n            list_=[\"list\", \"list\"],\n            set_={\"set\"},\n            map_={1: \"map\"},\n            bigint=1000000,\n        ),\n    )\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -256,8 +256,8 @@
                 "identifier_override": "endpoint_endpoints/object.getAndReturnNestedWithRequiredField"
             },
             "snippet": {
-                "sync_client": "import datetime\nimport uuid\n\nfrom seed import SeedExhaustive\nfrom seed.types.object import ObjectWithOptionalField\n\nclient = SeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.object.get_and_return_nested_with_required_field(\n    string_=\"string\",\n    string=\"string\",\n    nested_object=ObjectWithOptionalField(\n        string=\"string\",\n        integer=1,\n        long_=1000000,\n        double=1.1,\n        bool_=True,\n        datetime=datetime.datetime.fromisoformat(\n            \"2024-01-15 09:30:00+00:00\",\n        ),\n        date=datetime.date.fromisoformat(\n            \"2023-01-15\",\n        ),\n        uuid_=uuid.UUID(\n            \"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32\",\n        ),\n        base_64=\"SGVsbG8gd29ybGQh\",\n        list_=[\"list\", \"list\"],\n        set_={\"set\"},\n        map_={1: \"map\"},\n        bigint=1000000,\n    ),\n)\n",
-                "async_client": "import asyncio\nimport datetime\nimport uuid\n\nfrom seed import AsyncSeedExhaustive\nfrom seed.types.object import ObjectWithOptionalField\n\nclient = AsyncSeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.object.get_and_return_nested_with_required_field(\n        string_=\"string\",\n        string=\"string\",\n        nested_object=ObjectWithOptionalField(\n            string=\"string\",\n            integer=1,\n            long_=1000000,\n            double=1.1,\n            bool_=True,\n            datetime=datetime.datetime.fromisoformat(\n                \"2024-01-15 09:30:00+00:00\",\n            ),\n            date=datetime.date.fromisoformat(\n                \"2023-01-15\",\n            ),\n            uuid_=uuid.UUID(\n                \"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32\",\n            ),\n            base_64=\"SGVsbG8gd29ybGQh\",\n            list_=[\"list\", \"list\"],\n            set_={\"set\"},\n            map_={1: \"map\"},\n            bigint=1000000,\n        ),\n    )\n\n\nasyncio.run(main())\n",
+                "sync_client": "import datetime\nimport uuid\n\nfrom seed import Matryoshka\nfrom seed.types.object import ObjectWithOptionalField\n\nclient = Matryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.object.get_and_return_nested_with_required_field(\n    string_=\"string\",\n    string=\"string\",\n    nested_object=ObjectWithOptionalField(\n        string=\"string\",\n        integer=1,\n        long_=1000000,\n        double=1.1,\n        bool_=True,\n        datetime=datetime.datetime.fromisoformat(\n            \"2024-01-15 09:30:00+00:00\",\n        ),\n        date=datetime.date.fromisoformat(\n            \"2023-01-15\",\n        ),\n        uuid_=uuid.UUID(\n            \"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32\",\n        ),\n        base_64=\"SGVsbG8gd29ybGQh\",\n        list_=[\"list\", \"list\"],\n        set_={\"set\"},\n        map_={1: \"map\"},\n        bigint=1000000,\n    ),\n)\n",
+                "async_client": "import asyncio\nimport datetime\nimport uuid\n\nfrom seed import AsyncMatryoshka\nfrom seed.types.object import ObjectWithOptionalField\n\nclient = AsyncMatryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.object.get_and_return_nested_with_required_field(\n        string_=\"string\",\n        string=\"string\",\n        nested_object=ObjectWithOptionalField(\n            string=\"string\",\n            integer=1,\n            long_=1000000,\n            double=1.1,\n            bool_=True,\n            datetime=datetime.datetime.fromisoformat(\n                \"2024-01-15 09:30:00+00:00\",\n            ),\n            date=datetime.date.fromisoformat(\n                \"2023-01-15\",\n            ),\n            uuid_=uuid.UUID(\n                \"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32\",\n            ),\n            base_64=\"SGVsbG8gd29ybGQh\",\n            list_=[\"list\", \"list\"],\n            set_={\"set\"},\n            map_={1: \"map\"},\n            bigint=1000000,\n        ),\n    )\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -269,8 +269,8 @@
                 "identifier_override": "endpoint_endpoints/object.getAndReturnNestedWithRequiredFieldAsList"
             },
             "snippet": {
-                "sync_client": "import datetime\nimport uuid\n\nfrom seed import SeedExhaustive\nfrom seed.types.object import (\n    NestedObjectWithRequiredField,\n    ObjectWithOptionalField,\n)\n\nclient = SeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.object.get_and_return_nested_with_required_field_as_list(\n    request=[\n        NestedObjectWithRequiredField(\n            string=\"string\",\n            nested_object=ObjectWithOptionalField(\n                string=\"string\",\n                integer=1,\n                long_=1000000,\n                double=1.1,\n                bool_=True,\n                datetime=datetime.datetime.fromisoformat(\n                    \"2024-01-15 09:30:00+00:00\",\n                ),\n                date=datetime.date.fromisoformat(\n                    \"2023-01-15\",\n                ),\n                uuid_=uuid.UUID(\n                    \"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32\",\n                ),\n                base_64=\"SGVsbG8gd29ybGQh\",\n                list_=[\"list\", \"list\"],\n                set_={\"set\"},\n                map_={1: \"map\"},\n                bigint=1000000,\n            ),\n        ),\n        NestedObjectWithRequiredField(\n            string=\"string\",\n            nested_object=ObjectWithOptionalField(\n                string=\"string\",\n                integer=1,\n                long_=1000000,\n                double=1.1,\n                bool_=True,\n                datetime=datetime.datetime.fromisoformat(\n                    \"2024-01-15 09:30:00+00:00\",\n                ),\n                date=datetime.date.fromisoformat(\n                    \"2023-01-15\",\n                ),\n                uuid_=uuid.UUID(\n                    \"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32\",\n                ),\n                base_64=\"SGVsbG8gd29ybGQh\",\n                list_=[\"list\", \"list\"],\n                set_={\"set\"},\n                map_={1: \"map\"},\n                bigint=1000000,\n            ),\n        ),\n    ],\n)\n",
-                "async_client": "import asyncio\nimport datetime\nimport uuid\n\nfrom seed import AsyncSeedExhaustive\nfrom seed.types.object import (\n    NestedObjectWithRequiredField,\n    ObjectWithOptionalField,\n)\n\nclient = AsyncSeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.object.get_and_return_nested_with_required_field_as_list(\n        request=[\n            NestedObjectWithRequiredField(\n                string=\"string\",\n                nested_object=ObjectWithOptionalField(\n                    string=\"string\",\n                    integer=1,\n                    long_=1000000,\n                    double=1.1,\n                    bool_=True,\n                    datetime=datetime.datetime.fromisoformat(\n                        \"2024-01-15 09:30:00+00:00\",\n                    ),\n                    date=datetime.date.fromisoformat(\n                        \"2023-01-15\",\n                    ),\n                    uuid_=uuid.UUID(\n                        \"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32\",\n                    ),\n                    base_64=\"SGVsbG8gd29ybGQh\",\n                    list_=[\"list\", \"list\"],\n                    set_={\"set\"},\n                    map_={1: \"map\"},\n                    bigint=1000000,\n                ),\n            ),\n            NestedObjectWithRequiredField(\n                string=\"string\",\n                nested_object=ObjectWithOptionalField(\n                    string=\"string\",\n                    integer=1,\n                    long_=1000000,\n                    double=1.1,\n                    bool_=True,\n                    datetime=datetime.datetime.fromisoformat(\n                        \"2024-01-15 09:30:00+00:00\",\n                    ),\n                    date=datetime.date.fromisoformat(\n                        \"2023-01-15\",\n                    ),\n                    uuid_=uuid.UUID(\n                        \"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32\",\n                    ),\n                    base_64=\"SGVsbG8gd29ybGQh\",\n                    list_=[\"list\", \"list\"],\n                    set_={\"set\"},\n                    map_={1: \"map\"},\n                    bigint=1000000,\n                ),\n            ),\n        ],\n    )\n\n\nasyncio.run(main())\n",
+                "sync_client": "import datetime\nimport uuid\n\nfrom seed import Matryoshka\nfrom seed.types.object import (\n    NestedObjectWithRequiredField,\n    ObjectWithOptionalField,\n)\n\nclient = Matryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.object.get_and_return_nested_with_required_field_as_list(\n    request=[\n        NestedObjectWithRequiredField(\n            string=\"string\",\n            nested_object=ObjectWithOptionalField(\n                string=\"string\",\n                integer=1,\n                long_=1000000,\n                double=1.1,\n                bool_=True,\n                datetime=datetime.datetime.fromisoformat(\n                    \"2024-01-15 09:30:00+00:00\",\n                ),\n                date=datetime.date.fromisoformat(\n                    \"2023-01-15\",\n                ),\n                uuid_=uuid.UUID(\n                    \"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32\",\n                ),\n                base_64=\"SGVsbG8gd29ybGQh\",\n                list_=[\"list\", \"list\"],\n                set_={\"set\"},\n                map_={1: \"map\"},\n                bigint=1000000,\n            ),\n        ),\n        NestedObjectWithRequiredField(\n            string=\"string\",\n            nested_object=ObjectWithOptionalField(\n                string=\"string\",\n                integer=1,\n                long_=1000000,\n                double=1.1,\n                bool_=True,\n                datetime=datetime.datetime.fromisoformat(\n                    \"2024-01-15 09:30:00+00:00\",\n                ),\n                date=datetime.date.fromisoformat(\n                    \"2023-01-15\",\n                ),\n                uuid_=uuid.UUID(\n                    \"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32\",\n                ),\n                base_64=\"SGVsbG8gd29ybGQh\",\n                list_=[\"list\", \"list\"],\n                set_={\"set\"},\n                map_={1: \"map\"},\n                bigint=1000000,\n            ),\n        ),\n    ],\n)\n",
+                "async_client": "import asyncio\nimport datetime\nimport uuid\n\nfrom seed import AsyncMatryoshka\nfrom seed.types.object import (\n    NestedObjectWithRequiredField,\n    ObjectWithOptionalField,\n)\n\nclient = AsyncMatryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.object.get_and_return_nested_with_required_field_as_list(\n        request=[\n            NestedObjectWithRequiredField(\n                string=\"string\",\n                nested_object=ObjectWithOptionalField(\n                    string=\"string\",\n                    integer=1,\n                    long_=1000000,\n                    double=1.1,\n                    bool_=True,\n                    datetime=datetime.datetime.fromisoformat(\n                        \"2024-01-15 09:30:00+00:00\",\n                    ),\n                    date=datetime.date.fromisoformat(\n                        \"2023-01-15\",\n                    ),\n                    uuid_=uuid.UUID(\n                        \"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32\",\n                    ),\n                    base_64=\"SGVsbG8gd29ybGQh\",\n                    list_=[\"list\", \"list\"],\n                    set_={\"set\"},\n                    map_={1: \"map\"},\n                    bigint=1000000,\n                ),\n            ),\n            NestedObjectWithRequiredField(\n                string=\"string\",\n                nested_object=ObjectWithOptionalField(\n                    string=\"string\",\n                    integer=1,\n                    long_=1000000,\n                    double=1.1,\n                    bool_=True,\n                    datetime=datetime.datetime.fromisoformat(\n                        \"2024-01-15 09:30:00+00:00\",\n                    ),\n                    date=datetime.date.fromisoformat(\n                        \"2023-01-15\",\n                    ),\n                    uuid_=uuid.UUID(\n                        \"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32\",\n                    ),\n                    base_64=\"SGVsbG8gd29ybGQh\",\n                    list_=[\"list\", \"list\"],\n                    set_={\"set\"},\n                    map_={1: \"map\"},\n                    bigint=1000000,\n                ),\n            ),\n        ],\n    )\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -282,8 +282,8 @@
                 "identifier_override": "endpoint_endpoints/params.getWithPath"
             },
             "snippet": {
-                "sync_client": "from seed import SeedExhaustive\n\nclient = SeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.params.get_with_path(\n    param=\"param\",\n)\n",
-                "async_client": "import asyncio\n\nfrom seed import AsyncSeedExhaustive\n\nclient = AsyncSeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.params.get_with_path(\n        param=\"param\",\n    )\n\n\nasyncio.run(main())\n",
+                "sync_client": "from seed import Matryoshka\n\nclient = Matryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.params.get_with_path(\n    param=\"param\",\n)\n",
+                "async_client": "import asyncio\n\nfrom seed import AsyncMatryoshka\n\nclient = AsyncMatryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.params.get_with_path(\n        param=\"param\",\n    )\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -295,8 +295,8 @@
                 "identifier_override": "endpoint_endpoints/params.getWithInlinePath"
             },
             "snippet": {
-                "sync_client": "from seed import SeedExhaustive\n\nclient = SeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.params.get_with_inline_path(\n    param=\"param\",\n)\n",
-                "async_client": "import asyncio\n\nfrom seed import AsyncSeedExhaustive\n\nclient = AsyncSeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.params.get_with_inline_path(\n        param=\"param\",\n    )\n\n\nasyncio.run(main())\n",
+                "sync_client": "from seed import Matryoshka\n\nclient = Matryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.params.get_with_inline_path(\n    param=\"param\",\n)\n",
+                "async_client": "import asyncio\n\nfrom seed import AsyncMatryoshka\n\nclient = AsyncMatryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.params.get_with_inline_path(\n        param=\"param\",\n    )\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -308,8 +308,8 @@
                 "identifier_override": "endpoint_endpoints/params.getWithQuery"
             },
             "snippet": {
-                "sync_client": "from seed import SeedExhaustive\n\nclient = SeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.params.get_with_query(\n    query=\"query\",\n    number=1,\n)\n",
-                "async_client": "import asyncio\n\nfrom seed import AsyncSeedExhaustive\n\nclient = AsyncSeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.params.get_with_query(\n        query=\"query\",\n        number=1,\n    )\n\n\nasyncio.run(main())\n",
+                "sync_client": "from seed import Matryoshka\n\nclient = Matryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.params.get_with_query(\n    query=\"query\",\n    number=1,\n)\n",
+                "async_client": "import asyncio\n\nfrom seed import AsyncMatryoshka\n\nclient = AsyncMatryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.params.get_with_query(\n        query=\"query\",\n        number=1,\n    )\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -321,8 +321,8 @@
                 "identifier_override": "endpoint_endpoints/params.getWithAllowMultipleQuery"
             },
             "snippet": {
-                "sync_client": "from seed import SeedExhaustive\n\nclient = SeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.params.get_with_allow_multiple_query(\n    query=\"query\",\n    number=1,\n)\n",
-                "async_client": "import asyncio\n\nfrom seed import AsyncSeedExhaustive\n\nclient = AsyncSeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.params.get_with_allow_multiple_query(\n        query=\"query\",\n        number=1,\n    )\n\n\nasyncio.run(main())\n",
+                "sync_client": "from seed import Matryoshka\n\nclient = Matryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.params.get_with_allow_multiple_query(\n    query=\"query\",\n    number=1,\n)\n",
+                "async_client": "import asyncio\n\nfrom seed import AsyncMatryoshka\n\nclient = AsyncMatryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.params.get_with_allow_multiple_query(\n        query=\"query\",\n        number=1,\n    )\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -334,8 +334,8 @@
                 "identifier_override": "endpoint_endpoints/params.getWithPathAndQuery"
             },
             "snippet": {
-                "sync_client": "from seed import SeedExhaustive\n\nclient = SeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.params.get_with_path_and_query(\n    param=\"param\",\n    query=\"query\",\n)\n",
-                "async_client": "import asyncio\n\nfrom seed import AsyncSeedExhaustive\n\nclient = AsyncSeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.params.get_with_path_and_query(\n        param=\"param\",\n        query=\"query\",\n    )\n\n\nasyncio.run(main())\n",
+                "sync_client": "from seed import Matryoshka\n\nclient = Matryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.params.get_with_path_and_query(\n    param=\"param\",\n    query=\"query\",\n)\n",
+                "async_client": "import asyncio\n\nfrom seed import AsyncMatryoshka\n\nclient = AsyncMatryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.params.get_with_path_and_query(\n        param=\"param\",\n        query=\"query\",\n    )\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -347,8 +347,8 @@
                 "identifier_override": "endpoint_endpoints/params.getWithInlinePathAndQuery"
             },
             "snippet": {
-                "sync_client": "from seed import SeedExhaustive\n\nclient = SeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.params.get_with_inline_path_and_query(\n    param=\"param\",\n    query=\"query\",\n)\n",
-                "async_client": "import asyncio\n\nfrom seed import AsyncSeedExhaustive\n\nclient = AsyncSeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.params.get_with_inline_path_and_query(\n        param=\"param\",\n        query=\"query\",\n    )\n\n\nasyncio.run(main())\n",
+                "sync_client": "from seed import Matryoshka\n\nclient = Matryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.params.get_with_inline_path_and_query(\n    param=\"param\",\n    query=\"query\",\n)\n",
+                "async_client": "import asyncio\n\nfrom seed import AsyncMatryoshka\n\nclient = AsyncMatryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.params.get_with_inline_path_and_query(\n        param=\"param\",\n        query=\"query\",\n    )\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -360,8 +360,8 @@
                 "identifier_override": "endpoint_endpoints/params.modifyWithPath"
             },
             "snippet": {
-                "sync_client": "from seed import SeedExhaustive\n\nclient = SeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.params.modify_with_path(\n    param=\"param\",\n    request=\"string\",\n)\n",
-                "async_client": "import asyncio\n\nfrom seed import AsyncSeedExhaustive\n\nclient = AsyncSeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.params.modify_with_path(\n        param=\"param\",\n        request=\"string\",\n    )\n\n\nasyncio.run(main())\n",
+                "sync_client": "from seed import Matryoshka\n\nclient = Matryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.params.modify_with_path(\n    param=\"param\",\n    request=\"string\",\n)\n",
+                "async_client": "import asyncio\n\nfrom seed import AsyncMatryoshka\n\nclient = AsyncMatryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.params.modify_with_path(\n        param=\"param\",\n        request=\"string\",\n    )\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -373,8 +373,8 @@
                 "identifier_override": "endpoint_endpoints/params.modifyWithInlinePath"
             },
             "snippet": {
-                "sync_client": "from seed import SeedExhaustive\n\nclient = SeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.params.modify_with_inline_path(\n    param=\"param\",\n    request=\"string\",\n)\n",
-                "async_client": "import asyncio\n\nfrom seed import AsyncSeedExhaustive\n\nclient = AsyncSeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.params.modify_with_inline_path(\n        param=\"param\",\n        request=\"string\",\n    )\n\n\nasyncio.run(main())\n",
+                "sync_client": "from seed import Matryoshka\n\nclient = Matryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.params.modify_with_inline_path(\n    param=\"param\",\n    request=\"string\",\n)\n",
+                "async_client": "import asyncio\n\nfrom seed import AsyncMatryoshka\n\nclient = AsyncMatryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.params.modify_with_inline_path(\n        param=\"param\",\n        request=\"string\",\n    )\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -386,8 +386,8 @@
                 "identifier_override": "endpoint_endpoints/primitive.getAndReturnString"
             },
             "snippet": {
-                "sync_client": "from seed import SeedExhaustive\n\nclient = SeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.primitive.get_and_return_string(\n    request=\"string\",\n)\n",
-                "async_client": "import asyncio\n\nfrom seed import AsyncSeedExhaustive\n\nclient = AsyncSeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.primitive.get_and_return_string(\n        request=\"string\",\n    )\n\n\nasyncio.run(main())\n",
+                "sync_client": "from seed import Matryoshka\n\nclient = Matryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.primitive.get_and_return_string(\n    request=\"string\",\n)\n",
+                "async_client": "import asyncio\n\nfrom seed import AsyncMatryoshka\n\nclient = AsyncMatryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.primitive.get_and_return_string(\n        request=\"string\",\n    )\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -399,8 +399,8 @@
                 "identifier_override": "endpoint_endpoints/primitive.getAndReturnInt"
             },
             "snippet": {
-                "sync_client": "from seed import SeedExhaustive\n\nclient = SeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.primitive.get_and_return_int(\n    request=1,\n)\n",
-                "async_client": "import asyncio\n\nfrom seed import AsyncSeedExhaustive\n\nclient = AsyncSeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.primitive.get_and_return_int(\n        request=1,\n    )\n\n\nasyncio.run(main())\n",
+                "sync_client": "from seed import Matryoshka\n\nclient = Matryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.primitive.get_and_return_int(\n    request=1,\n)\n",
+                "async_client": "import asyncio\n\nfrom seed import AsyncMatryoshka\n\nclient = AsyncMatryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.primitive.get_and_return_int(\n        request=1,\n    )\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -412,8 +412,8 @@
                 "identifier_override": "endpoint_endpoints/primitive.getAndReturnLong"
             },
             "snippet": {
-                "sync_client": "from seed import SeedExhaustive\n\nclient = SeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.primitive.get_and_return_long(\n    request=1000000,\n)\n",
-                "async_client": "import asyncio\n\nfrom seed import AsyncSeedExhaustive\n\nclient = AsyncSeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.primitive.get_and_return_long(\n        request=1000000,\n    )\n\n\nasyncio.run(main())\n",
+                "sync_client": "from seed import Matryoshka\n\nclient = Matryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.primitive.get_and_return_long(\n    request=1000000,\n)\n",
+                "async_client": "import asyncio\n\nfrom seed import AsyncMatryoshka\n\nclient = AsyncMatryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.primitive.get_and_return_long(\n        request=1000000,\n    )\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -425,8 +425,8 @@
                 "identifier_override": "endpoint_endpoints/primitive.getAndReturnDouble"
             },
             "snippet": {
-                "sync_client": "from seed import SeedExhaustive\n\nclient = SeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.primitive.get_and_return_double(\n    request=1.1,\n)\n",
-                "async_client": "import asyncio\n\nfrom seed import AsyncSeedExhaustive\n\nclient = AsyncSeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.primitive.get_and_return_double(\n        request=1.1,\n    )\n\n\nasyncio.run(main())\n",
+                "sync_client": "from seed import Matryoshka\n\nclient = Matryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.primitive.get_and_return_double(\n    request=1.1,\n)\n",
+                "async_client": "import asyncio\n\nfrom seed import AsyncMatryoshka\n\nclient = AsyncMatryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.primitive.get_and_return_double(\n        request=1.1,\n    )\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -438,8 +438,8 @@
                 "identifier_override": "endpoint_endpoints/primitive.getAndReturnBool"
             },
             "snippet": {
-                "sync_client": "from seed import SeedExhaustive\n\nclient = SeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.primitive.get_and_return_bool(\n    request=True,\n)\n",
-                "async_client": "import asyncio\n\nfrom seed import AsyncSeedExhaustive\n\nclient = AsyncSeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.primitive.get_and_return_bool(\n        request=True,\n    )\n\n\nasyncio.run(main())\n",
+                "sync_client": "from seed import Matryoshka\n\nclient = Matryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.primitive.get_and_return_bool(\n    request=True,\n)\n",
+                "async_client": "import asyncio\n\nfrom seed import AsyncMatryoshka\n\nclient = AsyncMatryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.primitive.get_and_return_bool(\n        request=True,\n    )\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -451,8 +451,8 @@
                 "identifier_override": "endpoint_endpoints/primitive.getAndReturnDatetime"
             },
             "snippet": {
-                "sync_client": "import datetime\n\nfrom seed import SeedExhaustive\n\nclient = SeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.primitive.get_and_return_datetime(\n    request=datetime.datetime.fromisoformat(\n        \"2024-01-15 09:30:00+00:00\",\n    ),\n)\n",
-                "async_client": "import asyncio\nimport datetime\n\nfrom seed import AsyncSeedExhaustive\n\nclient = AsyncSeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.primitive.get_and_return_datetime(\n        request=datetime.datetime.fromisoformat(\n            \"2024-01-15 09:30:00+00:00\",\n        ),\n    )\n\n\nasyncio.run(main())\n",
+                "sync_client": "import datetime\n\nfrom seed import Matryoshka\n\nclient = Matryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.primitive.get_and_return_datetime(\n    request=datetime.datetime.fromisoformat(\n        \"2024-01-15 09:30:00+00:00\",\n    ),\n)\n",
+                "async_client": "import asyncio\nimport datetime\n\nfrom seed import AsyncMatryoshka\n\nclient = AsyncMatryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.primitive.get_and_return_datetime(\n        request=datetime.datetime.fromisoformat(\n            \"2024-01-15 09:30:00+00:00\",\n        ),\n    )\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -464,8 +464,8 @@
                 "identifier_override": "endpoint_endpoints/primitive.getAndReturnDate"
             },
             "snippet": {
-                "sync_client": "import datetime\n\nfrom seed import SeedExhaustive\n\nclient = SeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.primitive.get_and_return_date(\n    request=datetime.date.fromisoformat(\n        \"2023-01-15\",\n    ),\n)\n",
-                "async_client": "import asyncio\nimport datetime\n\nfrom seed import AsyncSeedExhaustive\n\nclient = AsyncSeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.primitive.get_and_return_date(\n        request=datetime.date.fromisoformat(\n            \"2023-01-15\",\n        ),\n    )\n\n\nasyncio.run(main())\n",
+                "sync_client": "import datetime\n\nfrom seed import Matryoshka\n\nclient = Matryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.primitive.get_and_return_date(\n    request=datetime.date.fromisoformat(\n        \"2023-01-15\",\n    ),\n)\n",
+                "async_client": "import asyncio\nimport datetime\n\nfrom seed import AsyncMatryoshka\n\nclient = AsyncMatryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.primitive.get_and_return_date(\n        request=datetime.date.fromisoformat(\n            \"2023-01-15\",\n        ),\n    )\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -477,8 +477,8 @@
                 "identifier_override": "endpoint_endpoints/primitive.getAndReturnUUID"
             },
             "snippet": {
-                "sync_client": "import uuid\n\nfrom seed import SeedExhaustive\n\nclient = SeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.primitive.get_and_return_uuid(\n    request=uuid.UUID(\n        \"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32\",\n    ),\n)\n",
-                "async_client": "import asyncio\nimport uuid\n\nfrom seed import AsyncSeedExhaustive\n\nclient = AsyncSeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.primitive.get_and_return_uuid(\n        request=uuid.UUID(\n            \"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32\",\n        ),\n    )\n\n\nasyncio.run(main())\n",
+                "sync_client": "import uuid\n\nfrom seed import Matryoshka\n\nclient = Matryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.primitive.get_and_return_uuid(\n    request=uuid.UUID(\n        \"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32\",\n    ),\n)\n",
+                "async_client": "import asyncio\nimport uuid\n\nfrom seed import AsyncMatryoshka\n\nclient = AsyncMatryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.primitive.get_and_return_uuid(\n        request=uuid.UUID(\n            \"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32\",\n        ),\n    )\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -490,8 +490,8 @@
                 "identifier_override": "endpoint_endpoints/primitive.getAndReturnBase64"
             },
             "snippet": {
-                "sync_client": "from seed import SeedExhaustive\n\nclient = SeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.primitive.get_and_return_base_64(\n    request=\"SGVsbG8gd29ybGQh\",\n)\n",
-                "async_client": "import asyncio\n\nfrom seed import AsyncSeedExhaustive\n\nclient = AsyncSeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.primitive.get_and_return_base_64(\n        request=\"SGVsbG8gd29ybGQh\",\n    )\n\n\nasyncio.run(main())\n",
+                "sync_client": "from seed import Matryoshka\n\nclient = Matryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.primitive.get_and_return_base_64(\n    request=\"SGVsbG8gd29ybGQh\",\n)\n",
+                "async_client": "import asyncio\n\nfrom seed import AsyncMatryoshka\n\nclient = AsyncMatryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.primitive.get_and_return_base_64(\n        request=\"SGVsbG8gd29ybGQh\",\n    )\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -503,8 +503,8 @@
                 "identifier_override": "endpoint_endpoints/put.add"
             },
             "snippet": {
-                "sync_client": "from seed import SeedExhaustive\n\nclient = SeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.put.add(\n    id=\"id\",\n)\n",
-                "async_client": "import asyncio\n\nfrom seed import AsyncSeedExhaustive\n\nclient = AsyncSeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.put.add(\n        id=\"id\",\n    )\n\n\nasyncio.run(main())\n",
+                "sync_client": "from seed import Matryoshka\n\nclient = Matryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.put.add(\n    id=\"id\",\n)\n",
+                "async_client": "import asyncio\n\nfrom seed import AsyncMatryoshka\n\nclient = AsyncMatryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.put.add(\n        id=\"id\",\n    )\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -516,8 +516,8 @@
                 "identifier_override": "endpoint_endpoints/union.getAndReturnUnion"
             },
             "snippet": {
-                "sync_client": "from seed import SeedExhaustive\nfrom seed.types.union import Animal_Dog\n\nclient = SeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.union.get_and_return_union(\n    request=Animal_Dog(\n        name=\"name\",\n        likes_to_woof=True,\n    ),\n)\n",
-                "async_client": "import asyncio\n\nfrom seed import AsyncSeedExhaustive\nfrom seed.types.union import Animal_Dog\n\nclient = AsyncSeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.union.get_and_return_union(\n        request=Animal_Dog(\n            name=\"name\",\n            likes_to_woof=True,\n        ),\n    )\n\n\nasyncio.run(main())\n",
+                "sync_client": "from seed import Matryoshka\nfrom seed.types.union import Animal_Dog\n\nclient = Matryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.union.get_and_return_union(\n    request=Animal_Dog(\n        name=\"name\",\n        likes_to_woof=True,\n    ),\n)\n",
+                "async_client": "import asyncio\n\nfrom seed import AsyncMatryoshka\nfrom seed.types.union import Animal_Dog\n\nclient = AsyncMatryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.union.get_and_return_union(\n        request=Animal_Dog(\n            name=\"name\",\n            likes_to_woof=True,\n        ),\n    )\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -529,8 +529,8 @@
                 "identifier_override": "endpoint_endpoints/urls.withMixedCase"
             },
             "snippet": {
-                "sync_client": "from seed import SeedExhaustive\n\nclient = SeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.urls.with_mixed_case()\n",
-                "async_client": "import asyncio\n\nfrom seed import AsyncSeedExhaustive\n\nclient = AsyncSeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.urls.with_mixed_case()\n\n\nasyncio.run(main())\n",
+                "sync_client": "from seed import Matryoshka\n\nclient = Matryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.urls.with_mixed_case()\n",
+                "async_client": "import asyncio\n\nfrom seed import AsyncMatryoshka\n\nclient = AsyncMatryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.urls.with_mixed_case()\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -542,8 +542,8 @@
                 "identifier_override": "endpoint_endpoints/urls.noEndingSlash"
             },
             "snippet": {
-                "sync_client": "from seed import SeedExhaustive\n\nclient = SeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.urls.no_ending_slash()\n",
-                "async_client": "import asyncio\n\nfrom seed import AsyncSeedExhaustive\n\nclient = AsyncSeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.urls.no_ending_slash()\n\n\nasyncio.run(main())\n",
+                "sync_client": "from seed import Matryoshka\n\nclient = Matryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.urls.no_ending_slash()\n",
+                "async_client": "import asyncio\n\nfrom seed import AsyncMatryoshka\n\nclient = AsyncMatryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.urls.no_ending_slash()\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -555,8 +555,8 @@
                 "identifier_override": "endpoint_endpoints/urls.withEndingSlash"
             },
             "snippet": {
-                "sync_client": "from seed import SeedExhaustive\n\nclient = SeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.urls.with_ending_slash()\n",
-                "async_client": "import asyncio\n\nfrom seed import AsyncSeedExhaustive\n\nclient = AsyncSeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.urls.with_ending_slash()\n\n\nasyncio.run(main())\n",
+                "sync_client": "from seed import Matryoshka\n\nclient = Matryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.urls.with_ending_slash()\n",
+                "async_client": "import asyncio\n\nfrom seed import AsyncMatryoshka\n\nclient = AsyncMatryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.urls.with_ending_slash()\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -568,8 +568,8 @@
                 "identifier_override": "endpoint_endpoints/urls.withUnderscores"
             },
             "snippet": {
-                "sync_client": "from seed import SeedExhaustive\n\nclient = SeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.urls.with_underscores()\n",
-                "async_client": "import asyncio\n\nfrom seed import AsyncSeedExhaustive\n\nclient = AsyncSeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.urls.with_underscores()\n\n\nasyncio.run(main())\n",
+                "sync_client": "from seed import Matryoshka\n\nclient = Matryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.endpoints.urls.with_underscores()\n",
+                "async_client": "import asyncio\n\nfrom seed import AsyncMatryoshka\n\nclient = AsyncMatryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.endpoints.urls.with_underscores()\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -581,8 +581,8 @@
                 "identifier_override": "endpoint_inlined-requests.postWithObjectBodyandResponse"
             },
             "snippet": {
-                "sync_client": "import datetime\nimport uuid\n\nfrom seed import SeedExhaustive\nfrom seed.types.object import ObjectWithOptionalField\n\nclient = SeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.inlined_requests.post_with_object_bodyand_response(\n    string=\"string\",\n    integer=1,\n    nested_object=ObjectWithOptionalField(\n        string=\"string\",\n        integer=1,\n        long_=1000000,\n        double=1.1,\n        bool_=True,\n        datetime=datetime.datetime.fromisoformat(\n            \"2024-01-15 09:30:00+00:00\",\n        ),\n        date=datetime.date.fromisoformat(\n            \"2023-01-15\",\n        ),\n        uuid_=uuid.UUID(\n            \"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32\",\n        ),\n        base_64=\"SGVsbG8gd29ybGQh\",\n        list_=[\"list\", \"list\"],\n        set_={\"set\"},\n        map_={1: \"map\"},\n        bigint=1000000,\n    ),\n)\n",
-                "async_client": "import asyncio\nimport datetime\nimport uuid\n\nfrom seed import AsyncSeedExhaustive\nfrom seed.types.object import ObjectWithOptionalField\n\nclient = AsyncSeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.inlined_requests.post_with_object_bodyand_response(\n        string=\"string\",\n        integer=1,\n        nested_object=ObjectWithOptionalField(\n            string=\"string\",\n            integer=1,\n            long_=1000000,\n            double=1.1,\n            bool_=True,\n            datetime=datetime.datetime.fromisoformat(\n                \"2024-01-15 09:30:00+00:00\",\n            ),\n            date=datetime.date.fromisoformat(\n                \"2023-01-15\",\n            ),\n            uuid_=uuid.UUID(\n                \"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32\",\n            ),\n            base_64=\"SGVsbG8gd29ybGQh\",\n            list_=[\"list\", \"list\"],\n            set_={\"set\"},\n            map_={1: \"map\"},\n            bigint=1000000,\n        ),\n    )\n\n\nasyncio.run(main())\n",
+                "sync_client": "import datetime\nimport uuid\n\nfrom seed import Matryoshka\nfrom seed.types.object import ObjectWithOptionalField\n\nclient = Matryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.inlined_requests.post_with_object_bodyand_response(\n    string=\"string\",\n    integer=1,\n    nested_object=ObjectWithOptionalField(\n        string=\"string\",\n        integer=1,\n        long_=1000000,\n        double=1.1,\n        bool_=True,\n        datetime=datetime.datetime.fromisoformat(\n            \"2024-01-15 09:30:00+00:00\",\n        ),\n        date=datetime.date.fromisoformat(\n            \"2023-01-15\",\n        ),\n        uuid_=uuid.UUID(\n            \"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32\",\n        ),\n        base_64=\"SGVsbG8gd29ybGQh\",\n        list_=[\"list\", \"list\"],\n        set_={\"set\"},\n        map_={1: \"map\"},\n        bigint=1000000,\n    ),\n)\n",
+                "async_client": "import asyncio\nimport datetime\nimport uuid\n\nfrom seed import AsyncMatryoshka\nfrom seed.types.object import ObjectWithOptionalField\n\nclient = AsyncMatryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.inlined_requests.post_with_object_bodyand_response(\n        string=\"string\",\n        integer=1,\n        nested_object=ObjectWithOptionalField(\n            string=\"string\",\n            integer=1,\n            long_=1000000,\n            double=1.1,\n            bool_=True,\n            datetime=datetime.datetime.fromisoformat(\n                \"2024-01-15 09:30:00+00:00\",\n            ),\n            date=datetime.date.fromisoformat(\n                \"2023-01-15\",\n            ),\n            uuid_=uuid.UUID(\n                \"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32\",\n            ),\n            base_64=\"SGVsbG8gd29ybGQh\",\n            list_=[\"list\", \"list\"],\n            set_={\"set\"},\n            map_={1: \"map\"},\n            bigint=1000000,\n        ),\n    )\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -594,8 +594,8 @@
                 "identifier_override": "endpoint_no-auth.postWithNoAuth"
             },
             "snippet": {
-                "sync_client": "from seed import SeedExhaustive\n\nclient = SeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.no_auth.post_with_no_auth(\n    request={\"key\": \"value\"},\n)\n",
-                "async_client": "import asyncio\n\nfrom seed import AsyncSeedExhaustive\n\nclient = AsyncSeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.no_auth.post_with_no_auth(\n        request={\"key\": \"value\"},\n    )\n\n\nasyncio.run(main())\n",
+                "sync_client": "from seed import Matryoshka\n\nclient = Matryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.no_auth.post_with_no_auth(\n    request={\"key\": \"value\"},\n)\n",
+                "async_client": "import asyncio\n\nfrom seed import AsyncMatryoshka\n\nclient = AsyncMatryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.no_auth.post_with_no_auth(\n        request={\"key\": \"value\"},\n    )\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -607,8 +607,8 @@
                 "identifier_override": "endpoint_no-req-body.getWithNoRequestBody"
             },
             "snippet": {
-                "sync_client": "from seed import SeedExhaustive\n\nclient = SeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.no_req_body.get_with_no_request_body()\n",
-                "async_client": "import asyncio\n\nfrom seed import AsyncSeedExhaustive\n\nclient = AsyncSeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.no_req_body.get_with_no_request_body()\n\n\nasyncio.run(main())\n",
+                "sync_client": "from seed import Matryoshka\n\nclient = Matryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.no_req_body.get_with_no_request_body()\n",
+                "async_client": "import asyncio\n\nfrom seed import AsyncMatryoshka\n\nclient = AsyncMatryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.no_req_body.get_with_no_request_body()\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -620,8 +620,8 @@
                 "identifier_override": "endpoint_no-req-body.postWithNoRequestBody"
             },
             "snippet": {
-                "sync_client": "from seed import SeedExhaustive\n\nclient = SeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.no_req_body.post_with_no_request_body()\n",
-                "async_client": "import asyncio\n\nfrom seed import AsyncSeedExhaustive\n\nclient = AsyncSeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.no_req_body.post_with_no_request_body()\n\n\nasyncio.run(main())\n",
+                "sync_client": "from seed import Matryoshka\n\nclient = Matryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.no_req_body.post_with_no_request_body()\n",
+                "async_client": "import asyncio\n\nfrom seed import AsyncMatryoshka\n\nclient = AsyncMatryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.no_req_body.post_with_no_request_body()\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -633,8 +633,8 @@
                 "identifier_override": "endpoint_req-with-headers.getWithCustomHeader"
             },
             "snippet": {
-                "sync_client": "from seed import SeedExhaustive\n\nclient = SeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.req_with_headers.get_with_custom_header(\n    x_test_service_header=\"X-TEST-SERVICE-HEADER\",\n    x_test_endpoint_header=\"X-TEST-ENDPOINT-HEADER\",\n    request=\"string\",\n)\n",
-                "async_client": "import asyncio\n\nfrom seed import AsyncSeedExhaustive\n\nclient = AsyncSeedExhaustive(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.req_with_headers.get_with_custom_header(\n        x_test_service_header=\"X-TEST-SERVICE-HEADER\",\n        x_test_endpoint_header=\"X-TEST-ENDPOINT-HEADER\",\n        request=\"string\",\n    )\n\n\nasyncio.run(main())\n",
+                "sync_client": "from seed import Matryoshka\n\nclient = Matryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.req_with_headers.get_with_custom_header(\n    x_test_service_header=\"X-TEST-SERVICE-HEADER\",\n    x_test_endpoint_header=\"X-TEST-ENDPOINT-HEADER\",\n    request=\"string\",\n)\n",
+                "async_client": "import asyncio\n\nfrom seed import AsyncMatryoshka\n\nclient = AsyncMatryoshka(\n    token=\"YOUR_TOKEN\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.req_with_headers.get_with_custom_header(\n        x_test_service_header=\"X-TEST-SERVICE-HEADER\",\n        x_test_endpoint_header=\"X-TEST-ENDPOINT-HEADER\",\n        request=\"string\",\n    )\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         }

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/__init__.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/__init__.py
@@ -7,14 +7,14 @@ from importlib import import_module
 
 if typing.TYPE_CHECKING:
     from . import endpoints, general_errors, inlined_requests, no_auth, no_req_body, req_with_headers, types
-    from .client import AsyncSeedExhaustive, SeedExhaustive
+    from .client import AsyncMatryoshka, Matryoshka
     from .general_errors import BadObjectRequestInfo, BadRequestBody
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
-    "AsyncSeedExhaustive": ".client",
+    "AsyncMatryoshka": ".client",
     "BadObjectRequestInfo": ".general_errors",
     "BadRequestBody": ".general_errors",
-    "SeedExhaustive": ".client",
+    "Matryoshka": ".client",
     "__version__": ".version",
     "endpoints": ".endpoints",
     "general_errors": ".general_errors",
@@ -48,10 +48,10 @@ def __dir__():
 
 
 __all__ = [
-    "AsyncSeedExhaustive",
+    "AsyncMatryoshka",
     "BadObjectRequestInfo",
     "BadRequestBody",
-    "SeedExhaustive",
+    "Matryoshka",
     "__version__",
     "endpoints",
     "general_errors",

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/client.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/client.py
@@ -15,7 +15,7 @@ if typing.TYPE_CHECKING:
     from .req_with_headers.client import AsyncReqWithHeadersClient, ReqWithHeadersClient
 
 
-class SeedExhaustive:
+class Matryoshka:
     """
     Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
 
@@ -39,9 +39,9 @@ class SeedExhaustive:
 
     Examples
     --------
-    from seed import SeedExhaustive
+    from seed import Matryoshka
 
-    client = SeedExhaustive(
+    client = Matryoshka(
         token="YOUR_TOKEN",
         base_url="https://yourhost.com/path/to/api",
     )
@@ -118,7 +118,7 @@ class SeedExhaustive:
         return self._req_with_headers
 
 
-class AsyncSeedExhaustive:
+class AsyncMatryoshka:
     """
     Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
 
@@ -142,9 +142,9 @@ class AsyncSeedExhaustive:
 
     Examples
     --------
-    from seed import AsyncSeedExhaustive
+    from seed import AsyncMatryoshka
 
-    client = AsyncSeedExhaustive(
+    client = AsyncMatryoshka(
         token="YOUR_TOKEN",
         base_url="https://yourhost.com/path/to/api",
     )

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/endpoints/container/client.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/endpoints/container/client.py
@@ -43,9 +43,9 @@ class ContainerClient:
 
         Examples
         --------
-        from seed import SeedExhaustive
+        from seed import Matryoshka
 
-        client = SeedExhaustive(
+        client = Matryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -76,10 +76,10 @@ class ContainerClient:
 
         Examples
         --------
-        from seed import SeedExhaustive
+        from seed import Matryoshka
         from seed.types.object import ObjectWithRequiredField
 
-        client = SeedExhaustive(
+        client = Matryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -114,9 +114,9 @@ class ContainerClient:
 
         Examples
         --------
-        from seed import SeedExhaustive
+        from seed import Matryoshka
 
-        client = SeedExhaustive(
+        client = Matryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -147,10 +147,10 @@ class ContainerClient:
 
         Examples
         --------
-        from seed import SeedExhaustive
+        from seed import Matryoshka
         from seed.types.object import ObjectWithRequiredField
 
-        client = SeedExhaustive(
+        client = Matryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -182,9 +182,9 @@ class ContainerClient:
 
         Examples
         --------
-        from seed import SeedExhaustive
+        from seed import Matryoshka
 
-        client = SeedExhaustive(
+        client = Matryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -215,10 +215,10 @@ class ContainerClient:
 
         Examples
         --------
-        from seed import SeedExhaustive
+        from seed import Matryoshka
         from seed.types.object import ObjectWithRequiredField
 
-        client = SeedExhaustive(
+        client = Matryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -255,10 +255,10 @@ class ContainerClient:
 
         Examples
         --------
-        from seed import SeedExhaustive
+        from seed import Matryoshka
         from seed.types.object import ObjectWithRequiredField
 
-        client = SeedExhaustive(
+        client = Matryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -306,9 +306,9 @@ class AsyncContainerClient:
         --------
         import asyncio
 
-        from seed import AsyncSeedExhaustive
+        from seed import AsyncMatryoshka
 
-        client = AsyncSeedExhaustive(
+        client = AsyncMatryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -349,10 +349,10 @@ class AsyncContainerClient:
         --------
         import asyncio
 
-        from seed import AsyncSeedExhaustive
+        from seed import AsyncMatryoshka
         from seed.types.object import ObjectWithRequiredField
 
-        client = AsyncSeedExhaustive(
+        client = AsyncMatryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -397,9 +397,9 @@ class AsyncContainerClient:
         --------
         import asyncio
 
-        from seed import AsyncSeedExhaustive
+        from seed import AsyncMatryoshka
 
-        client = AsyncSeedExhaustive(
+        client = AsyncMatryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -440,10 +440,10 @@ class AsyncContainerClient:
         --------
         import asyncio
 
-        from seed import AsyncSeedExhaustive
+        from seed import AsyncMatryoshka
         from seed.types.object import ObjectWithRequiredField
 
-        client = AsyncSeedExhaustive(
+        client = AsyncMatryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -485,9 +485,9 @@ class AsyncContainerClient:
         --------
         import asyncio
 
-        from seed import AsyncSeedExhaustive
+        from seed import AsyncMatryoshka
 
-        client = AsyncSeedExhaustive(
+        client = AsyncMatryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -528,10 +528,10 @@ class AsyncContainerClient:
         --------
         import asyncio
 
-        from seed import AsyncSeedExhaustive
+        from seed import AsyncMatryoshka
         from seed.types.object import ObjectWithRequiredField
 
-        client = AsyncSeedExhaustive(
+        client = AsyncMatryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -576,10 +576,10 @@ class AsyncContainerClient:
         --------
         import asyncio
 
-        from seed import AsyncSeedExhaustive
+        from seed import AsyncMatryoshka
         from seed.types.object import ObjectWithRequiredField
 
-        client = AsyncSeedExhaustive(
+        client = AsyncMatryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/endpoints/content_type/client.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/endpoints/content_type/client.py
@@ -87,9 +87,9 @@ class ContentTypeClient:
         import datetime
         import uuid
 
-        from seed import SeedExhaustive
+        from seed import Matryoshka
 
-        client = SeedExhaustive(
+        client = Matryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -193,9 +193,9 @@ class ContentTypeClient:
         import datetime
         import uuid
 
-        from seed import SeedExhaustive
+        from seed import Matryoshka
 
-        client = SeedExhaustive(
+        client = Matryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -316,9 +316,9 @@ class AsyncContentTypeClient:
         import datetime
         import uuid
 
-        from seed import AsyncSeedExhaustive
+        from seed import AsyncMatryoshka
 
-        client = AsyncSeedExhaustive(
+        client = AsyncMatryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -429,9 +429,9 @@ class AsyncContentTypeClient:
         import datetime
         import uuid
 
-        from seed import AsyncSeedExhaustive
+        from seed import AsyncMatryoshka
 
-        client = AsyncSeedExhaustive(
+        client = AsyncMatryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/endpoints/enum/client.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/endpoints/enum/client.py
@@ -43,9 +43,9 @@ class EnumClient:
 
         Examples
         --------
-        from seed import SeedExhaustive
+        from seed import Matryoshka
 
-        client = SeedExhaustive(
+        client = Matryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -91,9 +91,9 @@ class AsyncEnumClient:
         --------
         import asyncio
 
-        from seed import AsyncSeedExhaustive
+        from seed import AsyncMatryoshka
 
-        client = AsyncSeedExhaustive(
+        client = AsyncMatryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/endpoints/http_methods/client.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/endpoints/http_methods/client.py
@@ -43,9 +43,9 @@ class HttpMethodsClient:
 
         Examples
         --------
-        from seed import SeedExhaustive
+        from seed import Matryoshka
 
-        client = SeedExhaustive(
+        client = Matryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -73,9 +73,9 @@ class HttpMethodsClient:
 
         Examples
         --------
-        from seed import SeedExhaustive
+        from seed import Matryoshka
 
-        client = SeedExhaustive(
+        client = Matryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -105,9 +105,9 @@ class HttpMethodsClient:
 
         Examples
         --------
-        from seed import SeedExhaustive
+        from seed import Matryoshka
 
-        client = SeedExhaustive(
+        client = Matryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -182,9 +182,9 @@ class HttpMethodsClient:
         import datetime
         import uuid
 
-        from seed import SeedExhaustive
+        from seed import Matryoshka
 
-        client = SeedExhaustive(
+        client = Matryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -245,9 +245,9 @@ class HttpMethodsClient:
 
         Examples
         --------
-        from seed import SeedExhaustive
+        from seed import Matryoshka
 
-        client = SeedExhaustive(
+        client = Matryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -291,9 +291,9 @@ class AsyncHttpMethodsClient:
         --------
         import asyncio
 
-        from seed import AsyncSeedExhaustive
+        from seed import AsyncMatryoshka
 
-        client = AsyncSeedExhaustive(
+        client = AsyncMatryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -329,9 +329,9 @@ class AsyncHttpMethodsClient:
         --------
         import asyncio
 
-        from seed import AsyncSeedExhaustive
+        from seed import AsyncMatryoshka
 
-        client = AsyncSeedExhaustive(
+        client = AsyncMatryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -369,9 +369,9 @@ class AsyncHttpMethodsClient:
         --------
         import asyncio
 
-        from seed import AsyncSeedExhaustive
+        from seed import AsyncMatryoshka
 
-        client = AsyncSeedExhaustive(
+        client = AsyncMatryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -453,9 +453,9 @@ class AsyncHttpMethodsClient:
         import datetime
         import uuid
 
-        from seed import AsyncSeedExhaustive
+        from seed import AsyncMatryoshka
 
-        client = AsyncSeedExhaustive(
+        client = AsyncMatryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -524,9 +524,9 @@ class AsyncHttpMethodsClient:
         --------
         import asyncio
 
-        from seed import AsyncSeedExhaustive
+        from seed import AsyncMatryoshka
 
-        client = AsyncSeedExhaustive(
+        client = AsyncMatryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/endpoints/object/client.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/endpoints/object/client.py
@@ -92,9 +92,9 @@ class ObjectClient:
         import datetime
         import uuid
 
-        from seed import SeedExhaustive
+        from seed import Matryoshka
 
-        client = SeedExhaustive(
+        client = Matryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -155,9 +155,9 @@ class ObjectClient:
 
         Examples
         --------
-        from seed import SeedExhaustive
+        from seed import Matryoshka
 
-        client = SeedExhaustive(
+        client = Matryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -185,9 +185,9 @@ class ObjectClient:
 
         Examples
         --------
-        from seed import SeedExhaustive
+        from seed import Matryoshka
 
-        client = SeedExhaustive(
+        client = Matryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -224,10 +224,10 @@ class ObjectClient:
         import datetime
         import uuid
 
-        from seed import SeedExhaustive
+        from seed import Matryoshka
         from seed.types.object import ObjectWithOptionalField
 
-        client = SeedExhaustive(
+        client = Matryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -290,10 +290,10 @@ class ObjectClient:
         import datetime
         import uuid
 
-        from seed import SeedExhaustive
+        from seed import Matryoshka
         from seed.types.object import ObjectWithOptionalField
 
-        client = SeedExhaustive(
+        client = Matryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -351,13 +351,13 @@ class ObjectClient:
         import datetime
         import uuid
 
-        from seed import SeedExhaustive
+        from seed import Matryoshka
         from seed.types.object import (
             NestedObjectWithRequiredField,
             ObjectWithOptionalField,
         )
 
-        client = SeedExhaustive(
+        client = Matryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -496,9 +496,9 @@ class AsyncObjectClient:
         import datetime
         import uuid
 
-        from seed import AsyncSeedExhaustive
+        from seed import AsyncMatryoshka
 
-        client = AsyncSeedExhaustive(
+        client = AsyncMatryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -567,9 +567,9 @@ class AsyncObjectClient:
         --------
         import asyncio
 
-        from seed import AsyncSeedExhaustive
+        from seed import AsyncMatryoshka
 
-        client = AsyncSeedExhaustive(
+        client = AsyncMatryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -607,9 +607,9 @@ class AsyncObjectClient:
         --------
         import asyncio
 
-        from seed import AsyncSeedExhaustive
+        from seed import AsyncMatryoshka
 
-        client = AsyncSeedExhaustive(
+        client = AsyncMatryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -653,10 +653,10 @@ class AsyncObjectClient:
         import datetime
         import uuid
 
-        from seed import AsyncSeedExhaustive
+        from seed import AsyncMatryoshka
         from seed.types.object import ObjectWithOptionalField
 
-        client = AsyncSeedExhaustive(
+        client = AsyncMatryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -726,10 +726,10 @@ class AsyncObjectClient:
         import datetime
         import uuid
 
-        from seed import AsyncSeedExhaustive
+        from seed import AsyncMatryoshka
         from seed.types.object import ObjectWithOptionalField
 
-        client = AsyncSeedExhaustive(
+        client = AsyncMatryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -794,13 +794,13 @@ class AsyncObjectClient:
         import datetime
         import uuid
 
-        from seed import AsyncSeedExhaustive
+        from seed import AsyncMatryoshka
         from seed.types.object import (
             NestedObjectWithRequiredField,
             ObjectWithOptionalField,
         )
 
-        client = AsyncSeedExhaustive(
+        client = AsyncMatryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/endpoints/params/client.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/endpoints/params/client.py
@@ -42,9 +42,9 @@ class ParamsClient:
 
         Examples
         --------
-        from seed import SeedExhaustive
+        from seed import Matryoshka
 
-        client = SeedExhaustive(
+        client = Matryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -72,9 +72,9 @@ class ParamsClient:
 
         Examples
         --------
-        from seed import SeedExhaustive
+        from seed import Matryoshka
 
-        client = SeedExhaustive(
+        client = Matryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -106,9 +106,9 @@ class ParamsClient:
 
         Examples
         --------
-        from seed import SeedExhaustive
+        from seed import Matryoshka
 
-        client = SeedExhaustive(
+        client = Matryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -145,9 +145,9 @@ class ParamsClient:
 
         Examples
         --------
-        from seed import SeedExhaustive
+        from seed import Matryoshka
 
-        client = SeedExhaustive(
+        client = Matryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -182,9 +182,9 @@ class ParamsClient:
 
         Examples
         --------
-        from seed import SeedExhaustive
+        from seed import Matryoshka
 
-        client = SeedExhaustive(
+        client = Matryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -217,9 +217,9 @@ class ParamsClient:
 
         Examples
         --------
-        from seed import SeedExhaustive
+        from seed import Matryoshka
 
-        client = SeedExhaustive(
+        client = Matryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -252,9 +252,9 @@ class ParamsClient:
 
         Examples
         --------
-        from seed import SeedExhaustive
+        from seed import Matryoshka
 
-        client = SeedExhaustive(
+        client = Matryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -287,9 +287,9 @@ class ParamsClient:
 
         Examples
         --------
-        from seed import SeedExhaustive
+        from seed import Matryoshka
 
-        client = SeedExhaustive(
+        client = Matryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -336,9 +336,9 @@ class AsyncParamsClient:
         --------
         import asyncio
 
-        from seed import AsyncSeedExhaustive
+        from seed import AsyncMatryoshka
 
-        client = AsyncSeedExhaustive(
+        client = AsyncMatryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -374,9 +374,9 @@ class AsyncParamsClient:
         --------
         import asyncio
 
-        from seed import AsyncSeedExhaustive
+        from seed import AsyncMatryoshka
 
-        client = AsyncSeedExhaustive(
+        client = AsyncMatryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -416,9 +416,9 @@ class AsyncParamsClient:
         --------
         import asyncio
 
-        from seed import AsyncSeedExhaustive
+        from seed import AsyncMatryoshka
 
-        client = AsyncSeedExhaustive(
+        client = AsyncMatryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -463,9 +463,9 @@ class AsyncParamsClient:
         --------
         import asyncio
 
-        from seed import AsyncSeedExhaustive
+        from seed import AsyncMatryoshka
 
-        client = AsyncSeedExhaustive(
+        client = AsyncMatryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -508,9 +508,9 @@ class AsyncParamsClient:
         --------
         import asyncio
 
-        from seed import AsyncSeedExhaustive
+        from seed import AsyncMatryoshka
 
-        client = AsyncSeedExhaustive(
+        client = AsyncMatryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -551,9 +551,9 @@ class AsyncParamsClient:
         --------
         import asyncio
 
-        from seed import AsyncSeedExhaustive
+        from seed import AsyncMatryoshka
 
-        client = AsyncSeedExhaustive(
+        client = AsyncMatryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -596,9 +596,9 @@ class AsyncParamsClient:
         --------
         import asyncio
 
-        from seed import AsyncSeedExhaustive
+        from seed import AsyncMatryoshka
 
-        client = AsyncSeedExhaustive(
+        client = AsyncMatryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -639,9 +639,9 @@ class AsyncParamsClient:
         --------
         import asyncio
 
-        from seed import AsyncSeedExhaustive
+        from seed import AsyncMatryoshka
 
-        client = AsyncSeedExhaustive(
+        client = AsyncMatryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/endpoints/primitive/client.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/endpoints/primitive/client.py
@@ -42,9 +42,9 @@ class PrimitiveClient:
 
         Examples
         --------
-        from seed import SeedExhaustive
+        from seed import Matryoshka
 
-        client = SeedExhaustive(
+        client = Matryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -70,9 +70,9 @@ class PrimitiveClient:
 
         Examples
         --------
-        from seed import SeedExhaustive
+        from seed import Matryoshka
 
-        client = SeedExhaustive(
+        client = Matryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -98,9 +98,9 @@ class PrimitiveClient:
 
         Examples
         --------
-        from seed import SeedExhaustive
+        from seed import Matryoshka
 
-        client = SeedExhaustive(
+        client = Matryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -128,9 +128,9 @@ class PrimitiveClient:
 
         Examples
         --------
-        from seed import SeedExhaustive
+        from seed import Matryoshka
 
-        client = SeedExhaustive(
+        client = Matryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -156,9 +156,9 @@ class PrimitiveClient:
 
         Examples
         --------
-        from seed import SeedExhaustive
+        from seed import Matryoshka
 
-        client = SeedExhaustive(
+        client = Matryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -188,9 +188,9 @@ class PrimitiveClient:
         --------
         import datetime
 
-        from seed import SeedExhaustive
+        from seed import Matryoshka
 
-        client = SeedExhaustive(
+        client = Matryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -222,9 +222,9 @@ class PrimitiveClient:
         --------
         import datetime
 
-        from seed import SeedExhaustive
+        from seed import Matryoshka
 
-        client = SeedExhaustive(
+        client = Matryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -256,9 +256,9 @@ class PrimitiveClient:
         --------
         import uuid
 
-        from seed import SeedExhaustive
+        from seed import Matryoshka
 
-        client = SeedExhaustive(
+        client = Matryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -286,9 +286,9 @@ class PrimitiveClient:
 
         Examples
         --------
-        from seed import SeedExhaustive
+        from seed import Matryoshka
 
-        client = SeedExhaustive(
+        client = Matryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -334,9 +334,9 @@ class AsyncPrimitiveClient:
         --------
         import asyncio
 
-        from seed import AsyncSeedExhaustive
+        from seed import AsyncMatryoshka
 
-        client = AsyncSeedExhaustive(
+        client = AsyncMatryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -370,9 +370,9 @@ class AsyncPrimitiveClient:
         --------
         import asyncio
 
-        from seed import AsyncSeedExhaustive
+        from seed import AsyncMatryoshka
 
-        client = AsyncSeedExhaustive(
+        client = AsyncMatryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -408,9 +408,9 @@ class AsyncPrimitiveClient:
         --------
         import asyncio
 
-        from seed import AsyncSeedExhaustive
+        from seed import AsyncMatryoshka
 
-        client = AsyncSeedExhaustive(
+        client = AsyncMatryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -446,9 +446,9 @@ class AsyncPrimitiveClient:
         --------
         import asyncio
 
-        from seed import AsyncSeedExhaustive
+        from seed import AsyncMatryoshka
 
-        client = AsyncSeedExhaustive(
+        client = AsyncMatryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -484,9 +484,9 @@ class AsyncPrimitiveClient:
         --------
         import asyncio
 
-        from seed import AsyncSeedExhaustive
+        from seed import AsyncMatryoshka
 
-        client = AsyncSeedExhaustive(
+        client = AsyncMatryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -523,9 +523,9 @@ class AsyncPrimitiveClient:
         import asyncio
         import datetime
 
-        from seed import AsyncSeedExhaustive
+        from seed import AsyncMatryoshka
 
-        client = AsyncSeedExhaustive(
+        client = AsyncMatryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -564,9 +564,9 @@ class AsyncPrimitiveClient:
         import asyncio
         import datetime
 
-        from seed import AsyncSeedExhaustive
+        from seed import AsyncMatryoshka
 
-        client = AsyncSeedExhaustive(
+        client = AsyncMatryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -605,9 +605,9 @@ class AsyncPrimitiveClient:
         import asyncio
         import uuid
 
-        from seed import AsyncSeedExhaustive
+        from seed import AsyncMatryoshka
 
-        client = AsyncSeedExhaustive(
+        client = AsyncMatryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -645,9 +645,9 @@ class AsyncPrimitiveClient:
         --------
         import asyncio
 
-        from seed import AsyncSeedExhaustive
+        from seed import AsyncMatryoshka
 
-        client = AsyncSeedExhaustive(
+        client = AsyncMatryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/endpoints/put/client.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/endpoints/put/client.py
@@ -38,9 +38,9 @@ class PutClient:
 
         Examples
         --------
-        from seed import SeedExhaustive
+        from seed import Matryoshka
 
-        client = SeedExhaustive(
+        client = Matryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -84,9 +84,9 @@ class AsyncPutClient:
         --------
         import asyncio
 
-        from seed import AsyncSeedExhaustive
+        from seed import AsyncMatryoshka
 
-        client = AsyncSeedExhaustive(
+        client = AsyncMatryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/endpoints/union/client.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/endpoints/union/client.py
@@ -43,10 +43,10 @@ class UnionClient:
 
         Examples
         --------
-        from seed import SeedExhaustive
+        from seed import Matryoshka
         from seed.types.union import Animal_Dog
 
-        client = SeedExhaustive(
+        client = Matryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -95,10 +95,10 @@ class AsyncUnionClient:
         --------
         import asyncio
 
-        from seed import AsyncSeedExhaustive
+        from seed import AsyncMatryoshka
         from seed.types.union import Animal_Dog
 
-        client = AsyncSeedExhaustive(
+        client = AsyncMatryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/endpoints/urls/client.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/endpoints/urls/client.py
@@ -35,9 +35,9 @@ class UrlsClient:
 
         Examples
         --------
-        from seed import SeedExhaustive
+        from seed import Matryoshka
 
-        client = SeedExhaustive(
+        client = Matryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -59,9 +59,9 @@ class UrlsClient:
 
         Examples
         --------
-        from seed import SeedExhaustive
+        from seed import Matryoshka
 
-        client = SeedExhaustive(
+        client = Matryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -83,9 +83,9 @@ class UrlsClient:
 
         Examples
         --------
-        from seed import SeedExhaustive
+        from seed import Matryoshka
 
-        client = SeedExhaustive(
+        client = Matryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -107,9 +107,9 @@ class UrlsClient:
 
         Examples
         --------
-        from seed import SeedExhaustive
+        from seed import Matryoshka
 
-        client = SeedExhaustive(
+        client = Matryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -149,9 +149,9 @@ class AsyncUrlsClient:
         --------
         import asyncio
 
-        from seed import AsyncSeedExhaustive
+        from seed import AsyncMatryoshka
 
-        client = AsyncSeedExhaustive(
+        client = AsyncMatryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -181,9 +181,9 @@ class AsyncUrlsClient:
         --------
         import asyncio
 
-        from seed import AsyncSeedExhaustive
+        from seed import AsyncMatryoshka
 
-        client = AsyncSeedExhaustive(
+        client = AsyncMatryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -213,9 +213,9 @@ class AsyncUrlsClient:
         --------
         import asyncio
 
-        from seed import AsyncSeedExhaustive
+        from seed import AsyncMatryoshka
 
-        client = AsyncSeedExhaustive(
+        client = AsyncMatryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -245,9 +245,9 @@ class AsyncUrlsClient:
         --------
         import asyncio
 
-        from seed import AsyncSeedExhaustive
+        from seed import AsyncMatryoshka
 
-        client = AsyncSeedExhaustive(
+        client = AsyncMatryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/inlined_requests/client.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/inlined_requests/client.py
@@ -57,10 +57,10 @@ class InlinedRequestsClient:
         import datetime
         import uuid
 
-        from seed import SeedExhaustive
+        from seed import Matryoshka
         from seed.types.object import ObjectWithOptionalField
 
-        client = SeedExhaustive(
+        client = Matryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -143,10 +143,10 @@ class AsyncInlinedRequestsClient:
         import datetime
         import uuid
 
-        from seed import AsyncSeedExhaustive
+        from seed import AsyncMatryoshka
         from seed.types.object import ObjectWithOptionalField
 
-        client = AsyncSeedExhaustive(
+        client = AsyncMatryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/no_auth/client.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/no_auth/client.py
@@ -44,9 +44,9 @@ class NoAuthClient:
 
         Examples
         --------
-        from seed import SeedExhaustive
+        from seed import Matryoshka
 
-        client = SeedExhaustive(
+        client = Matryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -94,9 +94,9 @@ class AsyncNoAuthClient:
         --------
         import asyncio
 
-        from seed import AsyncSeedExhaustive
+        from seed import AsyncMatryoshka
 
-        client = AsyncSeedExhaustive(
+        client = AsyncMatryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/no_req_body/client.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/no_req_body/client.py
@@ -38,9 +38,9 @@ class NoReqBodyClient:
 
         Examples
         --------
-        from seed import SeedExhaustive
+        from seed import Matryoshka
 
-        client = SeedExhaustive(
+        client = Matryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -62,9 +62,9 @@ class NoReqBodyClient:
 
         Examples
         --------
-        from seed import SeedExhaustive
+        from seed import Matryoshka
 
-        client = SeedExhaustive(
+        client = Matryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -106,9 +106,9 @@ class AsyncNoReqBodyClient:
         --------
         import asyncio
 
-        from seed import AsyncSeedExhaustive
+        from seed import AsyncMatryoshka
 
-        client = AsyncSeedExhaustive(
+        client = AsyncMatryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -138,9 +138,9 @@ class AsyncNoReqBodyClient:
         --------
         import asyncio
 
-        from seed import AsyncSeedExhaustive
+        from seed import AsyncMatryoshka
 
-        client = AsyncSeedExhaustive(
+        client = AsyncMatryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/req_with_headers/client.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/req_with_headers/client.py
@@ -51,9 +51,9 @@ class ReqWithHeadersClient:
 
         Examples
         --------
-        from seed import SeedExhaustive
+        from seed import Matryoshka
 
-        client = SeedExhaustive(
+        client = Matryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )
@@ -115,9 +115,9 @@ class AsyncReqWithHeadersClient:
         --------
         import asyncio
 
-        from seed import AsyncSeedExhaustive
+        from seed import AsyncMatryoshka
 
-        client = AsyncSeedExhaustive(
+        client = AsyncMatryoshka(
             token="YOUR_TOKEN",
             base_url="https://yourhost.com/path/to/api",
         )

--- a/seed/python-sdk/exhaustive/package-path/tests/wire/conftest.py
+++ b/seed/python-sdk/exhaustive/package-path/tests/wire/conftest.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, Optional
 import pytest
 import requests
 
-from seed.matryoshka.doll.structure.client import SeedExhaustive
+from seed.matryoshka.doll.structure.client import Matryoshka
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -48,7 +48,7 @@ def wiremock_container():
     subprocess.run(["docker", "compose", "-f", compose_file, "down", "-v"], check=False, capture_output=True)
 
 
-def get_client(test_id: str) -> SeedExhaustive:
+def get_client(test_id: str) -> Matryoshka:
     """
     Creates a configured client instance for wire tests.
 
@@ -58,7 +58,7 @@ def get_client(test_id: str) -> SeedExhaustive:
     Returns:
         A configured client instance with all required auth parameters.
     """
-    return SeedExhaustive(
+    return Matryoshka(
         base_url="http://localhost:8080",
         headers={"X-Test-Id": test_id},
         token="test_token",

--- a/seed/python-sdk/seed.yml
+++ b/seed/python-sdk/seed.yml
@@ -255,6 +255,8 @@ fixtures:
     - customConfig:
         package_path: matryoshka/doll/structure
         enable_wire_tests: true
+        client:
+          class_name: Matryoshka
       outputFolder: package-path
   file-upload:
     - customConfig: null


### PR DESCRIPTION
## Description
`tests/wire/conftest.py` now respects a custom client name as specified in `customConfig.client.class_name`.

## Changes Made
To the `python-v2` generator.

## Testing
Added a custom class name to the `package-path` fixture.
- [X] Unit tests added/updated
- [X] Manual testing completed
