### PR TITLE
chore(ruby): add dist script and build.cjs for ruby-dynamic-snippets package

### DIFF
--- a/generators/ruby-v2/dynamic-snippets/build.cjs
+++ b/generators/ruby-v2/dynamic-snippets/build.cjs
@@ -1,0 +1,77 @@
+const { NodeModulesPolyfillPlugin } = require('@esbuild-plugins/node-modules-polyfill');
+const { NodeGlobalsPolyfillPlugin } = require('@esbuild-plugins/node-globals-polyfill');
+const packageJson = require("./package.json");
+const tsup = require('tsup');
+const { writeFile, mkdir } = require("fs/promises");
+const path = require("path");
+
+main();
+
+async function main() {
+    const config = {
+        entry: ['src/**/*.ts', '!src/__test__'],
+        target: "es2017",
+        minify: true,
+        dts: true,
+        sourcemap: true,
+        esbuildPlugins: [
+            NodeModulesPolyfillPlugin(),
+            NodeGlobalsPolyfillPlugin({
+                process: true,
+                buffer: true,
+                util: true
+            })
+        ],
+        tsconfig: "./build.tsconfig.json"
+    };
+
+    await tsup.build({
+        ...config,
+        format: ['cjs'],
+        outDir: 'dist/cjs',
+        clean: true,
+    });
+
+    await tsup.build({
+        ...config,
+        format: ['esm'],
+        outDir: 'dist/esm',
+        clean: false,
+    });
+
+    await mkdir(path.join(__dirname, "dist"), { recursive: true });
+    process.chdir(path.join(__dirname, "dist"));
+
+    await writeFile(
+        "package.json",
+        JSON.stringify(
+            {
+                name: packageJson.name,
+                version: process.argv[2] || packageJson.version,
+                repository: packageJson.repository,
+                type: "module",
+                exports: {
+                    // Conditional exports for ESM and CJS.
+                    "import": {
+                        "types": "./esm/index.d.ts",
+                        "default": "./esm/index.js"
+                    },
+                    "require": {
+                        "types": "./cjs/index.d.cts",
+                        "default": "./cjs/index.cjs"
+                    }
+                },
+                // Fallback for older tooling or direct imports.
+                main: "./cjs/index.cjs",
+                module: "./esm/index.js",
+                types: "./cjs/index.d.cts",
+                files: [
+                    "cjs",
+                    "esm"
+                ]
+            },
+            undefined,
+            2
+        )
+    );
+}

--- a/generators/ruby-v2/dynamic-snippets/package.json
+++ b/generators/ruby-v2/dynamic-snippets/package.json
@@ -26,11 +26,14 @@
     "compile": "tsc --build",
     "compile:debug": "tsc --build --sourceMap",
     "depcheck": "depcheck",
