### PR TITLE
fix(cli): fix <Code> replaceReferencedCode issue

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Fix parsing of `<Code>` components with `for` attribute for synced tabs. The `for` attribute is now properly preserved when converting `<Code>` components to markdown code blocks, allowing synced tabs to work correctly across multiple `<CodeGroup>` sections.
+      type: fix
+  irVersion: 63
+  createdAt: "2025-12-08"
+  version: 3.4.5
+
+- changelogEntry:
+    - summary: |
         Fallback to variant type for display name if title and mapping are not present.
       type: fix
   irVersion: 63

--- a/packages/cli/docs-markdown-utils/src/__test__/replaceReferencedCode.test.ts
+++ b/packages/cli/docs-markdown-utils/src/__test__/replaceReferencedCode.test.ts
@@ -761,4 +761,68 @@ describe("replaceReferencedCode", () => {
 
         `);
     });
+
+    it("should preserve for attribute for synced tabs", async () => {
+        const markdown = `
+            <CodeGroup>
+                <Code src="../snippets/test.py" title="yarn" language="shell" for="yarn" />
+                <Code src="../snippets/test.ts" title="npm" language="shell" for="npm" />
+            </CodeGroup>
+        `;
+
+        const result = await replaceReferencedCode({
+            markdown,
+            absolutePathToFernFolder,
+            absolutePathToMarkdownFile,
+            context,
+            fileLoader: async (filepath) => {
+                if (filepath === AbsoluteFilePath.of("/path/to/fern/snippets/test.py")) {
+                    return "yarn add package";
+                }
+                if (filepath === AbsoluteFilePath.of("/path/to/fern/snippets/test.ts")) {
+                    return "npm install package";
+                }
+                throw new Error(`Unexpected filepath: ${filepath}`);
+            }
+        });
+
+        expect(result).toBe(`
+            <CodeGroup>
+                \`\`\`shell title={"yarn"} for={"yarn"}
+                yarn add package
+                \`\`\`
+
+                \`\`\`shell title={"npm"} for={"npm"}
+                npm install package
+                \`\`\`
+
+            </CodeGroup>
+        `);
+    });
+
+    it("should preserve for attribute with curly brace syntax", async () => {
+        const markdown = `
+            <Code src="../snippets/test.py" title="yarn" language="shell" for={"yarn"} />
+        `;
+
+        const result = await replaceReferencedCode({
+            markdown,
+            absolutePathToFernFolder,
+            absolutePathToMarkdownFile,
+            context,
+            fileLoader: async (filepath) => {
+                if (filepath === AbsoluteFilePath.of("/path/to/fern/snippets/test.py")) {
+                    return "yarn add package";
+                }
+                throw new Error(`Unexpected filepath: ${filepath}`);
+            }
+        });
+
+        expect(result).toBe(`
+            \`\`\`shell title={"yarn"} for={"yarn"}
+            yarn add package
+            \`\`\`
+
+        `);
+    });
 });

--- a/packages/cli/docs-markdown-utils/src/replaceReferencedCode.ts
+++ b/packages/cli/docs-markdown-utils/src/replaceReferencedCode.ts
@@ -215,7 +215,25 @@ export async function replaceReferencedCode({
 
             // Add remaining properties as-is to metastring
             for (const [propName, propData] of allProps) {
-                metastring += ` ${propName}={${propData.value}}`;
+                // For string attributes from quotes, wrap in quotes. For expressions from curly braces, keep as-is.
+                if (propData.fromCurlyBraces) {
+                    // If it came from curly braces, use the value as-is (it might be an expression or already quoted)
+                    metastring += ` ${propName}={${propData.value}}`;
+                } else {
+                    // If it came from quotes, check if it's a number or boolean
+                    const trimmedValue = propData.value.trim();
+                    // Check if it's a number (integer or float)
+                    if (/^-?\d+(\.\d+)?$/.test(trimmedValue)) {
+                        // It's a number, output without quotes
+                        metastring += ` ${propName}={${trimmedValue}}`;
+                    } else if (trimmedValue === "true" || trimmedValue === "false") {
+                        // It's a boolean, output without quotes
+                        metastring += ` ${propName}={${trimmedValue}}`;
+                    } else {
+                        // It's a string, wrap in quotes for the metastring
+                        metastring += ` ${propName}={${JSON.stringify(propData.value)}}`;
+                    }
+                }
             }
 
             // TODO: if the code content includes ```, add more backticks to avoid conflicts


### PR DESCRIPTION
## Description

Fixed the issue where `<Code>` components with `for` attributes weren't being parsed correctly. The problem was in `replaceReferencedCode`: when converting `<Code>` to markdown code blocks, string attributes from quotes weren't quoted in the metastring.

## Changes Made

1. Updated property handling in `replaceReferencedCode.ts`:
   - String attributes from quotes (e.g., `for="yarn"`) are now wrapped in quotes in the metastring: `for={"yarn"}`
   - Attributes from curly braces (e.g., `for={"yarn"}`) are preserved as-is
   - Numeric and boolean values are handled correctly (no quotes)

2. Added tests to verify:
   - `for="yarn"` is preserved as `for={"yarn"}` in the output
   - `for={"yarn"}` is preserved as `for={"yarn"}` in the output

3. Added changelog entry for version 3.4.5

- [ ] Updated README.md generator (if applicable)

## Result

`<Code>` components with `for` attributes now work for synced tabs, matching `<CodeBlock>` behavior. The customer's example with `for="npm"`, `for="pnpm"`, and `for="yarn"` will now be correctly preserved in the markdown output, allowing the frontend to sync tabs across multiple `<CodeGroup>` sections.

## Testing

- [x] Unit tests added/updated
- [x] Manual testing completed

## Human Review Checklist

- [ ] Verify the regex for number detection (`/^-?\d+(\.\d+)?$/`) handles expected numeric formats
- [ ] Confirm `JSON.stringify` properly escapes special characters in string attribute values
- [ ] Check that the `fromCurlyBraces` flag is correctly set during parsing (not shown in diff but relied upon)

---

Link to Devin run: https://app.devin.ai/sessions/36f25d647e464814a7e3ea893117ad4c
Requested by: Sandeep Dinesh (sandeep@buildwithfern.com) (@thesandlord)