### PR TITLE
fix(typescript): dynamically calculate expected hasNextPage in pagination tests

### DIFF
--- a/generators/typescript/sdk/generator/src/test-generator/TestGenerator.ts
+++ b/generators/typescript/sdk/generator/src/test-generator/TestGenerator.ts
@@ -1823,7 +1823,8 @@ function getPropertyValueFromJson({ json, property }: { json: unknown; property:
             if (current == null || typeof current !== "object") {
                 return undefined;
             }
-            current = (current as Record<string, unknown>)[pathItem.name.wireValue];
+            // Use originalName for Name types (wire format for nested path segments)
+            current = (current as Record<string, unknown>)[pathItem.name.originalName];
         }
     }
 
@@ -1831,6 +1832,7 @@ function getPropertyValueFromJson({ json, property }: { json: unknown; property:
     if (current == null || typeof current !== "object") {
         return undefined;
     }
+    // Use wireValue for NameAndWireValue types (the actual wire name)
     return (current as Record<string, unknown>)[property.property.name.wireValue];
 }
 
@@ -1850,7 +1852,8 @@ function getRequestPropertyValueFromJson({ json, property }: { json: unknown; pr
             if (current == null || typeof current !== "object") {
                 return undefined;
             }
-            current = (current as Record<string, unknown>)[pathItem.name.wireValue];
+            // Use originalName for Name types (wire format for nested path segments)
+            current = (current as Record<string, unknown>)[pathItem.name.originalName];
         }
     }
 
@@ -1858,6 +1861,7 @@ function getRequestPropertyValueFromJson({ json, property }: { json: unknown; pr
     if (current == null || typeof current !== "object") {
         return undefined;
     }
+    // Use wireValue for NameAndWireValue types (the actual wire name)
     return (current as Record<string, unknown>)[property.property.name.wireValue];
 }
 

--- a/generators/typescript/sdk/generator/src/test-generator/TestGenerator.ts
+++ b/generators/typescript/sdk/generator/src/test-generator/TestGenerator.ts
@@ -1908,18 +1908,21 @@ function calculateExpectedHasNextPage({
 
             const resultsLength = resultsValue.length;
 
-            // If step is defined, check if results.length >= step
+            // If step is defined, try to get the step value from the request
             if (pagination.step != null) {
                 const stepValue = getRequestPropertyValueFromJson({
                     json: requestJson,
                     property: pagination.step
                 });
-                // Use the step value from request, or default to 100 if not provided
-                const step = typeof stepValue === "number" ? stepValue : 100;
-                return resultsLength >= Math.floor(step);
+                // Only use the step comparison if we can actually find the step value
+                // (step may be in query params which aren't in jsonExample for GET requests)
+                if (typeof stepValue === "number") {
+                    return resultsLength >= Math.floor(stepValue);
+                }
             }
 
-            // Fallback: check if results.length > 0
+            // Fallback: if we can't determine the step value, use resultsLength > 0
+            // This matches the SDK's behavior when there are results
             return resultsLength > 0;
         }
         case "custom":

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,17 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.39.1
+  changelogEntry:
+    - summary: |
+        Fix wire test generator to dynamically calculate expected `hasNextPage()` value based on pagination type and example data.
+        Previously, the test generator hardcoded `expect(page.hasNextPage()).toBe(true)` for all pagination tests, which caused
+        test failures when the mock response contained fewer items than the requested limit.
+        Now the expected value is calculated based on:
+        - Cursor pagination: `hasNextPage` is true when the `next` property is non-null and non-empty
+        - Offset pagination: `hasNextPage` is true when `results.length >= step` (or `> 0` if no step is defined)
+      type: fix
+  createdAt: "2025-12-10"
+  irVersion: 62
+
 - version: 3.39.0
   changelogEntry:
     - summary: |

--- a/seed/ts-sdk/pagination/no-custom-config/reference.md
+++ b/seed/ts-sdk/pagination/no-custom-config/reference.md
@@ -919,10 +919,7 @@ const response = page.response;
 
 ```typescript
 const pageableResponse = await client.users.listWithCursorPagination({
-    page: 1,
-    per_page: 1,
-    order: "asc",
-    starting_after: "starting_after"
+    starting_after: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"
 });
 for await (const item of pageableResponse) {
     console.log(item);
@@ -930,10 +927,7 @@ for await (const item of pageableResponse) {
 
 // Or you can manually iterate page-by-page
 let page = await client.users.listWithCursorPagination({
-    page: 1,
-    per_page: 1,
-    order: "asc",
-    starting_after: "starting_after"
+    starting_after: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"
 });
 while (page.hasNextPage()) {
     page = page.getNextPage();

--- a/seed/ts-sdk/pagination/no-custom-config/snippet.json
+++ b/seed/ts-sdk/pagination/no-custom-config/snippet.json
@@ -151,8 +151,9 @@
             },
             "snippet": {
                 "type": "typescript",
-                "client": "import { SeedPaginationClient } from \"@fern/pagination\";\n\nconst client = new SeedPaginationClient({ environment: \"YOUR_BASE_URL\", token: \"YOUR_TOKEN\" });\nconst pageableResponse = await client.users.listWithCursorPagination({\n    page: 1,\n    per_page: 1,\n    order: \"asc\",\n    starting_after: \"starting_after\"\n});\nfor await (const item of pageableResponse) {\n    console.log(item);\n}\n\n// Or you can manually iterate page-by-page\nlet page = await client.users.listWithCursorPagination({\n    page: 1,\n    per_page: 1,\n    order: \"asc\",\n    starting_after: \"starting_after\"\n});\nwhile (page.hasNextPage()) {\n    page = page.getNextPage();\n}\n\n// You can also access the underlying response\nconst response = page.response;\n"
-            }
+                "client": "import { SeedPaginationClient } from \"@fern/pagination\";\n\nconst client = new SeedPaginationClient({ environment: \"YOUR_BASE_URL\", token: \"YOUR_TOKEN\" });\nconst pageableResponse = await client.users.listWithCursorPagination({\n    starting_after: \"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32\"\n});\nfor await (const item of pageableResponse) {\n    console.log(item);\n}\n\n// Or you can manually iterate page-by-page\nlet page = await client.users.listWithCursorPagination({\n    starting_after: \"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32\"\n});\nwhile (page.hasNextPage()) {\n    page = page.getNextPage();\n}\n\n// You can also access the underlying response\nconst response = page.response;\n"
+            },
+            "example_identifier": "Last page"
         },
         {
             "id": {

--- a/seed/ts-sdk/pagination/no-custom-config/src/api/resources/users/client/Client.ts
+++ b/seed/ts-sdk/pagination/no-custom-config/src/api/resources/users/client/Client.ts
@@ -27,10 +27,7 @@ export class UsersClient {
      *
      * @example
      *     await client.users.listWithCursorPagination({
-     *         page: 1,
-     *         per_page: 1,
-     *         order: "asc",
-     *         starting_after: "starting_after"
+     *         starting_after: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"
      *     })
      */
     public async listWithCursorPagination(

--- a/seed/ts-sdk/pagination/no-custom-config/src/api/resources/users/client/requests/ListUsersCursorPaginationRequest.ts
+++ b/seed/ts-sdk/pagination/no-custom-config/src/api/resources/users/client/requests/ListUsersCursorPaginationRequest.ts
@@ -5,10 +5,7 @@ import type * as SeedPagination from "../../../../index.js";
 /**
  * @example
  *     {
- *         page: 1,
- *         per_page: 1,
- *         order: "asc",
- *         starting_after: "starting_after"
+ *         starting_after: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"
  *     }
  */
 export interface ListUsersCursorPaginationRequest {

--- a/seed/ts-sdk/pagination/no-custom-config/tests/wire/users.test.ts
+++ b/seed/ts-sdk/pagination/no-custom-config/tests/wire/users.test.ts
@@ -9,13 +9,10 @@ describe("UsersClient", () => {
         const client = new SeedPaginationClient({ maxRetries: 0, token: "test", environment: server.baseUrl });
 
         const rawResponseBody = {
-            hasNextPage: true,
-            page: { page: 1, next: { page: 1, starting_after: "starting_after" }, per_page: 1, total_page: 1 },
+            hasNextPage: false,
+            page: { page: 1, per_page: 1, total_page: 1 },
             total_count: 1,
-            data: [
-                { name: "name", id: 1 },
-                { name: "name", id: 1 },
-            ],
+            data: [{ name: "user", id: 1 }],
         };
         server
             .mockEndpoint({ once: false })
@@ -26,37 +23,26 @@ describe("UsersClient", () => {
             .build();
 
         const expected = {
-            hasNextPage: true,
+            hasNextPage: false,
             page: {
                 page: 1,
-                next: {
-                    page: 1,
-                    starting_after: "starting_after",
-                },
                 per_page: 1,
                 total_page: 1,
             },
             total_count: 1,
             data: [
                 {
-                    name: "name",
-                    id: 1,
-                },
-                {
-                    name: "name",
+                    name: "user",
                     id: 1,
                 },
             ],
         };
         const page = await client.users.listWithCursorPagination({
-            page: 1,
-            per_page: 1,
-            order: "asc",
-            starting_after: "starting_after",
+            starting_after: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
         });
 
         expect(expected.data).toEqual(page.data);
-        expect(page.hasNextPage()).toBe(true);
+        expect(page.hasNextPage()).toBe(false);
         const nextPage = await page.getNextPage();
         expect(expected.data).toEqual(nextPage.data);
     });

--- a/seed/ts-sdk/pagination/page-index-semantics/reference.md
+++ b/seed/ts-sdk/pagination/page-index-semantics/reference.md
@@ -919,10 +919,7 @@ const response = page.response;
 
 ```typescript
 const pageableResponse = await client.users.listWithCursorPagination({
-    page: 1,
-    per_page: 1,
-    order: "asc",
-    starting_after: "starting_after"
+    starting_after: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"
 });
 for await (const item of pageableResponse) {
     console.log(item);
@@ -930,10 +927,7 @@ for await (const item of pageableResponse) {
 
 // Or you can manually iterate page-by-page
 let page = await client.users.listWithCursorPagination({
-    page: 1,
-    per_page: 1,
-    order: "asc",
-    starting_after: "starting_after"
+    starting_after: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"
 });
 while (page.hasNextPage()) {
     page = page.getNextPage();

--- a/seed/ts-sdk/pagination/page-index-semantics/snippet.json
+++ b/seed/ts-sdk/pagination/page-index-semantics/snippet.json
@@ -151,8 +151,9 @@
             },
             "snippet": {
                 "type": "typescript",
-                "client": "import { SeedPaginationClient } from \"@fern/pagination\";\n\nconst client = new SeedPaginationClient({ environment: \"YOUR_BASE_URL\", token: \"YOUR_TOKEN\" });\nconst pageableResponse = await client.users.listWithCursorPagination({\n    page: 1,\n    per_page: 1,\n    order: \"asc\",\n    starting_after: \"starting_after\"\n});\nfor await (const item of pageableResponse) {\n    console.log(item);\n}\n\n// Or you can manually iterate page-by-page\nlet page = await client.users.listWithCursorPagination({\n    page: 1,\n    per_page: 1,\n    order: \"asc\",\n    starting_after: \"starting_after\"\n});\nwhile (page.hasNextPage()) {\n    page = page.getNextPage();\n}\n\n// You can also access the underlying response\nconst response = page.response;\n"
-            }
+                "client": "import { SeedPaginationClient } from \"@fern/pagination\";\n\nconst client = new SeedPaginationClient({ environment: \"YOUR_BASE_URL\", token: \"YOUR_TOKEN\" });\nconst pageableResponse = await client.users.listWithCursorPagination({\n    starting_after: \"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32\"\n});\nfor await (const item of pageableResponse) {\n    console.log(item);\n}\n\n// Or you can manually iterate page-by-page\nlet page = await client.users.listWithCursorPagination({\n    starting_after: \"d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32\"\n});\nwhile (page.hasNextPage()) {\n    page = page.getNextPage();\n}\n\n// You can also access the underlying response\nconst response = page.response;\n"
+            },
+            "example_identifier": "Last page"
         },
         {
             "id": {

--- a/seed/ts-sdk/pagination/page-index-semantics/src/api/resources/users/client/Client.ts
+++ b/seed/ts-sdk/pagination/page-index-semantics/src/api/resources/users/client/Client.ts
@@ -27,10 +27,7 @@ export class UsersClient {
      *
      * @example
      *     await client.users.listWithCursorPagination({
-     *         page: 1,
-     *         per_page: 1,
-     *         order: "asc",
-     *         starting_after: "starting_after"
+     *         starting_after: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"
      *     })
      */
     public async listWithCursorPagination(

--- a/seed/ts-sdk/pagination/page-index-semantics/src/api/resources/users/client/requests/ListUsersCursorPaginationRequest.ts
+++ b/seed/ts-sdk/pagination/page-index-semantics/src/api/resources/users/client/requests/ListUsersCursorPaginationRequest.ts
@@ -5,10 +5,7 @@ import type * as SeedPagination from "../../../../index.js";
 /**
  * @example
  *     {
- *         page: 1,
- *         per_page: 1,
- *         order: "asc",
- *         starting_after: "starting_after"
+ *         starting_after: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"
  *     }
  */
 export interface ListUsersCursorPaginationRequest {

--- a/seed/ts-sdk/pagination/page-index-semantics/tests/wire/users.test.ts
+++ b/seed/ts-sdk/pagination/page-index-semantics/tests/wire/users.test.ts
@@ -9,13 +9,10 @@ describe("UsersClient", () => {
         const client = new SeedPaginationClient({ maxRetries: 0, token: "test", environment: server.baseUrl });
 
         const rawResponseBody = {
-            hasNextPage: true,
-            page: { page: 1, next: { page: 1, starting_after: "starting_after" }, per_page: 1, total_page: 1 },
+            hasNextPage: false,
+            page: { page: 1, per_page: 1, total_page: 1 },
             total_count: 1,
-            data: [
-                { name: "name", id: 1 },
-                { name: "name", id: 1 },
-            ],
+            data: [{ name: "user", id: 1 }],
         };
         server
             .mockEndpoint({ once: false })
@@ -26,37 +23,26 @@ describe("UsersClient", () => {
             .build();
 
         const expected = {
-            hasNextPage: true,
+            hasNextPage: false,
             page: {
                 page: 1,
-                next: {
-                    page: 1,
-                    starting_after: "starting_after",
-                },
                 per_page: 1,
                 total_page: 1,
             },
             total_count: 1,
             data: [
                 {
-                    name: "name",
-                    id: 1,
-                },
-                {
-                    name: "name",
+                    name: "user",
                     id: 1,
                 },
             ],
         };
         const page = await client.users.listWithCursorPagination({
-            page: 1,
-            per_page: 1,
-            order: "asc",
-            starting_after: "starting_after",
+            starting_after: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
         });
 
         expect(expected.data).toEqual(page.data);
-        expect(page.hasNextPage()).toBe(true);
+        expect(page.hasNextPage()).toBe(false);
         const nextPage = await page.getNextPage();
         expect(expected.data).toEqual(nextPage.data);
     });

--- a/test-definitions/fern/apis/pagination/definition/users.yml
+++ b/test-definitions/fern/apis/pagination/definition/users.yml
@@ -113,6 +113,21 @@ service:
               The cursor used for pagination in order to fetch
               the next page of results.
       response: ListUsersPaginationResponse
+      examples:
+        - name: Last page
+          query-parameters:
+            starting_after: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"
+          response:
+            body:
+              hasNextPage: false
+              page:
+                page: 1
+                per_page: 1
+                total_page: 1
+              total_count: 1
+              data:
+                - name: "user"
+                  id: 1
 
     listWithMixedTypeCursorPagination:
       pagination:


### PR DESCRIPTION
## Description

Refs: Slack thread from @tstanmay13

Fixes the TypeScript SDK's wire test generator to dynamically calculate the expected `hasNextPage()` value based on pagination type and example data, instead of hardcoding `true`.

**Link to Devin run:** https://app.devin.ai/sessions/6353b685386f4bfd821c4daa4196ef35
**Requested by:** tanmay.singh@buildwithfern.com (@tstanmay13)

## Changes Made

- Added helper functions to extract property values from JSON examples using the IR's property path definitions:
  - `getPropertyValueFromJson()` for response properties
  - `getRequestPropertyValueFromJson()` for request properties
- Added `calculateExpectedHasNextPage()` function that mirrors the SDK's actual pagination logic:
  - **Cursor pagination**: returns `true` when `next` property is non-null and non-empty string
  - **Offset pagination**: returns `true` when `results.length >= step`, or falls back to `results.length > 0` when step value can't be extracted (e.g., GET requests with query params)
- Updated pagination test block to use the calculated value instead of hardcoded `true`
- Added version 3.39.1 to versions.yml with changelog entry
- Added "Last page" example to `listWithCursorPagination` endpoint in pagination test definition to verify `hasNextPage: false` case
- Regenerated seed test fixtures for pagination

## Testing

- [x] Lint checks pass (`pnpm run check`)
- [x] TypeScript compilation passes
- [x] Local seed tests pass for pagination fixtures
- [x] Generated test correctly expects `hasNextPage().toBe(false)` for the new "Last page" example

## Human Review Checklist

- [ ] Verify the pagination logic in `calculateExpectedHasNextPage()` matches the SDK's actual implementation
- [ ] Confirm the fallback to `resultsLength > 0` when step value can't be extracted is acceptable (this happens for GET requests where limit/step is a query param, not in the request body)
- [ ] Check that property path traversal correctly uses `originalName` for `Name` types and `wireValue` for `NameAndWireValue` types

## CI Notes

Two CI failures are unrelated to this PR:
- `java-model`: TypeScript errors in `RustFilenameRegistry.ts` (Rust generator)
- `test`: `SourceFetcher.test.ts` errors in browser-compatible-base