### PR TITLE
fix(java): Remove oauth-token-override config flag, always enable token override

### DIFF
--- a/generators/java-v2/ast/src/custom-config/BaseJavaCustomConfigSchema.ts
+++ b/generators/java-v2/ast/src/custom-config/BaseJavaCustomConfigSchema.ts
@@ -27,9 +27,6 @@ export const BaseJavaCustomConfigSchema = z.object({
     "custom-readme-sections": z.array(CustomReadmeSectionSchema).optional(),
     "custom-pager-name": z.string().optional(),
 
-    // OAuth token override configuration
-    "oauth-token-override": z.boolean().optional(),
-
     // Deprecated.
     "wrapped-aliases": z.boolean().optional()
 });

--- a/generators/java-v2/sdk/src/readme/ReadmeSnippetBuilder.ts
+++ b/generators/java-v2/sdk/src/readme/ReadmeSnippetBuilder.ts
@@ -134,8 +134,8 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
             addendumsByFeatureId[FernGeneratorCli.StructuredFeatureId.Usage] = this.getOptionalNullableDocumentation();
         }
 
-        // Check if OAuth token override is enabled with OAuth client credentials
-        if (customConfig != null && customConfig["oauth-token-override"] === true && this.hasOAuthClientCredentials()) {
+        // Always show OAuth token override documentation when OAuth client credentials are present
+        if (this.hasOAuthClientCredentials()) {
             const oauthDoc = this.getOAuthTokenOverrideDocumentation();
             // Append to existing Usage addendum or create new one
             if (addendumsByFeatureId[FernGeneratorCli.StructuredFeatureId.Usage]) {

--- a/generators/java/generator-utils/src/main/java/com/fern/java/ICustomConfig.java
+++ b/generators/java/generator-utils/src/main/java/com/fern/java/ICustomConfig.java
@@ -114,12 +114,6 @@ public interface ICustomConfig {
     Optional<String> customPagerName();
 
     @Value.Default
-    @JsonProperty("oauth-token-override")
-    default Boolean oauthTokenOverride() {
-        return false;
-    }
-
-    @Value.Default
     @JsonProperty("package-layout")
     default PackageLayout packageLayout() {
         return PackageLayout.NESTED;

--- a/generators/java/sdk/src/main/java/com/fern/java/client/JavaSdkCustomConfig.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/JavaSdkCustomConfig.java
@@ -77,7 +77,7 @@ public interface JavaSdkCustomConfig extends ICustomConfig {
         return false;
     }
 
-    static ImmutableJavaSdkCustomConfig.Builder builder(){
+    static ImmutableJavaSdkCustomConfig.Builder builder() {
         return ImmutableJavaSdkCustomConfig.builder();
     }
 }

--- a/generators/java/sdk/src/main/java/com/fern/java/client/JavaSdkCustomConfig.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/JavaSdkCustomConfig.java
@@ -77,14 +77,7 @@ public interface JavaSdkCustomConfig extends ICustomConfig {
         return false;
     }
 
-    @Override
-    @Value.Default
-    @JsonProperty("oauth-token-override")
-    default Boolean oauthTokenOverride() {
-        return false;
-    }
-
-    static ImmutableJavaSdkCustomConfig.Builder builder() {
+    static ImmutableJavaSdkCustomConfig.Builder builder(){
         return ImmutableJavaSdkCustomConfig.builder();
     }
 }

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/AbstractRootClientGenerator.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/AbstractRootClientGenerator.java
@@ -333,7 +333,6 @@ public abstract class AbstractRootClientGenerator extends AbstractFileGenerator 
 
     private TypeSpec getClientBuilder() {
         boolean isExtensible = clientGeneratorContext.getCustomConfig().enableExtensibleBuilders();
-        boolean hasOAuthTokenOverride = clientGeneratorContext.getCustomConfig().oauthTokenOverride();
 
         // Check if we have OAuth client credentials auth scheme
         boolean hasOAuthClientCredentials = generatorContext.getResolvedAuthSchemes().stream()

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/AbstractRootClientGenerator.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/AbstractRootClientGenerator.java
@@ -264,7 +264,8 @@ public abstract class AbstractRootClientGenerator extends AbstractFileGenerator 
                     }
                 }));
 
-        // Always use staged builder pattern when OAuth client credentials are present (unless extensible builders are enabled)
+        // Always use staged builder pattern when OAuth client credentials are present (unless extensible builders are
+        // enabled)
         boolean useStagedBuilder = hasOAuthClientCredentials && !isExtensible;
 
         if (isExtensible) {
@@ -378,7 +379,8 @@ public abstract class AbstractRootClientGenerator extends AbstractFileGenerator 
                     }
                 }));
 
