### PR TITLE
feat(python): add model_dump_json override to handle FieldMetadata aliases

### DIFF
--- a/generators/python/core_utilities/shared/pydantic_utilities.py
+++ b/generators/python/core_utilities/shared/pydantic_utilities.py
@@ -99,6 +99,10 @@ class UniversalBaseModel(pydantic.BaseModel):
         import json
 
         data = self.dict(**kwargs)
+        if IS_PYDANTIC_V2:
+            from pydantic_core import to_jsonable_python
+
+            return json.dumps(to_jsonable_python(data, fallback=encode_by_type))
         return json.dumps(data, default=encode_by_type)
 
     def dict(self, **kwargs: Any) -> Dict[str, Any]:

--- a/generators/python/core_utilities/shared/pydantic_utilities.py
+++ b/generators/python/core_utilities/shared/pydantic_utilities.py
@@ -91,6 +91,16 @@ class UniversalBaseModel(pydantic.BaseModel):
             return super().model_dump_json(**kwargs_with_defaults)  # type: ignore[misc]
         return super().json(**kwargs_with_defaults)
 
+    def model_dump_json(self, **kwargs: Any) -> str:
+        """
+        Override model_dump_json to use our custom dict() method which properly
+        handles FieldMetadata aliases, then serialize to JSON.
+        """
+        import json
+
+        data = self.dict(**kwargs)
+        return json.dumps(data, default=encode_by_type)
+
     def dict(self, **kwargs: Any) -> Dict[str, Any]:
         """
         Override the default dict method to `exclude_unset` by default. This function patches

--- a/generators/python/core_utilities/shared/with_pydantic_v1_on_v2/pydantic_utilities.py
+++ b/generators/python/core_utilities/shared/with_pydantic_v1_on_v2/pydantic_utilities.py
@@ -54,6 +54,16 @@ class UniversalBaseModel(pydantic.v1.BaseModel):
         }
         return super().json(**kwargs_with_defaults)
 
+    def model_dump_json(self, **kwargs: Any) -> str:
+        """
+        Override model_dump_json to use our custom dict() method which properly
+        handles FieldMetadata aliases, then serialize to JSON.
+        """
+        import json
+
+        data = self.dict(**kwargs)
+        return json.dumps(data, default=encode_by_type)
+
     def dict(self, **kwargs: Any) -> Dict[str, Any]:
         """
         Override the default dict method to `exclude_unset` by default. This function patches

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 4.43.0
+  changelogEntry:
+    - summary: |
+        Add `model_dump_json()` override to `UniversalBaseModel` that properly handles `FieldMetadata` aliases.
+        When using the default `FieldMetadata` aliasing (not native Pydantic aliases), calling `model_dump_json()`
+        now correctly serializes field names to their camelCase aliases, matching the behavior of `dict()`.
+      type: feat
+  createdAt: "2025-12-05"
+  irVersion: 61
+
 - version: 4.42.0
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs https://github.com/extend-hq/extend-python-sdk/pull/14

Adds a `model_dump_json()` override to `UniversalBaseModel` so that JSON serialization properly respects `FieldMetadata` aliases (e.g., `snake_case` → `camelCase`).

**Background**: The existing `dict()` method already handles `FieldMetadata` aliases via `convert_and_respect_annotation_metadata()`. However, `model_dump_json()` was calling Pydantic's native implementation directly, which doesn't know about `FieldMetadata` annotations. This caused JSON output to use Python field names instead of the expected wire-format aliases.

**Requested by**: thomas@buildwithfern.com (@tjb9dc)
**Link to Devin run**: https://app.devin.ai/sessions/078ffa2dec06476a9c041a29f6f37cf4

## Changes Made

- Added `model_dump_json()` override to `UniversalBaseModel` in `pydantic_utilities.py`
- Added same override to `with_pydantic_v1_on_v2/pydantic_utilities.py` variant
- Updated `versions.yml` with changelog entry for v4.43.0

The new method delegates to our custom `dict()` (which handles aliases correctly) and then serializes to JSON:
- **Pydantic v2**: Uses `to_jsonable_python(data, fallback=encode_by_type)` for proper v2 JSON normalization
- **Pydantic v1**: Uses `json.dumps(data, default=encode_by_type)` directly

**Note**: The `with_pydantic_aliases` variants were intentionally NOT updated because they use native Pydantic `Field(alias=...)` where `by_alias=True` already works correctly. The `with_pydantic_v1_on_v2` variant uses the simpler v1-style implementation since it's explicitly v1-only.

## Updates Since Last Revision

- Added proper v1/v2 branching in the main `pydantic_utilities.py` to use `to_jsonable_python` for Pydantic v2, matching the existing pattern used by `to_jsonable_with_fallback` in the codebase

## Testing

- [ ] Unit tests added/updated
- [x] Lint checks pass (`pnpm run check`)
- [ ] Seed tests (will run in CI)

## Human Review Checklist

- [ ] Verify v1/v2 branching is correct (v2 uses `to_jsonable_python`, v1 uses `json.dumps` with `default`)
- [ ] Verify `encode_by_type` handles all necessary types (datetime, UUID, Decimal, Enum, etc.) - it uses Pydantic's `ENCODERS_BY_TYPE`
- [ ] Confirm seed tests adequately cover `model_dump_json()` with aliased fields
- [ ] Verify `with_pydantic_v1_on_v2` variant correctly uses simpler implementation (no `IS_PYDANTIC_V2` check needed since it's v1-only)