### PR TITLE
feat(go): add OAuth token override support

### DIFF
--- a/generators/go-v2/ast/src/custom-config/BaseGoCustomConfigSchema.ts
+++ b/generators/go-v2/ast/src/custom-config/BaseGoCustomConfigSchema.ts
@@ -24,7 +24,8 @@ export const baseGoCustomConfigSchema = z.object({
     enableWireTests: z.boolean().optional(),
     exportAllRequestsAtRoot: z.boolean().optional(),
     customReadmeSections: z.array(CustomReadmeSectionSchema).optional(),
-    customPagerName: z.string().optional()
+    customPagerName: z.string().optional(),
+    oauthTokenOverride: z.boolean().optional()
 });
 
 export type BaseGoCustomConfigSchema = z.infer<typeof baseGoCustomConfigSchema>;

--- a/generators/go/cmd/fern-go-fiber/main.go
+++ b/generators/go/cmd/fern-go-fiber/main.go
@@ -34,6 +34,7 @@ func run(config *cmd.Config, coordinator *coordinator.Client) ([]*generator.File
 		config.UseReaderForBytesRequest,
 		config.GettersPassByValue,
 		config.ExportAllRequestsAtRoot,
+		config.OAuthTokenOverride,
 		config.Organization,
 		config.Version,
 		config.IrFilepath,

--- a/generators/go/cmd/fern-go-model/main.go
+++ b/generators/go/cmd/fern-go-model/main.go
@@ -34,6 +34,7 @@ func run(config *cmd.Config, coordinator *coordinator.Client) ([]*generator.File
 		config.UseReaderForBytesRequest,
 		config.GettersPassByValue,
 		config.ExportAllRequestsAtRoot,
+		config.OAuthTokenOverride,
 		config.Organization,
 		config.Version,
 		config.IrFilepath,

--- a/generators/go/cmd/fern-go-sdk/main.go
+++ b/generators/go/cmd/fern-go-sdk/main.go
@@ -34,6 +34,7 @@ func run(config *cmd.Config, coordinator *coordinator.Client) ([]*generator.File
 		config.UseReaderForBytesRequest,
 		config.GettersPassByValue,
 		config.ExportAllRequestsAtRoot,
+		config.OAuthTokenOverride,
 		config.Organization,
 		config.Version,
 		config.IrFilepath,

--- a/generators/go/internal/cmd/cmd.go
+++ b/generators/go/internal/cmd/cmd.go
@@ -64,6 +64,7 @@ type Config struct {
 	UseReaderForBytesRequest     bool
 	GettersPassByValue           bool
 	ExportAllRequestsAtRoot      bool
+	OAuthTokenOverride           bool
 	Organization                 string
 	CoordinatorURL               string
 	CoordinatorTaskID            string
@@ -235,6 +236,7 @@ func newConfig(configFilename string) (*Config, error) {
 		UseReaderForBytesRequest:     *customConfig.UseReaderForBytesRequest,
 		GettersPassByValue:           *customConfig.GettersPassByValue,
 		ExportAllRequestsAtRoot:      *customConfig.ExportAllRequestsAtRoot,
+		OAuthTokenOverride:           *customConfig.OAuthTokenOverride,
 		Organization:                 config.Organization,
 		AlwaysSendRequiredProperties: *customConfig.AlwaysSendRequiredProperties,
 		Whitelabel:                   config.Whitelabel,
@@ -299,6 +301,7 @@ type customConfig struct {
 	UseReaderForBytesRequest     *bool         `json:"useReaderForBytesRequest,omitempty"`
 	GettersPassByValue           *bool         `json:"gettersPassByValue,omitempty"`
 	ExportAllRequestsAtRoot      *bool         `json:"exportAllRequestsAtRoot,omitempty"`
+	OAuthTokenOverride           *bool         `json:"oauthTokenOverride,omitempty"`
 	ClientName                   string        `json:"clientName,omitempty"`
 	ClientConstructorName        string        `json:"clientConstructorName,omitempty"`
 	ImportPath                   string        `json:"importPath,omitempty"`
@@ -458,6 +461,9 @@ func applyCustomConfigDefaultsForV1(customConfig *customConfig) *customConfig {
 	}
 	if customConfig.ExportAllRequestsAtRoot == nil {
 		customConfig.ExportAllRequestsAtRoot = gospec.Ptr(false)
+	}
+	if customConfig.OAuthTokenOverride == nil {
+		customConfig.OAuthTokenOverride = gospec.Ptr(false)
 	}
 	if customConfig.UnionVersion == "" {
 		customConfig.UnionVersion = "v1"

--- a/generators/go/internal/generator/config.go
+++ b/generators/go/internal/generator/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	UseReaderForBytesRequest     bool
 	GettersPassByValue           bool
 	ExportAllRequestsAtRoot      bool
+	OAuthTokenOverride           bool
 	Organization                 string
 	Version                      string
 	IRFilepath                   string
@@ -74,6 +75,7 @@ func NewConfig(
 	useReaderForBytesRequest bool,
 	gettersPassByValue bool,
 	exportAllRequestsAtRoot bool,
+	oauthTokenOverride bool,
 	organization string,
 	version string,
 	irFilepath string,
@@ -105,6 +107,7 @@ func NewConfig(
 		UseReaderForBytesRequest:     useReaderForBytesRequest,
 		GettersPassByValue:           gettersPassByValue,
 		ExportAllRequestsAtRoot:      exportAllRequestsAtRoot,
+		OAuthTokenOverride:           oauthTokenOverride,
 		Version:                      version,
 		IRFilepath:                   irFilepath,
 		SnippetFilepath:              snippetFilepath,

--- a/generators/go/internal/generator/generator.go
+++ b/generators/go/internal/generator/generator.go
@@ -382,6 +382,7 @@ func (g *Generator) generate(ir *fernir.IntermediateRepresentation, mode Mode) (
 			ir.SdkConfig,
 			g.config.ModuleConfig,
 			g.config.Version,
+			g.config.OAuthTokenOverride,
 		); err != nil {
 			return nil, err
 		}

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,5 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.19.0
+  changelogEntry:
+    - summary: |
+        Add support for OAuth token override via the `oauthTokenOverride` config option.
+        When enabled, users can provide a pre-generated bearer token directly via the `WithToken`
+        option function, bypassing the OAuth client credentials flow.
+      type: feat
+  createdAt: "2025-12-08"
+  irVersion: 60
+
 - version: 1.18.4
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description
Refs https://github.com/fern-api/fern/pull/11029

Implements OAuth token override support for the Go SDK generator, mirroring the feature from the TypeScript generator PR #11029. When enabled via the `oauthTokenOverride` config option, users can provide a pre-generated bearer token directly via the `WithToken` option function, bypassing the OAuth client credentials flow.

**Link to Devin run**: https://app.devin.ai/sessions/f7ea32bafbe64688bced47359d9fb67c
**Requested by**: thomas@buildwithfern.com (@tjb9dc)

## Changes Made
- Added `oauthTokenOverride` to Go v2 custom config schema (BaseGoCustomConfigSchema.ts)
- Added `OAuthTokenOverride` field to Go v1 custom config and generator Config structs
- Implemented OAuth token override in Go v1 generator (sdk.go):
  - Adds `Token string` field to `RequestOptions` struct when OAuth auth scheme is present and config is enabled
  - Adds `WithToken` option function for setting the token
  - Adds logic in `ToHeader()` to set `Authorization: Bearer <token>` header
- Updated all Go generator entry points (fern-go-sdk, fern-go-model, fern-go-fiber) to pass the new parameter
- Updated versions.yml with changelog entry for v1.19.0

## Updates Since Last Revision
- Fixed CI build failure by adding `OAuthTokenOverride` parameter to `NewConfig` calls in `fern-go-model/main.go` and `fern-go-fiber/main.go` (the parameter is passed through but not used by these generators)

## Testing
- [x] TypeScript lint checks passed (`pnpm run check`)
- [ ] Go compilation verification (Go not installed in environment - relying on CI)
- [ ] Seed tests for Go SDK

## Human Review Checklist
- [ ] Verify Go code compiles correctly (CI should confirm this)
- [ ] Verify generated code produces correct `WithToken` option when `oauthTokenOverride: true` is configured
- [ ] Consider adding/updating seed tests for OAuth token override feature
- [ ] Note: Go v2 generator has OAuth marked as TODO - only config option was added, no implementation