-        // Always use staged builder pattern when OAuth client credentials are present (unless extensible builders are enabled)
+        // Always use staged builder pattern when OAuth client credentials are present (unless extensible builders are
+        // enabled)
         boolean useStagedBuilder = hasOAuthClientCredentials && !isExtensible;
 
         TypeSpec.Builder clientBuilder;

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/AbstractRootClientGenerator.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/AbstractRootClientGenerator.java
@@ -219,7 +219,6 @@ public abstract class AbstractRootClientGenerator extends AbstractFileGenerator 
         TypeSpec builderTypeSpec = getClientBuilder();
 
         boolean isExtensible = clientGeneratorContext.getCustomConfig().enableExtensibleBuilders();
-        boolean hasOAuthTokenOverride = clientGeneratorContext.getCustomConfig().oauthTokenOverride();
 
         // Check if we have OAuth client credentials auth scheme for staged builder
         boolean hasOAuthClientCredentials = generatorContext.getResolvedAuthSchemes().stream()
@@ -265,7 +264,8 @@ public abstract class AbstractRootClientGenerator extends AbstractFileGenerator 
                     }
                 }));
 
-        boolean useStagedBuilder = hasOAuthTokenOverride && hasOAuthClientCredentials && !isExtensible;
+        // Always use staged builder pattern when OAuth client credentials are present (unless extensible builders are enabled)
+        boolean useStagedBuilder = hasOAuthClientCredentials && !isExtensible;
 
         if (isExtensible) {
             ClassName implClassName = builderName.nestedClass("Impl");
@@ -379,8 +379,8 @@ public abstract class AbstractRootClientGenerator extends AbstractFileGenerator 
                     }
                 }));
 
