### PR TITLE
feat(python): add coerce_numbers_to_str to pydantic_config

### DIFF
--- a/generators/python-v2/browser-compatible-base/src/custom-config/PydanticConfig.ts
+++ b/generators/python-v2/browser-compatible-base/src/custom-config/PydanticConfig.ts
@@ -7,6 +7,7 @@ export const PydanticConfig = z.object({
     union_naming: z.enum(["v0", "v1"]).optional().default("v0"),
 
     // General options.
+    coerce_numbers_to_str: z.boolean().optional(),
     extra_fields: z.enum(["allow", "forbid", "ignore"]).optional(),
     include_validators: z.boolean().optional(),
     skip_formatting: z.boolean().optional(),

--- a/generators/python/fastapi/versions.yml
+++ b/generators/python/fastapi/versions.yml
@@ -1,5 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 1.13.0
+  changelogEntry:
+    - summary: |
+        Add `coerce_numbers_to_str` option to `pydantic_config`. When enabled, numeric types (int, float, Decimal)
+        will be coerced to strings during validation. This is useful for APIs that return numeric values as strings.
+      type: feat
+  createdAt: "2025-12-09"
+  irVersion: 61
+
 - version: 1.12.2
   changelogEntry:
     - summary: |

--- a/generators/python/pydantic/versions.yml
+++ b/generators/python/pydantic/versions.yml
@@ -1,5 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 1.11.0
+  changelogEntry:
+    - summary: |
+        Add `coerce_numbers_to_str` option to `pydantic_config`. When enabled, numeric types (int, float, Decimal)
+        will be coerced to strings during validation. This is useful for APIs that return numeric values as strings.
+      type: feat
+  createdAt: "2025-12-09"
+  irVersion: 61
+
 - version: 1.10.2
   changelogEntry:
     - summary: |

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 4.45.0
+  changelogEntry:
+    - summary: |
+        Add `coerce_numbers_to_str` option to `pydantic_config`. When enabled, numeric types (int, float, Decimal)
+        will be coerced to strings during validation. This is useful for APIs that return numeric values as strings.
+      type: feat
+  createdAt: "2025-12-09"
+  irVersion: 61
+
 - version: 4.44.1
   changelogEntry:
     - summary: |

--- a/generators/python/src/fern_python/generators/pydantic_model/custom_config.py
+++ b/generators/python/src/fern_python/generators/pydantic_model/custom_config.py
@@ -15,6 +15,7 @@ class BasePydanticModelCustomConfig(pydantic.BaseModel):
     orm_mode: bool = False
     smart_union: bool = False
     require_optional_fields: bool = False
+    coerce_numbers_to_str: bool = False
     use_str_enums: bool = True
     """
     use_str_enums is deprecated, prefer `enum_type` instead (default: 'literals', which is the equivalent of `use_str_enums=True`)

--- a/generators/python/src/fern_python/generators/pydantic_model/fern_aware_pydantic_model.py
+++ b/generators/python/src/fern_python/generators/pydantic_model/fern_aware_pydantic_model.py
@@ -99,6 +99,7 @@ class FernAwarePydanticModel:
             update_forward_ref_function_reference=self._context.core_utilities.get_update_forward_refs(),
             field_metadata_getter=lambda: self._context.core_utilities.get_field_metadata(),
             use_pydantic_field_aliases=self._custom_config.use_pydantic_field_aliases,
+            coerce_numbers_to_str=custom_config.coerce_numbers_to_str,
         )
 
         self._force_update_forward_refs = force_update_forward_refs


### PR DESCRIPTION
## Description

Refs: Slack request from @tjb9dc

Adds `coerce_numbers_to_str` option to `pydantic_config` for Python generators (SDK, FastAPI, and Pydantic). When enabled, numeric types (int, float, Decimal) will be coerced to strings during validation. This is useful for APIs that return numeric values as strings.

Reference: https://docs.pydantic.dev/2.11/api/config/#pydantic.config.ConfigDict.coerce_numbers_to_str

## Changes Made

- Added `coerce_numbers_to_str: bool = False` to `BasePydanticModelCustomConfig` (Python)
- Added `coerce_numbers_to_str` to TypeScript `PydanticConfig` schema
- Updated `PydanticModel` class to generate the config option for both Pydantic v1 and v2
- Updated `FernAwarePydanticModel` to pass the config through to `PydanticModel`
- Bumped versions: python-sdk 4.45.0, fastapi 1.13.0, pydantic 1.11.0

## Testing

- [x] Lint checks passed (`pnpm run check`)
- [ ] Seed tests (CI will run)

## Human Review Checklist

- [ ] **Verify Pydantic v1 compatibility**: `coerce_numbers_to_str` is a Pydantic v2.11+ feature. The v1 Config class generation adds this option, but Pydantic v1 may not recognize it. Please verify this doesn't cause errors for users on Pydantic v1 (it may be silently ignored, which would be fine).
- [ ] Consider if a seed test fixture should be added to validate this feature

---

Link to Devin run: https://app.devin.ai/sessions/41f1fd5175a04725a4a9784af11e0fdb
Requested by: thomas@buildwithfern.com (@tjb9dc)