### PR TITLE
fix(openapi): widen global header type to string when schemas are incompatible

### DIFF
--- a/generators/swift/sdk/src/generators/client/util/__test__/snapshots/formatted-endpoint-paths/openapi-accept-header.swift
+++ b/generators/swift/sdk/src/generators/client/util/__test__/snapshots/formatted-endpoint-paths/openapi-accept-header.swift
@@ -1,0 +1,5 @@
+// service_
+"/events"
+"/data"
+"/other"
+"/more"

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/openapi-accept-header/type__GetDataResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/openapi-accept-header/type__GetDataResponse.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {}
+}

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/openapi-accept-header/type__GetMoreResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/openapi-accept-header/type__GetMoreResponse.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "value": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {}
+}

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/openapi-accept-header/type__GetOtherResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/openapi-accept-header/type__GetOtherResponse.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "name": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {}
+}

--- a/test-definitions/fern/apis/openapi-accept-header/generators.yml
+++ b/test-definitions/fern/apis/openapi-accept-header/generators.yml
@@ -1,0 +1,3 @@
+api:
+  specs:
+    - openapi: ./openapi.yml

--- a/test-definitions/fern/apis/openapi-accept-header/openapi.yml
+++ b/test-definitions/fern/apis/openapi-accept-header/openapi.yml
@@ -1,0 +1,89 @@
+openapi: 3.0.3
+info:
+  title: Accept Header Test API
+  version: 1.0.0
+  description: Test API for Accept header with text/event-stream default
+paths:
+  /events:
+    get:
+      operationId: getEvents
+      summary: Get events stream
+      description: Returns a stream of events
+      parameters:
+        - $ref: '#/components/parameters/AcceptEventStream'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            text/event-stream:
+              schema:
+                type: string
+  /data:
+    get:
+      operationId: getData
+      summary: Get data as JSON
+      description: Returns data as JSON
+      parameters:
+        - $ref: '#/components/parameters/AcceptJson'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+  /other:
+    get:
+      operationId: getOther
+      summary: Get other data as JSON
+      description: Returns other data as JSON
+      parameters:
+        - $ref: '#/components/parameters/AcceptJson'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+  /more:
+    get:
+      operationId: getMore
+      summary: Get more data as JSON
+      description: Returns more data as JSON
+      parameters:
+        - $ref: '#/components/parameters/AcceptJson'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  value:
+                    type: string
+components:
+  parameters:
+    AcceptEventStream:
+      name: Accept
+      in: header
+      required: true
+      description: The MIME type of the response body.
+      schema:
+        type: string
+        default: 'text/event-stream'
+    AcceptJson:
+      name: Accept
+      in: header
+      required: true
+      description: The MIME type of the response body.
+      schema:
+        type: string
+        const: 'application/json'


### PR DESCRIPTION
## Description

Refs https://buildwithfern.slack.com/archives/C09NRQZ4A2X/p1765250090217619

Fixes a bug where an OpenAPI spec with the same header name (e.g., `Accept`) across multiple endpoints but with different schemas causes validation errors during example generation.

**Root cause:** When detecting global headers, the importer uses the first endpoint's schema for all endpoints. If subsequent endpoints have different schemas for the same header (e.g., one with `default: 'text/event-stream'` and another with `const: 'application/json'`), the generated examples don't match the global header's type, causing validation errors like:
```
Expected example to be "application/json". Example is: "text/event-stream"
```

**Fix:** When incompatible schemas are detected for the same header name across endpoints, widen the header type to `string` instead of using a literal type.

## Changes Made

- Added `markIncompatible()` and `isIncompatible()` methods to `HeaderWithCount` class to track schema incompatibility
- Added `getTypeFromHttpHeaderSchema()` helper to extract type from Fern header schema for comparison
- Added `widenToString()` helper to convert header schema to plain string type
- Added logic to detect when headers with the same name have different schemas across endpoints
- When incompatible schemas are detected, the global header type is widened to `string`
- Added test fixture `openapi-accept-header` to reproduce the issue
- Added JSON schema snapshots for the test fixture
- Added Swift SDK endpoint path snapshot for the test fixture

## Testing

- [x] Manual testing: Verified the test fixture passes `fern ir` without validation errors
- [x] Lint checks pass
- [x] JSON schema snapshot tests added
- [x] Swift SDK snapshot tests added

## Human Review Checklist

- [ ] Verify the schema comparison logic in `getTypeFromHttpHeaderSchema` is sufficient (currently only compares the `type` field from the converted Fern schema)
- [ ] Consider if there are edge cases where widening to `string` loses important type information
- [ ] Confirm the test fixture adequately covers the reported bug scenario

---

Link to Devin run: https://app.devin.ai/sessions/dab9b93cc55a4f79ae9e7453b2e024ad
Requested by: thomas@buildwithfern.com (@tjb9dc)