-        // Use staged builder pattern when OAuth token override is enabled
-        boolean useStagedBuilder = hasOAuthTokenOverride && hasOAuthClientCredentials && !isExtensible;
+        // Always use staged builder pattern when OAuth client credentials are present (unless extensible builders are enabled)
+        boolean useStagedBuilder = hasOAuthClientCredentials && !isExtensible;
 
         TypeSpec.Builder clientBuilder;
         if (isExtensible) {
@@ -1172,8 +1172,6 @@ public abstract class AbstractRootClientGenerator extends AbstractFileGenerator 
                 EndpointReference tokenEndpointReference =
                         clientCredentials.getTokenEndpoint().getEndpointReference();
 
-                boolean hasTokenOverride =
-                        clientGeneratorContext.getCustomConfig().oauthTokenOverride();
                 String tokenOverridePropertyName = "token";
 
                 // Collect custom properties info for OAuth token supplier
@@ -1217,7 +1215,8 @@ public abstract class AbstractRootClientGenerator extends AbstractFileGenerator 
 
                 String tokenPrefix = clientCredentials.getTokenPrefix().orElse("Bearer");
 
-                if (useStagedBuilder && hasTokenOverride) {
+                if (useStagedBuilder) {
+                    // Always use staged builder pattern for OAuth client credentials (token override is always enabled)
                     generateStagedBuilderForOAuth(
                             clientCredentials,
                             tokenOverridePropertyName,
@@ -1226,31 +1225,29 @@ public abstract class AbstractRootClientGenerator extends AbstractFileGenerator 
                             authClientClassName,
                             oauthTokenSupplierClassName);
                 } else {
-                    // Original behavior: flat builder with runtime validation
-                    if (hasTokenOverride) {
-                        createTokenOverrideSetter(tokenOverridePropertyName);
+                    // Extensible builders: flat builder with runtime validation and token override support
+                    createTokenOverrideSetter(tokenOverridePropertyName);
 
-                        // Add validation: must provide either token OR (clientId AND clientSecret), but not both
-                        buildMethod
-                                .beginControlFlow(
-                                        "if (this.$L != null && (this.clientId != null || this.clientSecret != null))",
-                                        tokenOverridePropertyName)
-                                .addStatement(
-                                        "throw new $T($S)",
-                                        IllegalStateException.class,
-                                        "Cannot provide both '" + tokenOverridePropertyName
-                                                + "' and 'clientId'/'clientSecret'. Use one authentication method.")
-                                .endControlFlow()
-                                .beginControlFlow(
-                                        "if (this.$L == null && (this.clientId == null || this.clientSecret == null))",
-                                        tokenOverridePropertyName)
-                                .addStatement(
-                                        "throw new $T($S)",
-                                        IllegalStateException.class,
-                                        "Please provide either '" + tokenOverridePropertyName
-                                                + "' or both 'clientId' and 'clientSecret'")
-                                .endControlFlow();
-                    }
+                    // Add validation: must provide either token OR (clientId AND clientSecret), but not both
+                    buildMethod
+                            .beginControlFlow(
+                                    "if (this.$L != null && (this.clientId != null || this.clientSecret != null))",
+                                    tokenOverridePropertyName)
+                            .addStatement(
+                                    "throw new $T($S)",
+                                    IllegalStateException.class,
+                                    "Cannot provide both '" + tokenOverridePropertyName
+                                            + "' and 'clientId'/'clientSecret'. Use one authentication method.")
+                            .endControlFlow()
+                            .beginControlFlow(
+                                    "if (this.$L == null && (this.clientId == null || this.clientSecret == null))",
+                                    tokenOverridePropertyName)
+                            .addStatement(
+                                    "throw new $T($S)",
+                                    IllegalStateException.class,
+                                    "Please provide either '" + tokenOverridePropertyName
+                                            + "' or both 'clientId' and 'clientSecret'")
+                            .endControlFlow();
 
                     createSetter("clientId", clientCredentials.getClientIdEnvVar(), Optional.empty());
                     createSetter("clientSecret", clientCredentials.getClientSecretEnvVar(), Optional.empty());
@@ -1261,20 +1258,15 @@ public abstract class AbstractRootClientGenerator extends AbstractFileGenerator 
                     }
 
                     if (configureAuthMethod != null) {
-                        // If token override is enabled, check for token first
-                        if (hasTokenOverride) {
-                            configureAuthMethod.beginControlFlow("if (this.$L != null)", tokenOverridePropertyName);
-                            configureAuthMethod.addStatement(
-                                    "builder.addHeader($S, $S + this.$L)",
-                                    "Authorization",
-                                    tokenPrefix + " ",
-                                    tokenOverridePropertyName);
-                            configureAuthMethod.nextControlFlow(
-                                    "else if (this.clientId != null && this.clientSecret != null)");
-                        } else {
-                            configureAuthMethod.beginControlFlow(
-                                    "if (this.clientId != null && this.clientSecret != null)");
-                        }
+                        // Check for token first, then fall back to OAuth client credentials flow
+                        configureAuthMethod.beginControlFlow("if (this.$L != null)", tokenOverridePropertyName);
+                        configureAuthMethod.addStatement(
+                                "builder.addHeader($S, $S + this.$L)",
+                                "Authorization",
+                                tokenPrefix + " ",
+                                tokenOverridePropertyName);
+                        configureAuthMethod.nextControlFlow(
+                                "else if (this.clientId != null && this.clientSecret != null)");
 
                         configureAuthMethod.addStatement(
                                 "$T.Builder authClientOptionsBuilder = $T.builder().environment(this.$L)",

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,3 +1,14 @@
+- version: 3.23.4
+  changelogEntry:
+    - summary: |
+        Remove `oauth-token-override` config flag. OAuth token override is now always enabled for APIs
+        with OAuth client credentials authentication. SDK users can always choose between providing a
+        pre-generated bearer token directly via `withToken()` or using the OAuth client credentials
+        flow via `withCredentials()`.
+      type: fix
+  createdAt: "2025-12-09"
+  irVersion: 61
+
 - version: 3.23.3
   changelogEntry:
     - summary: |

--- a/seed/java-sdk/seed.yml
+++ b/seed/java-sdk/seed.yml
@@ -265,8 +265,7 @@ fixtures:
     - customConfig:
         enable-wire-tests: true
       outputFolder: oauth-client-credentials
-    - customConfig:
-        oauth-token-override: true
+    - customConfig: null
       outputFolder: token-override
   oauth-client-credentials-mandatory-auth:
     - customConfig: null

--- a/seed/java-sdk/seed.yml
+++ b/seed/java-sdk/seed.yml
@@ -265,8 +265,6 @@ fixtures:
     - customConfig:
         enable-wire-tests: true
       outputFolder: oauth-client-credentials
-    - customConfig: null
-      outputFolder: token-override
   oauth-client-credentials-mandatory-auth:
     - customConfig: null
       outputFolder: no-custom-config
@@ -317,7 +315,6 @@ allowedFailures:
   - nullable-optional:with-nullable-annotation
   - nullable-optional:collapse-optional-nullable
   - oauth-client-credentials
-  - oauth-client-credentials:token-override
   - oauth-client-credentials-custom
   - oauth-client-credentials-default
   - oauth-client-credentials-environment-variables


### PR DESCRIPTION
## Description
Refs [Slack thread](https://buildwithfern.slack.com/archives/C09NRQZ4A2X/p1765245418322719)

Removes the `oauth-token-override` config flag from the Java generator. OAuth token override is now always enabled for APIs with OAuth client credentials authentication, allowing SDK users to always choose between providing a pre-generated bearer token directly or using the OAuth client credentials flow.

## Changes Made
- Removed `oauth-token-override` config option from `ICustomConfig.java` and `JavaSdkCustomConfig.java`
- Removed `oauth-token-override` from Java v2 `BaseJavaCustomConfigSchema.ts`
- Updated `AbstractRootClientGenerator.java` to always use staged builder pattern when OAuth client credentials are present (unless extensible builders are enabled)
- Updated `ReadmeSnippetBuilder.ts` to always show OAuth token override documentation when OAuth client credentials are present
- Removed `token-override` seed fixture entirely (no longer needed since feature is always enabled)
- Added version 3.23.4 changelog entry

## Updates Since Last Revision
- Fixed remaining `oauthTokenOverride()` reference in `getClientBuilder()` method that was causing compilation failure
- Removed entire `token-override` seed fixture entry per PR feedback (instead of setting `customConfig: null`)
- Removed `oauth-client-credentials:token-override` from `allowedFailures` list
- Fixed spotless formatting violations (wrapped long comments to satisfy line length requirements)

## Testing
- [x] Lint checks pass (`pnpm run check`)
- [x] Java spotless formatting passes
- [x] All CI checks passing

## Human Review Checklist
- [ ] Verify the extensible builders path (else branch in `visitClientCredentials`) correctly includes token override support with runtime validation
- [ ] Confirm staged builder is now always used when OAuth client credentials are present (unless extensible builders enabled)
- [ ] Verify removing the token-override seed fixture is expected behavior

---
Requested by: thomas@buildwithfern.com (thomas@buildwithfern.com) | GitHub: @tjb9dc
Link to Devin run: https://app.devin.ai/sessions/50792a850bab4ae4a164965b4bab760b