### PR TITLE
feat(ruby): add extraDependencies and extraDevDependencies config flags to Ruby v2 generator

### DIFF
--- a/generators/ruby-v2/ast/src/custom-config/BaseRubyCustomConfigSchema.ts
+++ b/generators/ruby-v2/ast/src/custom-config/BaseRubyCustomConfigSchema.ts
@@ -1,19 +1,6 @@
 import { z } from "zod";
 import { CustomReadmeSectionSchema } from "./CustomReadmeSectionSchema";
 
-const RangeSchema = z.strictObject({
-    version: z.string(),
-    specifier: z.optional(z.string())
-});
-
-const DependencySchema = z.strictObject({
-    upperBound: z.optional(RangeSchema),
-    lowerBound: z.optional(RangeSchema)
-});
-
-export type ExtraDependenciesSchema = z.infer<typeof ExtraDependenciesSchema>;
-export const ExtraDependenciesSchema = z.record(z.union([z.string(), DependencySchema]));
-
 export const BaseRubyCustomConfigSchema = z.object({
     module: z.optional(z.string()),
     clientModuleName: z.optional(z.string()),
@@ -21,10 +8,10 @@ export const BaseRubyCustomConfigSchema = z.object({
     customPagerName: z.optional(z.string()),
     // Generate wire tests for serialization/deserialization
     enableWireTests: z.boolean().optional(),
-    // Extra dependencies to add to the gemspec
-    extraDependencies: z.optional(ExtraDependenciesSchema),
-    // Extra dev dependencies to add to the Gemfile
-    extraDevDependencies: z.optional(ExtraDependenciesSchema)
+    // Extra dependencies to add to the gemspec (e.g., { "my-gem": "~> 6.0" })
+    extraDependencies: z.optional(z.record(z.string())),
+    // Extra dev dependencies to add to the Gemfile (e.g., { "my-gem": "~> 6.0" })
+    extraDevDependencies: z.optional(z.record(z.string()))
 });
 
 export type BaseRubyCustomConfigSchema = z.infer<typeof BaseRubyCustomConfigSchema>;

--- a/generators/ruby-v2/ast/src/custom-config/BaseRubyCustomConfigSchema.ts
+++ b/generators/ruby-v2/ast/src/custom-config/BaseRubyCustomConfigSchema.ts
@@ -1,13 +1,30 @@
 import { z } from "zod";
 import { CustomReadmeSectionSchema } from "./CustomReadmeSectionSchema";
 
+const RangeSchema = z.strictObject({
+    version: z.string(),
+    specifier: z.optional(z.string())
+});
+
+const DependencySchema = z.strictObject({
+    upperBound: z.optional(RangeSchema),
+    lowerBound: z.optional(RangeSchema)
+});
+
+export type ExtraDependenciesSchema = z.infer<typeof ExtraDependenciesSchema>;
+export const ExtraDependenciesSchema = z.record(z.union([z.string(), DependencySchema]));
+
 export const BaseRubyCustomConfigSchema = z.object({
     module: z.optional(z.string()),
     clientModuleName: z.optional(z.string()),
     customReadmeSections: z.optional(z.array(CustomReadmeSectionSchema)),
     customPagerName: z.optional(z.string()),
     // Generate wire tests for serialization/deserialization
-    enableWireTests: z.boolean().optional()
+    enableWireTests: z.boolean().optional(),
+    // Extra dependencies to add to the gemspec
+    extraDependencies: z.optional(ExtraDependenciesSchema),
+    // Extra dev dependencies to add to the Gemfile
+    extraDevDependencies: z.optional(ExtraDependenciesSchema)
 });
 
 export type BaseRubyCustomConfigSchema = z.infer<typeof BaseRubyCustomConfigSchema>;

--- a/generators/ruby-v2/ast/src/index.ts
+++ b/generators/ruby-v2/ast/src/index.ts
@@ -1,3 +1,3 @@
 export { RubyFile } from "./ast/core/RubyFile";
-export { BaseRubyCustomConfigSchema, ExtraDependenciesSchema } from "./custom-config/BaseRubyCustomConfigSchema";
+export { BaseRubyCustomConfigSchema } from "./custom-config/BaseRubyCustomConfigSchema";
 export * as ruby from "./ruby";

--- a/generators/ruby-v2/ast/src/index.ts
+++ b/generators/ruby-v2/ast/src/index.ts
@@ -1,3 +1,3 @@
 export { RubyFile } from "./ast/core/RubyFile";
-export { BaseRubyCustomConfigSchema } from "./custom-config/BaseRubyCustomConfigSchema";
+export { BaseRubyCustomConfigSchema, ExtraDependenciesSchema } from "./custom-config/BaseRubyCustomConfigSchema";
 export * as ruby from "./ruby";

--- a/generators/ruby-v2/sdk/versions.yml
+++ b/generators/ruby-v2/sdk/versions.yml
@@ -7,9 +7,9 @@
       summary: |
         Add extraDependencies and extraDevDependencies config flags to Ruby v2 SDK generator.
         These options allow users to specify additional gem dependencies to include in the
-        generated gemspec (extraDependencies) and Gemfile (extraDevDependencies). Supports
-        both simple version strings (e.g., "1.0") and complex dependency objects with
-        upper/lower bounds and custom specifiers.
+        generated gemspec (extraDependencies) and Gemfile (extraDevDependencies). Values are
+        written directly as version constraints (e.g., { "my-gem": "~> 6.0" } produces
+        spec.add_dependency "my-gem", "~> 6.0").
   irVersion: 61
 
 - version: 1.0.0-rc59

--- a/generators/ruby-v2/sdk/versions.yml
+++ b/generators/ruby-v2/sdk/versions.yml
@@ -1,5 +1,17 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.0.0-rc60
+  createdAt: "2025-12-05"
+  changelogEntry:
+    - type: feat
+      summary: |
+        Add extraDependencies and extraDevDependencies config flags to Ruby v2 SDK generator.
+        These options allow users to specify additional gem dependencies to include in the
+        generated gemspec (extraDependencies) and Gemfile (extraDevDependencies). Supports
+        both simple version strings (e.g., "1.0") and complex dependency objects with
+        upper/lower bounds and custom specifiers.
+  irVersion: 61
+
 - version: 1.0.0-rc59
   createdAt: "2025-12-04"
   changelogEntry:


### PR DESCRIPTION
## Description

Refs: Slack request from thomas@buildwithfern.com

Implements the `extraDependencies` and `extraDevDependencies` config flags in the Ruby v2 generator. Values are passed through directly as version constraints.

**Link to Devin run:** https://app.devin.ai/sessions/0dfdf3d2560649aa887410da2a513940
**Requested by:** thomas@buildwithfern.com (@tjb9dc)

## Changes Made

- Added `extraDependencies` config option (`z.record(z.string())`) - dependencies are written directly to the generated gemspec via `spec.add_dependency`
- Added `extraDevDependencies` config option - dependencies are written directly to the generated Gemfile in the `:test, :development` group
- Values are passed through as-is (e.g., `{ "my-gem": "~> 6.0" }` produces `spec.add_dependency "my-gem", "~> 6.0"`)
- Updated `versions.yml` with new version 1.0.0-rc60

## Example Usage

```yaml
extraDependencies:
  my-gem: "~> 6.0"
  another-gem: ">= 1.0, < 2.0"
```

Produces in gemspec:
```ruby
spec.add_dependency "my-gem", "~> 6.0"
spec.add_dependency "another-gem", ">= 1.0, < 2.0"
```

## Testing

- [x] Lint checks pass (`pnpm run check`)
- [ ] Unit tests added/updated
- [ ] Manual testing completed

## Human Review Checklist

- [ ] Verify the generated gemspec/Gemfile output format is correct
- [ ] Confirm placement of extra dependencies in generated files is appropriate (gemspec: after `require_paths`, Gemfile: inside dev group)
- [ ] Consider if seed tests should be added for this feature