### PR TITLE
fix(cli): optimize fern docs dev performance for large sites

### DIFF
--- a/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
+++ b/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
@@ -316,7 +316,9 @@ export class DocsDefinitionResolver {
             });
         }
         const refMdTime = performance.now() - refMdStart;
-        this.taskContext.logger.debug(`Replaced referenced markdown in ${refMdTime.toFixed(0)}ms (${snippetCache.size} unique snippets cached)`);
+        this.taskContext.logger.debug(
+            `Replaced referenced markdown in ${refMdTime.toFixed(0)}ms (${snippetCache.size} unique snippets cached)`
+        );
 
         // replaces all instances of <Code src="path/to/file.js" /> with the content of the referenced code file
         this.taskContext.logger.debug("Replacing referenced code files...");


### PR DESCRIPTION
## Description

Refs: Performance investigation for `fern docs dev` with large docs sites

Optimizes `DocsDefinitionResolver` performance for docs sites with thousands of pages through two targeted improvements.

**Link to Devin run**: https://app.devin.ai/sessions/e6c66114f0fc4fbca20902b7d6dcd2c6
**Requested by**: Sandeep Dinesh (@thesandlord)

## Changes Made

### 1. Parse frontmatter once per page instead of 4 times
- Replaced 4 separate methods (`getMarkdownFilesToFullSlugs`, `getMarkdownFilesToSidebarTitle`, `getMarkdownFilesToNoIndex`, `getMarkdownFilesToTags`) with a single `extractAllFrontmatterData` method
- For a site with 1000 pages, this reduces `gray-matter` calls from 4000 to 1000

### 2. Combine page processing loops
- Merged the `replaceReferencedMarkdown` and `replaceReferencedCode` loops into a single pass over all pages
- Reduces iterations from 2N to N for N pages

## Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed - verified compilation passes
- [x] CI checks passing

## Review Checklist

- [ ] Verify extraction logic for each frontmatter field (slug, sidebar-title, noindex, tags) is preserved correctly
- [ ] Confirm the order of operations (markdown includes before code includes) is correct