### PR TITLE
fix(typescript): use default for 'step' on offset pagination

### DIFF
--- a/generators/typescript/sdk/client-class-generator/src/endpoints/default/endpoint-response/GeneratedThrowingEndpointResponse.ts
+++ b/generators/typescript/sdk/client-class-generator/src/endpoints/default/endpoint-response/GeneratedThrowingEndpointResponse.ts
@@ -350,7 +350,11 @@ export class GeneratedThrowingEndpointResponse implements GeneratedEndpointRespo
                                       ts.factory.createBinaryExpression(
                                           stepPropertyAccess,
                                           ts.factory.createToken(ts.SyntaxKind.QuestionQuestionToken),
-                                          ts.factory.createNumericLiteral("1")
+                                          ts.factory.createNumericLiteral(
+                                              this.getDefaultPaginationValue({
+                                                  type: offset.step.property.valueType
+                                              })
+                                          )
                                       )
                                   )
                               ]

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.38.1
+  changelogEntry:
+    - summary: |
+        `hasNextPage` employs the default for the `step` attribute on offset-based pagination endpoints if it's set.
+      type: fix
+  createdAt: "2025-12-09"
+  irVersion: 62
+
 - version: 3.38.0
   changelogEntry:
     - summary: |

--- a/seed/ts-sdk/pagination/no-custom-config/src/api/resources/users/client/Client.ts
+++ b/seed/ts-sdk/pagination/no-custom-config/src/api/resources/users/client/Client.ts
@@ -558,7 +558,7 @@ export class UsersClient {
         return new core.Page<SeedPagination.User, SeedPagination.ListUsersPaginationResponse>({
             response: dataWithRawResponse.data,
             rawResponse: dataWithRawResponse.rawResponse,
-            hasNextPage: (response) => (response?.data ?? []).length >= Math.floor(request?.limit ?? 1),
+            hasNextPage: (response) => (response?.data ?? []).length >= Math.floor(request?.limit ?? 123),
             getItems: (response) => response?.data ?? [],
             loadPage: (response) => {
                 _offset += response?.data != null ? response.data.length : 1;

--- a/test-definitions/fern/apis/pagination/definition/users.yml
+++ b/test-definitions/fern/apis/pagination/definition/users.yml
@@ -228,6 +228,7 @@ service:
             docs: Defaults to first page
           limit:
             type: optional<integer>
+            default: 123
             docs: |
               The maximum number of elements to return.
               This is also used as the step size in this


### PR DESCRIPTION
## Description
When `step` is provided, the `hasNextPage` function uses it to calculate whether the returned page was as large as was requested:
```
hasNextPage: (response) => (response?.data ?? []).length >= Math.floor(request?.limit ?? 1),
```
but we can do better by making sure that the `1` at the end is replaced with the default if specified for the `step` property (in this case `limit`):
```
hasNextPage: (response) => (response?.data ?? []).length >= Math.floor(request?.limit ?? 123),
```

## Changes Made
One-liner to paginated endpoints.

## Testing
Tweaked the `pagination` fixture to check this; no other fixtures change!
- [X] Unit tests added/updated
- [X] Manual testing completed
