### PR TITLE
fix(cli): detect Swagger 2.0 specs in JSON format for docs validation

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Fix `fern check` failing to detect Swagger 2.0 specs in JSON format. The docs validator now correctly identifies JSON-formatted Swagger 2.0 specs (with `"swagger": "2.0"`) in addition to YAML format, preventing false positive errors about `#/definitions/` references.
+      type: fix
+  irVersion: 63
+  createdAt: "2025-12-08"
+  version: 3.4.3
+
+- changelogEntry:
+    - summary: |
         Fix `fern generate` crash when inheriting from a schema with top-level `nullable: true` via `allOf`. The OpenAPI importer now correctly strips nullable wrappers from type references in extends lists.
       type: fix
   irVersion: 63

--- a/packages/cli/yaml/docs-validator/src/rules/no-non-component-refs/no-non-component-refs.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/no-non-component-refs/no-non-component-refs.ts
@@ -2,6 +2,7 @@ import { relative } from "@fern-api/fs-utils";
 import { readFile } from "fs/promises";
 
 import { Rule, RuleViolation } from "../../Rule";
+import { isSwagger2 } from "../../utils/isSwagger2";
 
 export const NoNonComponentRefsRule: Rule = {
     name: "no-non-component-refs",
@@ -27,13 +28,7 @@ export const NoNonComponentRefsRule: Rule = {
                                     );
 
                                     // Skip OpenAPI v2 files - they should be handled by the v2 rule first
-                                    const isOpenApiV2 =
-                                        contents.includes("swagger:") &&
-                                        (contents.includes('swagger: "2.0"') ||
-                                            contents.includes("swagger: '2.0'") ||
-                                            contents.includes("swagger: 2.0"));
-
-                                    if (isOpenApiV2) {
+                                    if (isSwagger2(contents)) {
                                         continue; // Skip v2 files
                                     }
 

--- a/packages/cli/yaml/docs-validator/src/rules/no-openapi-v2-in-docs/no-openapi-v2-in-docs.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/no-openapi-v2-in-docs/no-openapi-v2-in-docs.ts
@@ -2,6 +2,7 @@ import { relative } from "@fern-api/fs-utils";
 import { readFile } from "fs/promises";
 
 import { Rule, RuleViolation } from "../../Rule";
+import { isSwagger2 } from "../../utils/isSwagger2";
 
 export const NoOpenApiV2InDocsRule: Rule = {
     name: "no-openapi-v2-in-docs",
@@ -21,13 +22,8 @@ export const NoOpenApiV2InDocsRule: Rule = {
                                 // Use the docs workspace as reference point for more descriptive path
                                 const relativePath = relative(docsWorkspace.absoluteFilePath, spec.absoluteFilepath);
 
-                                // Simple check for OpenAPI v2 by looking for "swagger: " pattern
-                                if (
-                                    contents.includes("swagger:") &&
-                                    (contents.includes('swagger: "2.0"') ||
-                                        contents.includes("swagger: '2.0'") ||
-                                        contents.includes("swagger: 2.0"))
-                                ) {
+                                // Check for OpenAPI v2 (Swagger 2.0) in both YAML and JSON formats
+                                if (isSwagger2(contents)) {
                                     violations.push({
                                         severity: "error",
                                         name: "OpenAPI v2.0 not supported",

--- a/packages/cli/yaml/docs-validator/src/rules/valid-local-references/valid-local-references.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/valid-local-references/valid-local-references.ts
@@ -3,6 +3,7 @@ import { readFile } from "fs/promises";
 import yaml from "js-yaml";
 
 import { Rule, RuleViolation } from "../../Rule";
+import { isSwagger2 } from "../../utils/isSwagger2";
 
 /**
  * Validates that a reference path exists in the OpenAPI specification
@@ -100,13 +101,7 @@ export const ValidLocalReferencesRule: Rule = {
                                 const relativePath = relative(docsWorkspace.absoluteFilePath, spec.absoluteFilepath);
 
                                 // Skip OpenAPI v2 files - they should be handled by the v2 rule first
-                                const isOpenApiV2 =
-                                    contents.includes("swagger:") &&
-                                    (contents.includes('swagger: "2.0"') ||
-                                        contents.includes("swagger: '2.0'") ||
-                                        contents.includes("swagger: 2.0"));
-
-                                if (isOpenApiV2) {
+                                if (isSwagger2(contents)) {
                                     continue; // Skip v2 files
                                 }
 

--- a/packages/cli/yaml/docs-validator/src/utils/isSwagger2.ts
+++ b/packages/cli/yaml/docs-validator/src/utils/isSwagger2.ts
@@ -1,0 +1,20 @@
+/**
+ * Detects if the given file contents represent a Swagger 2.0 (OpenAPI v2) specification.
+ * Handles both YAML and JSON formats.
+ *
+ * @param contents - The raw file contents as a string
+ * @returns true if the file is a Swagger 2.0 specification
+ */
+export function isSwagger2(contents: string): boolean {
+    // YAML format detection: swagger: "2.0", swagger: '2.0', or swagger: 2.0
+    const isYamlSwagger2 =
+        contents.includes("swagger:") &&
+        (contents.includes('swagger: "2.0"') ||
+            contents.includes("swagger: '2.0'") ||
+            contents.includes("swagger: 2.0"));
+
+    // JSON format detection: "swagger": "2.0" (with possible whitespace variations)
+    const isJsonSwagger2 = /"swagger"\s*:\s*"2\.0"/.test(contents);
+
+    return isYamlSwagger2 || isJsonSwagger2;
+}


### PR DESCRIPTION
## Description

Refs: Slack thread from thomas@buildwithfern.com

Fixes `fern check` incorrectly reporting errors about `#/definitions/` references when validating Swagger 2.0 specs in JSON format. The docs validator was only detecting YAML-formatted Swagger 2.0 specs (e.g., `swagger: "2.0"`) but not JSON format (e.g., `"swagger": "2.0"`).

Link to Devin run: https://app.devin.ai/sessions/48aab8d562f44e6c85c4ccb25f53dd76
Requested by: thomas@buildwithfern.com (@tjb9dc)

## Changes Made

- Created shared `isSwagger2()` utility function that detects Swagger 2.0 in both YAML and JSON formats
- Updated 3 validation rules to use the new utility:
  - `no-non-component-refs.ts` - now correctly skips JSON Swagger 2.0 files
  - `no-openapi-v2-in-docs.ts` - now correctly detects JSON Swagger 2.0 files
  - `valid-local-references.ts` - now correctly skips JSON Swagger 2.0 files
- Added changelog entry in versions.yml (v3.4.3)

## Testing

- [x] Manual testing completed against the uipath-demo OpenAPI spec (JSON Swagger 2.0 with 806 `#/definitions/` references)
- [x] Verified the `#/definitions/` errors are no longer reported
- [x] Verified the `no-openapi-v2-in-docs` rule now correctly detects the JSON spec and reports "OpenAPI v2.0 not supported"
- [ ] Unit tests added/updated (not added - consider adding tests for `isSwagger2` utility)

## Human Review Checklist

- [ ] Verify the JSON regex pattern `/"swagger"\s*:\s*"2\.0"/` handles all expected whitespace variations
- [ ] Consider if unit tests should be added for the `isSwagger2` utility function