### PR TITLE
fix(java): use wire value for header names instead of SDK parameter name

### DIFF
--- a/generators/java-v2/sdk/src/sdk-wire-tests/validators/HeaderValidator.ts
+++ b/generators/java-v2/sdk/src/sdk-wire-tests/validators/HeaderValidator.ts
@@ -10,9 +10,9 @@ export class HeaderValidator {
      * Generates header validation assertions for a test method.
      * Validates that all expected headers from the test example are present in the recorded request.
      *
-     * Note: The Java SDK sends headers using camelCase names (e.g., "idempotencyKey"),
-     * while the OpenAPI spec/IR uses wire format names (e.g., "Idempotency-Key").
-     * We validate using the camelCase format that the SDK actually sends.
+     * Note: The Java SDK sends headers using their wire format names (e.g., "Idempotency-Key", "x-api-key"),
+     * which are the actual HTTP header names defined in the OpenAPI spec/IR.
+     * We validate using the wire format that the SDK actually sends.
      */
     public generateHeaderValidation(writer: Writer, testExample: WireTestExample): void {
         const expectedHeaders = testExample.request.headers;
@@ -27,51 +27,13 @@ export class HeaderValidator {
         for (const [headerName, expectedValue] of Object.entries(expectedHeaders)) {
             if (expectedValue !== undefined && expectedValue !== null) {
                 const escapedValue = this.escapeJavaString(expectedValue.toString());
-                // Convert wire header name to camelCase as the Java SDK sends headers in camelCase
-                const javaHeaderName = this.toJavaHeaderName(headerName);
+                // Use the wire header name directly - the Java SDK sends headers with their wire values
                 writer.writeLine(
-                    `Assertions.assertEquals("${escapedValue}", request.getHeader("${javaHeaderName}"), ` +
-                        `"Header '${javaHeaderName}' should match expected value");`
+                    `Assertions.assertEquals("${escapedValue}", request.getHeader("${headerName}"), ` +
+                        `"Header '${headerName}' should match expected value");`
                 );
             }
         }
-    }
-
-    /**
-     * Converts a wire header name (e.g., "Idempotency-Key", "Content-Type") to the
-     * Java SDK header name format (camelCase, e.g., "idempotencyKey", "contentType").
-     *
-     * The Java SDK uses camelCase for custom headers while standard HTTP headers
-     * like Content-Type and Accept are sent as-is.
-     */
-    private toJavaHeaderName(wireHeaderName: string): string {
-        // Standard HTTP headers should remain as-is
-        const standardHeaders = [
-            "Content-Type",
-            "Accept",
-            "Authorization",
-            "User-Agent",
-            "Host",
-            "Content-Length",
-            "Cache-Control"
-        ];
-        if (standardHeaders.includes(wireHeaderName)) {
-            return wireHeaderName;
-        }
-
-        // Convert kebab-case or other formats to camelCase
-        // "Idempotency-Key" -> "idempotencyKey"
-        // "X-Custom-Header" -> "xCustomHeader"
-        const parts = wireHeaderName.split("-");
-        return parts
-            .map((part, index) => {
-                const lower = part.toLowerCase();
-                if (index === 0) {
-                    return lower;
-                }
-                return lower.charAt(0).toUpperCase() + lower.slice(1);
-            })
-            .join("");
     }
 
     /**

--- a/generators/java/sdk/src/main/java/com/fern/java/client/GeneratedWrappedRequest.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/GeneratedWrappedRequest.java
@@ -7,6 +7,7 @@ import com.fern.java.immutables.StagedBuilderImmutablesStyle;
 import com.fern.java.output.AbstractGeneratedJavaFile;
 import com.squareup.javapoet.MethodSpec;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.immutables.value.Value;
 
@@ -15,6 +16,8 @@ import org.immutables.value.Value;
 public abstract class GeneratedWrappedRequest extends AbstractGeneratedJavaFile {
 
     public abstract List<EnrichedObjectProperty> headerParams();
+
+    public abstract Map<String, String> headerWireValues();
 
     public abstract List<EnrichedObjectProperty> queryParams();
 

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/WrappedRequestEndpointWriter.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/WrappedRequestEndpointWriter.java
@@ -191,7 +191,14 @@ public final class WrappedRequestEndpointWriter extends AbstractEndpointWriter {
         requestBodyCodeBlock.add(";\n");
         requestBodyCodeBlock.unindent();
         for (EnrichedObjectProperty header : generatedWrappedRequest.headerParams()) {
-            String headerName = header.objectProperty().getName().getName().getOriginalName();
+            String sdkName = header.camelCaseKey();
+            String headerName = generatedWrappedRequest.headerWireValues().get(sdkName);
+            if (headerName == null) {
+                String wireValue = header.objectProperty().getName().getWireValue();
+                headerName = (wireValue != null && !wireValue.isEmpty())
+                        ? wireValue
+                        : header.objectProperty().getName().getName().getOriginalName();
+            }
             if (typeNameIsOptional(header.poetTypeName())) {
                 requestBodyCodeBlock
                         .beginControlFlow("if ($L.$N().isPresent())", requestParameterName, header.getterProperty())

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,3 +1,11 @@
+- version: 3.21.1
+  changelogEntry:
+    - summary: |
+        Fix header parameters with `x-fern-parameter-name` to use the correct HTTP header name (wire value) instead of the SDK parameter name.
+      type: fix
+  createdAt: "2025-12-04"
+  irVersion: 61
+
 - version: 3.21.0
   changelogEntry:
     - summary: |

--- a/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/ReqWithHeadersWireTest.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/ReqWithHeadersWireTest.java
@@ -48,12 +48,12 @@ public class ReqWithHeadersWireTest {
         // Validate headers
         Assertions.assertEquals(
                 "X-TEST-SERVICE-HEADER",
-                request.getHeader("xTestServiceHeader"),
-                "Header 'xTestServiceHeader' should match expected value");
+                request.getHeader("X-TEST-SERVICE-HEADER"),
+                "Header 'X-TEST-SERVICE-HEADER' should match expected value");
         Assertions.assertEquals(
                 "X-TEST-ENDPOINT-HEADER",
-                request.getHeader("xTestEndpointHeader"),
-                "Header 'xTestEndpointHeader' should match expected value");
+                request.getHeader("X-TEST-ENDPOINT-HEADER"),
+                "Header 'X-TEST-ENDPOINT-HEADER' should match expected value");
         // Validate request body
         String actualRequestBody = request.getBody().readUtf8();
         String expectedRequestBody = "" + "\"string\"";


### PR DESCRIPTION
## Description
Linear ticket: Closes [FER-7959: \[Java, Payroc\] wire value for header names](https://linear.app/buildwithfern/issue/FER-7959/java-payroc-wire-value-for-header-names)
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
<!-- Provide a clear and concise description of the changes made in this PR -->

Fixes a bug where header parameters with `x-fern-parameter-name` override incorrectly used the SDK parameter name (e.g., `api_key`) instead of the actual HTTP header name (e.g., `x-api-key`) in generated `addHeader()` calls.

The issue occurred because headers have their wire value stripped to trigger `@JsonIgnore` (preventing them from being serialized in the request body), but the original wire value was lost and not available when generating HTTP request code.

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Fixed issue and adjusted wire tests 
- 
- [ ] Updated README.md generator (if applicable)

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated
- [x] Manual testing completed -tested with payroc