### PR TITLE
fix(python): align exported client filename with custom client.filename

### DIFF
--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 4.41.12
+  changelogEntry:
+    - summary: |
+        Fix exported client filename to match custom client filename when only `client.filename` is set.
+        Previously, setting `client.filename` to a custom value (e.g., `uipath_client.py`) without also
+        setting `client.exported_filename` would cause the generated `__init__.py` to import from `.client`
+        instead of the actual file, resulting in mypy import-not-found errors.
+      type: fix
+  createdAt: "2025-12-04"
+  irVersion: 61
+
 - version: 4.41.11
   changelogEntry:
     - summary: |

--- a/generators/python/src/fern_python/generators/sdk/custom_config.py
+++ b/generators/python/src/fern_python/generators/sdk/custom_config.py
@@ -137,6 +137,14 @@ class SDKCustomConfig(pydantic.BaseModel):
             if "custom-pager-name" in obj and "custom_pager_name" not in obj:
                 obj["custom_pager_name"] = obj.pop("custom-pager-name")
 
+            # Propagate client.filename to client.exported_filename if user set filename but not exported_filename.
+            # This ensures that when a custom client filename is specified (e.g., "uipath_client.py"),
+            # the exported filename in __init__.py matches the actual generated file.
+            client_cfg = obj.get("client")
+            if isinstance(client_cfg, dict):
+                if "filename" in client_cfg and "exported_filename" not in client_cfg:
+                    client_cfg["exported_filename"] = client_cfg["filename"]
+
         obj = super().parse_obj(obj)
 
         use_typeddict_requests = obj.use_typeddict_requests or obj.pydantic_config.use_typeddict_requests


### PR DESCRIPTION
## Description

Refs https://github.com/fern-demo/uipath-python

Fixes a bug where setting `client.filename` to a custom value without also setting `client.exported_filename` would cause the generated `__init__.py` to import from the wrong module.

**Link to Devin run**: https://app.devin.ai/sessions/9583fdcddbc543e7bb8b5a121a521d8a
**Requested by**: @tstanmay13

## Changes Made

- Modified `SDKCustomConfig.parse_obj` to propagate `client.filename` to `client.exported_filename` when only `filename` is set
- Added version 4.41.12 changelog entry

**Root cause**: The `ClientConfiguration` class has independent defaults for `filename` and `exported_filename` (both default to `"client.py"`). When a user sets only `filename` (e.g., `"uipath_client.py"`), the `exported_filename` remains `"client.py"`, causing the generated `__init__.py` to import from `.client` instead of `.uipath_client`.

## Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed (verified the logic by tracing through the code)

## Human Review Checklist

- [ ] Verify the fix doesn't break SDKs that don't customize `client.filename` (default case should still work)
- [ ] Note: The deprecated top-level `client_filename` field is not handled by this fix - only the `client.filename` nested config is addressed