### PR TITLE
fix(ruby): fix README.md not being generated for GitHub and direct publish modes in ruby-v2

### DIFF
--- a/generators/ruby-v2/sdk/src/SdkGeneratorCli.ts
+++ b/generators/ruby-v2/sdk/src/SdkGeneratorCli.ts
@@ -188,6 +188,9 @@ export class SdkGeneratorCLI extends AbstractRubyGeneratorCli<SdkCustomConfigSch
                 return publishConfig.generateFullProject || hasSnippetFilepath;
             case "github":
             case "direct":
+                // For GitHub/self-hosted or direct publish, we're generating a real SDK;
+                // README should always be present regardless of snippetFilepath.
+                return true;
             default:
                 return hasSnippetFilepath;
         }

--- a/generators/ruby-v2/sdk/versions.yml
+++ b/generators/ruby-v2/sdk/versions.yml
@@ -1,5 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.0.0-rc63
+  createdAt: "2025-12-10"
+  changelogEntry:
+    - type: fix
+      summary: |
+        Fix README.md not being generated for GitHub and direct publish modes.
+        The shouldGenerateReadme method was incorrectly requiring snippetFilepath to be set
+        for GitHub and direct publish configs. README generation now always occurs for these
+        output modes when generating a full SDK.
+  irVersion: 61
+
 - version: 1.0.0-rc62
   createdAt: "2025-12-08"
   changelogEntry:

--- a/generators/ruby-v2/sdk/versions.yml
+++ b/generators/ruby-v2/sdk/versions.yml
@@ -9,6 +9,12 @@
         The shouldGenerateReadme method was incorrectly requiring snippetFilepath to be set
         for GitHub and direct publish configs. README generation now always occurs for these
         output modes when generating a full SDK.
+    - type: fix
+      summary: |
+        Fix snippet generation to use auto-generated examples when no explicit examples are defined.
+        Previously, generateSnippets only looked at explicit examples in the dynamic IR, causing
+        empty snippet.json files for APIs without user-specified examples. Now it uses the same
+        approach as reference.md generation, falling back to auto-generated examples.
   irVersion: 61
 
 - version: 1.0.0-rc62


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of the changes made in this PR -->

Fixes two issues preventing README.md from being generated for ruby-v2 SDK generation:

1. **`shouldGenerateReadme` logic**: The method was incorrectly falling through to the `default` case for `github` and `direct` publish configs, which required `snippetFilepath` to be set. For full SDK generation to GitHub repos, README should always be generated.

2. **`generateSnippets` using only explicit examples**: The method only looked at explicit examples in the dynamic IR (`dynamicIr.endpoints[].examples`), causing empty `snippet.json` files for APIs without user-specified examples. Now it uses the same approach as `reference.md` generation, falling back to auto-generated examples via `maybeGetExampleEndpointCall`.

Link to Devin run: https://app.devin.ai/sessions/0082254d6fa2426db8fac4be437d7ba7
Requested by: naman.anand@buildwithfern.com (@iamnamananand996)

## Changes Made
- Modified `shouldGenerateReadme` in `SdkGeneratorCli.ts` to return `true` for `github` and `direct` publish modes
- Rewrote `generateSnippets` to iterate over `context.ir.services` and use `maybeGetExampleEndpointCall` for auto-generated example fallback
- Removed unused imports (`DynamicSnippetsGenerator`, `convertDynamicEndpointSnippetRequest`, `convertIr`)
- Added version bump to `1.0.0-rc63` with two changelog entries

## Human Review Checklist
- [ ] Verify the `shouldGenerateReadme` logic change is correct - should GitHub/direct modes always generate README?
- [ ] Verify path construction change: `endpoint.location.path` → `endpoint.path.head` is correct
- [ ] Verify method access change: `endpoint.location.method` → `endpoint.method` is correct
- [ ] Verify snippet content source: using `singleEndpointSnippet.endpointCall` instead of `dynamicSnippetsGenerator.generateSync()` produces equivalent output
- [ ] Consider if `go-v2` should have the same fixes applied (it has similar `shouldGenerateReadme` and `generateSnippets` logic)
- [ ] Note: README content still depends on having endpoint snippets - if no snippets are produced, README generation is skipped (existing behavior at line 203-205)

## Testing
- [x] Lint checks passed (`pnpm run check`)
- [x] Seed tests run for `ruby-sdk-v2` imdb fixture - snippets are now generated (2 snippets produced)
- [ ] Manual testing completed
- [ ] Unit tests added/updated

Note: README.md file is not created in seed tests due to a generator-cli authentication error when trying to clone a non-existent GitHub repo (`github.com/NONE`). This is a seed test environment limitation, not a code issue. The logs show "Has snippets length: 2" confirming snippets are being generated correctly.