### PR TITLE
feat(cli): Add a -y flag for migrations

### DIFF
--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -1087,6 +1087,12 @@ function addUpgradeCommand({
                 .option("from-git", {
                     boolean: true,
                     hidden: true
+                })
+                .option("yes", {
+                    alias: "y",
+                    boolean: true,
+                    default: false,
+                    description: "Automatically answer yes to migration prompts."
                 }),
         async (argv) => {
             await upgrade({
@@ -1094,7 +1100,8 @@ function addUpgradeCommand({
                 includePreReleases: argv.rc,
                 targetVersion: argv.to ?? argv.version,
                 fromVersion: argv.from,
-                fromGit: argv["from-git"]
+                fromGit: argv["from-git"],
+                yes: argv.yes
             });
             onRun();
         }

--- a/packages/cli/cli/src/cliV2.ts
+++ b/packages/cli/cli/src/cliV2.ts
@@ -133,6 +133,13 @@ export function addGeneratorCommands(cli: Argv<GlobalCliOptions>, cliContext: Cl
                             description:
                                 "The API to upgrade the generator for. If not specified, the generator will be upgraded for all APIs."
                         })
+                        .option("yes", {
+                            alias: "y",
+                            boolean: true,
+                            default: false,
+                            description:
+                                "Automatically answer yes to any prompts that may appear during the upgrade process."
+                        })
                         .option("include-major", {
                             boolean: true,
                             default: false,

--- a/packages/cli/cli/src/commands/upgrade/__test__/upgrade.test.ts
+++ b/packages/cli/cli/src/commands/upgrade/__test__/upgrade.test.ts
@@ -121,6 +121,29 @@ describe("upgrade", () => {
             expect(writeFile).not.toHaveBeenCalled();
         });
 
+        it("should forward --yes when rerunning programmatically", async () => {
+            process.argv = ["node", "cli.js", "upgrade", "--version", "1.2.0"];
+
+            await upgrade({
+                cliContext: mockCliContext,
+                includePreReleases: false,
+                targetVersion: "1.2.0",
+                fromVersion: undefined,
+                yes: true
+            });
+
+            expect(rerunFernCliAtVersion).toHaveBeenCalledWith({
+                version: "1.2.0",
+                cliContext: mockCliContext,
+                env: {
+                    [PREVIOUS_VERSION_ENV_VAR]: "1.0.0"
+                },
+                args: ["upgrade", "--from", "1.0.0", "--to", "1.2.0", "--yes"],
+                throwOnError: true
+            });
+            expect(runMigrations).not.toHaveBeenCalled();
+        });
+
         it("should use explicit --from flag when provided", async () => {
             process.argv = ["node", "cli.js", "upgrade", "--version", "1.2.0", "--from", "0.84.1"];
 
@@ -251,7 +274,8 @@ describe("upgrade", () => {
             expect(runMigrations).toHaveBeenCalledWith({
                 fromVersion: "1.0.0",
                 toVersion: "1.2.0",
-                context: {}
+                context: {},
+                yes: false
             });
             expect(writeFile).toHaveBeenCalled();
         });
@@ -275,12 +299,30 @@ describe("upgrade", () => {
             expect(runMigrations).toHaveBeenCalledWith({
                 fromVersion: "1.0.0",
                 toVersion: "1.2.0",
-                context: {}
+                context: {},
+                yes: false
             });
             expect(writeFile).toHaveBeenCalledWith(
                 "/test/fern/fern.config.json",
                 expect.stringContaining('"version": "1.2.0"')
             );
+        });
+
+        it("should skip migration prompt when yes flag is provided", async () => {
+            await upgrade({
+                cliContext: mockCliContext,
+                includePreReleases: false,
+                targetVersion: "1.2.0",
+                fromVersion: "1.0.0",
+                yes: true
+            });
+
+            expect(runMigrations).toHaveBeenCalledWith({
+                fromVersion: "1.0.0",
+                toVersion: "1.2.0",
+                context: {},
+                yes: true
+            });
         });
 
         it("should use PREVIOUS_VERSION_ENV_VAR if --from not provided", async () => {
@@ -296,7 +338,8 @@ describe("upgrade", () => {
             expect(runMigrations).toHaveBeenCalledWith({
                 fromVersion: "0.84.1",
                 toVersion: "1.2.0",
-                context: {}
+                context: {},
+                yes: false
             });
         });
 
@@ -311,7 +354,8 @@ describe("upgrade", () => {
             expect(runMigrations).toHaveBeenCalledWith({
                 fromVersion: "1.0.0",
                 toVersion: "1.2.0",
-                context: {}
+                context: {},
+                yes: false
             });
         });
 
@@ -415,7 +459,8 @@ describe("upgrade", () => {
             expect(runMigrations).toHaveBeenCalledWith({
                 fromVersion: "0.84.1",
                 toVersion: "1.3.0-rc0",
-                context: {}
+                context: {},
+                yes: false
             });
             expect(writeFile).toHaveBeenCalledWith(
                 "/test/fern/fern.config.json",
@@ -670,7 +715,8 @@ describe("upgrade", () => {
             expect(runMigrations).toHaveBeenCalledWith({
                 fromVersion: "0.84.1",
                 toVersion: "1.2.0",
-                context: {}
+                context: {},
+                yes: false
             });
         });
 
@@ -692,7 +738,8 @@ describe("upgrade", () => {
             expect(runMigrations).toHaveBeenCalledWith({
                 fromVersion: "0.80.0",
                 toVersion: "1.2.0",
-                context: {}
+                context: {},
+                yes: false
             });
         });
 
@@ -717,7 +764,8 @@ describe("upgrade", () => {
             expect(runMigrations).toHaveBeenCalledWith({
                 fromVersion: "1.0.0", // Falls back to projectConfig.version
                 toVersion: "1.2.0",
-                context: {}
+                context: {},
+                yes: false
             });
         });
 
@@ -872,7 +920,8 @@ describe("upgrade", () => {
             expect(runMigrations).toHaveBeenCalledWith({
                 fromVersion: "0.75.0",
                 toVersion: "1.2.0",
-                context: {}
+                context: {},
+                yes: false
             });
         });
 
@@ -894,7 +943,8 @@ describe("upgrade", () => {
             expect(runMigrations).toHaveBeenCalledWith({
                 fromVersion: "1.0.0",
                 toVersion: "1.2.0",
-                context: {}
+                context: {},
+                yes: false
             });
         });
 
@@ -916,7 +966,8 @@ describe("upgrade", () => {
             expect(runMigrations).toHaveBeenCalledWith({
                 fromVersion: "0.90.0",
                 toVersion: "1.2.0",
-                context: {}
+                context: {},
+                yes: false
             });
         });
 
@@ -939,7 +990,8 @@ describe("upgrade", () => {
             expect(runMigrations).toHaveBeenCalledWith({
                 fromVersion: "1.0.0", // Uses projectConfig.version
                 toVersion: "1.2.0",
-                context: {}
+                context: {},
+                yes: false
             });
         });
 
@@ -1003,7 +1055,8 @@ describe("upgrade", () => {
             expect(runMigrations).toHaveBeenCalledWith({
                 fromVersion: "0.84.1", // Should use git history, not env var
                 toVersion: "1.3.0-rc0",
-                context: {}
+                context: {},
+                yes: false
             });
             expect(writeFile).toHaveBeenCalled();
         });
@@ -1044,7 +1097,8 @@ describe("upgrade", () => {
             expect(runMigrations).toHaveBeenCalledWith({
                 fromVersion: "1.3.0-rc0", // Falls back to config version (same as target, but migrations should still run)
                 toVersion: "1.3.0-rc0",
-                context: {}
+                context: {},
+                yes: false
             });
         });
     });
@@ -1071,7 +1125,8 @@ describe("upgrade", () => {
             expect(runMigrations).toHaveBeenCalledWith({
                 fromVersion: "0.85.0",
                 toVersion: "1.2.0",
-                context: {}
+                context: {},
+                yes: false
             });
         });
 
@@ -1111,7 +1166,8 @@ describe("upgrade", () => {
             expect(runMigrations).toHaveBeenCalledWith({
                 fromVersion: "0.85.0", // From git, not from env var
                 toVersion: "1.2.0",
-                context: {}
+                context: {},
+                yes: false
             });
         });
 
@@ -1137,7 +1193,8 @@ describe("upgrade", () => {
             expect(runMigrations).toHaveBeenCalledWith({
                 fromVersion: "1.0.0", // Falls back to projectConfig.version
                 toVersion: "1.2.0",
-                context: {}
+                context: {},
+                yes: false
             });
         });
 
@@ -1157,7 +1214,8 @@ describe("upgrade", () => {
             expect(runMigrations).toHaveBeenCalledWith({
                 fromVersion: "0.80.0", // Uses explicit --from, not git
                 toVersion: "1.2.0",
-                context: {}
+                context: {},
+                yes: false
             });
         });
     });

--- a/packages/cli/cli/src/commands/upgrade/upgrade.ts
+++ b/packages/cli/cli/src/commands/upgrade/upgrade.ts
@@ -298,13 +298,15 @@ export async function upgrade({
     includePreReleases,
     targetVersion,
     fromVersion,
-    fromGit
+    fromGit,
+    yes
 }: {
     cliContext: CliContext;
     includePreReleases: boolean;
     targetVersion: string | undefined;
     fromVersion: string | undefined;
     fromGit?: boolean;
+    yes?: boolean;
 }): Promise<void> {
     const isLocalDev = cliContext.environment.packageVersion === "0.0.0";
 
@@ -389,7 +391,8 @@ export async function upgrade({
             await runMigrations({
                 fromVersion: resolvedFromVersion,
                 toVersion: resolvedTargetVersion,
-                context
+                context,
+                yes: yes ?? false
             });
         });
         await cliContext.exitIfFailed();
@@ -437,6 +440,10 @@ export async function upgrade({
     // Filter out upgrade-specific flags and build args for rerun
     const otherArgs = filterUpgradeFlags(process.argv.slice(2));
     const rerunArgs = ["upgrade", "--from", resolvedFromVersion, "--to", resolvedTargetVersion, ...otherArgs];
+
+    if (yes && !otherArgs.some((arg) => arg === "--yes" || arg === "-y")) {
+        rerunArgs.push("--yes");
+    }
 
     try {
         await rerunFernCliAtVersion({

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Include -y flag for the upgrade for non-interactive environments.
+      type: feat
+  irVersion: 63
+  createdAt: "2025-12-10"
+  version: 3.8.0
+
+- changelogEntry:
+    - summary: |
         Add API flag `default-integer-format` to configure which format is assumed for `type: "integer"`
         properties in OpenAPI that do not specify a format.
 

--- a/packages/cli/ete-tests/src/tests/upgrade-generator/__snapshots__/upgrade-generator.test.ts.snap
+++ b/packages/cli/ete-tests/src/tests/upgrade-generator/__snapshots__/upgrade-generator.test.ts.snap
@@ -21,21 +21,23 @@ exports[`fern generator upgrade > fern generator help commands 2`] = `
 Upgrades the specified generator in generators.yml to the latest stable version.
 
 Options:
-  --help           Show help                                           [boolean]
-  --log-level
+      --help           Show help                                       [boolean]
+      --log-level
           [choices: "trace", "debug", "info", "warn", "error"] [default: "info"]
-  --generator      The type of generator to upgrade, ex:
-                   \`fern-typescript-node-sdk\`.                          [string]
-  --group          The group in which the generator is located, if group is not
-                   specified, the all generators of the specified type will be
-                   upgraded.                                            [string]
-  --api            The API to upgrade the generator for. If not specified, the
-                   generator will be upgraded for all APIs.             [string]
-  --include-major  Whether or not to include major versions within the upgrade.
-                   Defaults to false, meaning major versions will be skipped.
-                                                      [boolean] [default: false]
-  --channel                                                [choices: "GA", "RC"]
-  --list           When specified, a list of available upgrades will be
-                   displayed, but no upgrade will be taken.
+      --generator      The type of generator to upgrade, ex:
+                       \`fern-typescript-node-sdk\`.                      [string]
+      --group          The group in which the generator is located, if group is
+                       not specified, the all generators of the specified type
+                       will be upgraded.                                [string]
+      --api            The API to upgrade the generator for. If not specified,
+                       the generator will be upgraded for all APIs.     [string]
+  -y, --yes            Automatically answer yes to any prompts that may appear
+                       during the upgrade process.    [boolean] [default: false]
+      --include-major  Whether or not to include major versions within the
+                       upgrade. Defaults to false, meaning major versions will
+                       be skipped.                    [boolean] [default: false]
+      --channel                                            [choices: "GA", "RC"]
+      --list           When specified, a list of available upgrades will be
+                       displayed, but no upgrade will be taken.
                                                       [boolean] [default: false]"
 `;


### PR DESCRIPTION

## Description
Linear ticket: contributes to FER-7979 
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
<!-- Provide a clear and concise description of the changes made in this PR -->
The intention here is to make it eaiser to script migration bumps against docs-starter
## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Create a `-y` / `--yes` flag that skips confirmations for migrations
- Skips std based confirmation when present 
- add tests

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated
- [x] Manual testing completed
