### PR TITLE
fix(java): fix `QueryStringMapper`'s handling of `OptionalNullable`s

### DIFF
--- a/generators/java/generator-utils/src/main/resources/QueryStringMapper.java
+++ b/generators/java/generator-utils/src/main/resources/QueryStringMapper.java
@@ -15,6 +15,14 @@ public class QueryStringMapper {
     private static final ObjectMapper MAPPER = ObjectMappers.JSON_MAPPER;
 
     public static void addQueryParameter(HttpUrl.Builder httpUrl, String key, Object value, boolean arraysAsRepeats) {
+        if (value instanceof OptionalNullable) {
+            OptionalNullable<?> opt = (OptionalNullable<?>) value;
+            if (!opt.isPresent()) {
+                return;
+            }
+            value = opt.get();
+        }
+
         JsonNode valueNode = MAPPER.valueToTree(value);
 
         List<Map.Entry<String, JsonNode>> flat;
@@ -42,6 +50,14 @@ public class QueryStringMapper {
 
     public static void addFormDataPart(
             MultipartBody.Builder multipartBody, String key, Object value, boolean arraysAsRepeats) {
+        if (value instanceof OptionalNullable) {
+            OptionalNullable<?> opt = (OptionalNullable<?>) value;
+            if (!opt.isPresent()) {
+                return;
+            }
+            value = opt.get();
+        }
+
         JsonNode valueNode = MAPPER.valueToTree(value);
 
         List<Map.Entry<String, JsonNode>> flat;

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,3 +1,11 @@
+- version: 3.21.1
+  changelogEntry:
+    - summary: |
+        Fix how the query string mapper handles `OptionalNullable` values.
+      type: fix
+  createdAt: "2025-12-04"
+  irVersion: 61
+
 - version: 3.21.0
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description
In particular, lets `addQueryParameter()` handle `OptionalNullable` inputs gracefully.

## Changes Made
Changes to v1-side Java generator's as-is `QueryStringMapper.java` file.

## Testing
Fixes a problem with Auth0; regenerating seed now.
- [X] Unit tests added/updated
- [X] Manual testing completed
