### PR TITLE
chore(seed): add curly brace escaping validation to changelog validator

### DIFF
--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1663,8 +1663,8 @@
     - type: break
       summary: >-
         The C# SDK is now on major version 1.0.0. To preserve compatibility with
-        pre-1.0.0, set all of \{root-namespace-for-core-classes,
-        pascal-case-environments, simplify-object-dictionaries\} to `false`.
+        pre-1.0.0, set all of `{root-namespace-for-core-classes,
+        pascal-case-environments, simplify-object-dictionaries}` to `false`.
     - type: internal
       summary: Core classes that are exposed publicly are now in the root namespace.
     - type: internal

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -382,7 +382,7 @@
 - version: 3.14.3
   changelogEntry:
     - summary: |
-        Skip empty object validation in wire tests for optional request bodies. When request bodies are optional(nullable(T)) where T has only optional properties, wire tests now correctly skip {} validation when Optional.empty() is passed, matching actual SDK behavior.
+        Skip empty object validation in wire tests for optional request bodies. When request bodies are optional(nullable(T)) where T has only optional properties, wire tests now correctly skip `{}` validation when Optional.empty() is passed, matching actual SDK behavior.
       type: fix
   createdAt: "2025-11-11"
   irVersion: 61
@@ -468,7 +468,7 @@
 - version: 3.11.6
   changelogEntry:
     - summary: |
-        Fix path parameter prefixes (e.g., v{version}) being split into separate segments, producing URLs like .../v/1 instead of .../v1.
+        Fix path parameter prefixes (e.g., `v{version}`) being split into separate segments, producing URLs like .../v/1 instead of .../v1.
       type: fix
   createdAt: "2025-11-04"
   irVersion: 61

--- a/generators/php/model/versions.yml
+++ b/generators/php/model/versions.yml
@@ -11,7 +11,7 @@
 - version: 0.0.1
   changelogEntry:
     - summary: |
-        Fix duplicate logging in PHP model generator by including class names in log messages. Previously, multiple types in the same directory would log identical "Generating {directory}" messages, causing log spam. Now each type logs a unique "Generating {directory}/{className}" message.
+        Fix duplicate logging in PHP model generator by including class names in log messages. Previously, multiple types in the same directory would log identical "Generating `{directory}`" messages, causing log spam. Now each type logs a unique "Generating `{directory}/{className}`" message.
       type: fix
   createdAt: "2025-11-20"
   irVersion: 61

--- a/generators/php/sdk/versions.yml
+++ b/generators/php/sdk/versions.yml
@@ -195,7 +195,7 @@
 - version: 1.18.3
   changelogEntry:
     - summary: |
-        Fix duplicate logging in PHP SDK generator by including class names in log messages. Previously, multiple types in the same directory would log identical "Generating {directory}" messages, causing log spam. Now each type logs a unique "Generating {directory}/{className}" message.
+        Fix duplicate logging in PHP SDK generator by including class names in log messages. Previously, multiple types in the same directory would log identical "Generating `{directory}`" messages, causing log spam. Now each type logs a unique "Generating `{directory}/{className}`" message.
       type: fix
   createdAt: "2025-11-20"
   irVersion: 61

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -137,7 +137,7 @@
 
 - version: 4.39.0
   changelogEntry:
-    - summary: Add environment_class_name config option to customize the environment class name. Default remains {ClientName}Environment.
+    - summary: Add environment_class_name config option to customize the environment class name. Default remains `{ClientName}Environment`.
       type: feat
   createdAt: "2025-11-25"
   irVersion: 61

--- a/generators/ruby-v2/sdk/versions.yml
+++ b/generators/ruby-v2/sdk/versions.yml
@@ -21,8 +21,8 @@
         Add extraDependencies and extraDevDependencies config flags to Ruby v2 SDK generator.
         These options allow users to specify additional gem dependencies to include in the
         generated gemspec (extraDependencies) and Gemfile (extraDevDependencies). Values are
-        written directly as version constraints (e.g., { "my-gem": "~> 6.0" } produces
-        spec.add_dependency "my-gem", "~> 6.0").
+        written directly as version constraints (e.g., `{ "my-gem": "~> 6.0" }` produces
+        `spec.add_dependency "my-gem", "~> 6.0"`).
   irVersion: 61
 
 - version: 1.0.0-rc59

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -149,7 +149,7 @@
         Add `substitute-env-vars` flag to `docs.yml` settings configuration. When set to `true`,
         environment variables using `${VAR_NAME}` syntax are substituted across all files in the docs bundle,
         including markdown/MDX content. This is useful for injecting dynamic values like API keys or URLs.
-        Use \$\{VAR\} to escape and output literal ${VAR} without substitution.
+        Use `\$\{VAR\}` to escape and output literal `${VAR}` without substitution.
       type: feat
   irVersion: 62
   createdAt: "2025-12-02"
@@ -4359,7 +4359,7 @@
 - changelogEntry:
     - summary: |
         Improve server handling in OpenAPI imports by exploding servers with enum variables into multiple servers,
-        one for each enum value. For example, a server with URL "https://{region}.example.com" where region
+        one for each enum value. For example, a server with URL `https://{region}.example.com` where region
         is an enum ["us", "eu"] will be exploded into two servers: "https://us.example.com" and "https://eu.example.com".
       type: feat
   irVersion: 57


### PR DESCRIPTION
## Description

Refs: Slack thread request from @tstanmay13

Extends the changelog validation to also check that curly braces (`{` and `}`) are escaped with backticks, similar to the existing angle bracket (`<` and `>`) validation. This prevents breaking the docs publishing workflow when curly braces appear unescaped in changelog summaries.

## Changes Made

- Added `findUnescapedCurlyBraces` function that detects unescaped `{...}` patterns outside of code blocks and inline code
- Updated `validateAngleBracketEscaping` to also check for unescaped curly braces
- Renamed internal variable from `unescapedBrackets` to `unescapedAngleBrackets` for clarity
- Escaped curly braces in existing changelog entries that were flagged by the new validation:
  - `packages/cli/cli/versions.yml` (versions 2.17.0, 0.57.32)
  - `generators/ruby-v2/sdk/versions.yml` (version 1.0.0-rc60)
  - `generators/python/sdk/versions.yml` (version 4.39.0)
  - `generators/java/sdk/versions.yml` (versions 3.14.3, 3.11.6)
  - `generators/csharp/sdk/versions.yml` (version 1.0.0)
  - `generators/php/model/versions.yml` (version 0.0.1)
  - `generators/php/sdk/versions.yml` (version 1.18.3)

## Testing

- [x] Manual testing completed (lint checks pass)
- [x] Ran `scripts/validate-all-changelogs.sh` locally - all changelogs pass validation
- [ ] Unit tests added/updated

## Human Review Checklist

- [ ] Verify the curly brace regex pattern `/\{[^}]*\}/g` correctly matches the intended patterns
- [ ] Verify the changelog entry fixes preserve the original meaning (just added backticks around curly brace patterns)

---

Link to Devin run: https://app.devin.ai/sessions/989bcb3107ee47db948d6f3f710d6908
Requested by: tanmay.singh@buildwithfern.com (@tstanmay13)