### PR TITLE
feat(cli): add support for vendor-specific JSON content types in example validation

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Add support for vendor-specific JSON content types in example validation. Content types like `application/vnd.bc.v1+json` are now accepted as valid JSON content types when validating examples against `literal<"application/json">` types.
+      type: feat
+  irVersion: 63
+  createdAt: "2025-12-09"
+  version: 3.5.0
+
+- changelogEntry:
+    - summary: |
         Fix parsing of `<Code>` components with `for` attribute for synced tabs. The `for` attribute is now properly preserved when converting `<Code>` components to markdown code blocks, allowing synced tabs to work correctly across multiple `<CodeGroup>` sections.
       type: fix
   irVersion: 63

--- a/packages/cli/generation/ir-generator/src/examples/validateTypeReferenceExample.ts
+++ b/packages/cli/generation/ir-generator/src/examples/validateTypeReferenceExample.ts
@@ -1,5 +1,5 @@
 import { FernWorkspace } from "@fern-api/api-workspace-commons";
-import { assertNever, getDuplicates, isPlainObject } from "@fern-api/core-utils";
+import { assertNever, getDuplicates, isPlainObject, MediaType } from "@fern-api/core-utils";
 import { EXAMPLE_REFERENCE_PREFIX, RawSchemas, visitRawTypeReference } from "@fern-api/fern-definition-schema";
 import {
     DoubleValidationRules,
@@ -243,7 +243,7 @@ export function validateTypeReferenceExample({
                         )(example);
                     case "string":
                         return createValidator(
-                            (e) => e === expectedLiteral.string,
+                            (e) => e === expectedLiteral.string || areMediaTypesCompatible(expectedLiteral.string, e),
                             `"${expectedLiteral.string}"`
                         )(example);
                     default:
@@ -556,4 +556,23 @@ function areLiteralTypesEquivalent({ expected, actual }: { expected: Literal; ac
         default:
             assertNever(expected);
     }
+}
+
+function areMediaTypesCompatible(expected: string, example: RawSchemas.ExampleTypeReferenceSchema): boolean {
+    if (typeof example !== "string") {
+        return false;
+    }
+
+    const expectedMediaType = MediaType.parse(expected);
+    const exampleMediaType = MediaType.parse(example);
+
+    if (expectedMediaType == null || exampleMediaType == null) {
+        return false;
+    }
+
+    if (expectedMediaType.isJSON() && exampleMediaType.isJSON()) {
+        return true;
+    }
+
+    return false;
 }


### PR DESCRIPTION
## Description

Refs: Slack thread from @tjb9dc

Adds support for vendor-specific JSON content types (e.g., `application/vnd.bc.v1+json`) in example validation. Previously, `fern check` would fail with:
```
Expected example to be "application/json". Example is: "application/vnd.bc.v1+json"
```

This change recognizes that vendor-specific JSON content types are semantically equivalent to `application/json` on the wire.

**Link to Devin run**: https://app.devin.ai/sessions/656a1860b77746bfbfd021fc401fbcf2
**Requested by**: thomas@buildwithfern.com (@tjb9dc)

## Changes Made

- Modified literal string validation in `validateTypeReferenceExample.ts` to accept compatible media types
- Added `areMediaTypesCompatible()` helper function that uses the existing `MediaType` class to check if two content types are both JSON types
- Added changelog entry for CLI version 3.5.0

## Human Review Checklist

- [ ] Verify `MediaType.parse()` correctly parses `application/vnd.bc.v1+json` (subtype should be `vnd.bc.v1+json`)
- [ ] Verify `isJSON()` returns true for vendor-specific JSON types (it checks `subtype.includes("json")`)
- [ ] Consider: `areMediaTypesCompatible` is called for ALL string literal validations - is this safe? (It's conservative: only returns true if both parse as valid media types AND both are JSON)
- [ ] Note: User also asked about `text/event-stream` support - this implementation only handles JSON media types. The `text/event-stream` case may be a different issue (inline OpenAPI examples vs literal type validation)

## Testing

- [ ] Unit tests added/updated
- [x] Manual lint check passed (`pnpm run check`)