+    "dist": "pnpm compile && node build.cjs",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",
     "test:update": "vitest --passWithNoTests --run -u"
   },
   "devDependencies": {
+    "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
+    "@esbuild-plugins/node-modules-polyfill": "^0.2.2",
     "@fern-api/browser-compatible-base-generator": "workspace:*",
     "@fern-api/configs": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
@@ -41,6 +44,7 @@
     "@types/node": "18.15.3",
     "depcheck": "^1.4.7",
     "lodash-es": "^4.17.21",
+    "tsup": "^8.5.0",
     "typescript": "5.9.3",
     "vitest": "^4.0.8"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1481,6 +1481,12 @@ importers:
 
   generators/ruby-v2/dynamic-snippets:
     devDependencies:
+      '@esbuild-plugins/node-globals-polyfill':
+        specifier: ^0.2.3
+        version: 0.2.3(esbuild@0.25.12)
+      '@esbuild-plugins/node-modules-polyfill':
+        specifier: ^0.2.2
+        version: 0.2.2(esbuild@0.25.12)
       '@fern-api/browser-compatible-base-generator':
         specifier: workspace:*
         version: link:../../browser-compatible-base
@@ -1511,6 +1517,9 @@ importers:
       lodash-es:
         specifier: ^4.17.21
         version: 4.17.21
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.0(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.3.3)
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -9087,6 +9096,16 @@ packages:
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
 
+  '@esbuild-plugins/node-globals-polyfill@0.2.3':
+    resolution: {integrity: sha512-r3MIryXDeXDOZh7ih1l/yE9ZLORCd5e8vWg02azWRGj5SPTuoh69A2AIyn0Z31V/kHBfZ4HgWJ+OK3GTTwLmnw==}
+    peerDependencies:
+      esbuild: '*'
+
+  '@esbuild-plugins/node-modules-polyfill@0.2.2':
+    resolution: {integrity: sha512-LXV7QsWJxRuMYvKbiznh+U1ilIop3g2TeKRzUxOG5X3YITc8JyyTa90BmLwqqv0YnX4v32CSlG+vsziZp9dMvA==}
+    peerDependencies:
+      esbuild: '*'
+
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
     engines: {node: '>=18'}
@@ -12036,6 +12055,9 @@ packages:
   estree-util-visit@2.0.0:
     resolution: {integrity: sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==}
 
+  estree-walker@0.6.1:
+    resolution: {integrity: sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==}
+
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
@@ -13278,6 +13300,9 @@ packages:
   lru-memoizer@2.3.0:
     resolution: {integrity: sha512-GXn7gyHAMhO13WSKrIiNfztwxodVsP8IoZ3XfrJV4yH2x0/OeTO/FIaAHTY5YekdGgW94njfuKmyyt1E0mR6Ug==}
 
+  magic-string@0.25.9:
+    resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -14348,6 +14373,16 @@ packages:
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
+  rollup-plugin-inject@3.0.2:
+    resolution: {integrity: sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==}
+    deprecated: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-inject.
+
+  rollup-plugin-node-polyfills@0.2.1:
+    resolution: {integrity: sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==}
+
+  rollup-pluginutils@2.8.2:
+    resolution: {integrity: sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==}
+
   rollup@4.53.2:
     resolution: {integrity: sha512-MHngMYwGJVi6Fmnk6ISmnk7JAHRNF0UkuucA0CUW3N3a4KnONPEZz+vUanQP/ZC/iY1Qkf3bwPWzyY84wEks1g==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -14541,6 +14576,10 @@ packages:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
     engines: {node: '>= 8'}
     deprecated: The work that was done in this beta branch won't be included in future versions
+
+  sourcemap-codec@1.4.8:
+    resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
+    deprecated: Please use @jridgewell/sourcemap-codec instead
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
@@ -16757,6 +16796,16 @@ snapshots:
   '@emnapi/wasi-threads@1.1.0':
     dependencies:
       tslib: 2.8.1
+
+  '@esbuild-plugins/node-globals-polyfill@0.2.3(esbuild@0.25.12)':
+    dependencies:
+      esbuild: 0.25.12
+
+  '@esbuild-plugins/node-modules-polyfill@0.2.2(esbuild@0.25.12)':
+    dependencies:
+      esbuild: 0.25.12
+      escape-string-regexp: 4.0.0
+      rollup-plugin-node-polyfills: 0.2.1
 
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
@@ -20299,6 +20348,8 @@ snapshots:
       '@types/estree-jsx': 1.0.5
       '@types/unist': 3.0.3
 
+  estree-walker@0.6.1: {}
+
   estree-walker@2.0.2: {}
 
   estree-walker@3.0.3:
@@ -21870,6 +21921,10 @@ snapshots:
     dependencies:
       lodash.clonedeep: 4.5.0
       lru-cache: 6.0.0
+
+  magic-string@0.25.9:
+    dependencies:
+      sourcemap-codec: 1.4.8
 
   magic-string@0.30.21:
     dependencies:
@@ -23479,6 +23534,20 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
+  rollup-plugin-inject@3.0.2:
+    dependencies:
+      estree-walker: 0.6.1
+      magic-string: 0.25.9
+      rollup-pluginutils: 2.8.2
+
+  rollup-plugin-node-polyfills@0.2.1:
+    dependencies:
+      rollup-plugin-inject: 3.0.2
+
+  rollup-pluginutils@2.8.2:
+    dependencies:
+      estree-walker: 0.6.1
+
   rollup@4.53.2:
     dependencies:
       '@types/estree': 1.0.8
@@ -23736,6 +23805,8 @@ snapshots:
   source-map@0.8.0-beta.0:
     dependencies:
       whatwg-url: 7.1.0
+
+  sourcemap-codec@1.4.8: {}
 
   space-separated-tokens@2.0.2: {}
 


### PR DESCRIPTION
## Description

Refs FER-7972

Adds the missing `dist` script and `build.cjs` file to the `@fern-api/ruby-dynamic-snippets` package. These files were accidentally omitted from PR #11099 and are required for the publish workflow to successfully build and publish the package to npm.

**Link to Devin run**: https://app.devin.ai/sessions/b477dd9fc0ea40209f2f32050aad3768
**Requested by**: naman.anand@buildwithfern.com (@iamnamananand996)

## Changes Made

- Added `build.cjs` - build script that uses tsup to create CJS and ESM bundles with proper package.json for npm publishing
- Added `dist` script to package.json: `pnpm compile && node build.cjs`
- Added required build dependencies: `@esbuild-plugins/node-globals-polyfill`, `@esbuild-plugins/node-modules-polyfill`, `tsup`

## Testing

- [x] Tested `pnpm run dist 1.0.0-rc62` locally - successfully creates `dist/` directory with `cjs/`, `esm/`, and `package.json`
- [ ] Unit tests added/updated (N/A - infrastructure change only)

## Human Review Checklist

- [ ] Verify `build.cjs` follows the same pattern as other dynamic-snippets packages in the repo
- [ ] Confirm the added dependencies are appropriate for the build process