### PR TITLE
feat(go): Add OAuth token fetching support

### DIFF
--- a/generators/go-v2/sdk/src/client/ClientGenerator.ts
+++ b/generators/go-v2/sdk/src/client/ClientGenerator.ts
@@ -418,12 +418,14 @@ export class ClientGenerator extends FileGenerator<GoFile, SdkCustomConfigSchema
                 // Fetch a new token from the auth endpoint
                 // Get the request type reference from the endpoint
                 const serviceId = oauthScheme.configuration.tokenEndpoint.endpointReference.serviceId;
-                const requestWrapperName = tokenEndpoint.sdkRequest?.shape.type === "wrapper" 
-                    ? tokenEndpoint.sdkRequest.shape.wrapperName 
-                    : tokenEndpoint.sdkRequest?.requestParameterName;
-                const requestTypeRef = requestWrapperName != null 
-                    ? this.context.getRequestWrapperTypeReference(serviceId, requestWrapperName)
-                    : go.typeReference({ name: "GetTokenRequest", importPath: this.context.getRootImportPath() });
+                const requestWrapperName =
+                    tokenEndpoint.sdkRequest?.shape.type === "wrapper"
+                        ? tokenEndpoint.sdkRequest.shape.wrapperName
+                        : tokenEndpoint.sdkRequest?.requestParameterName;
+                const requestTypeRef =
+                    requestWrapperName != null
+                        ? this.context.getRequestWrapperTypeReference(serviceId, requestWrapperName)
+                        : go.typeReference({ name: "GetTokenRequest", importPath: this.context.getRootImportPath() });
                 w.write(`response, err := authClient.${methodName}(`);
                 w.writeNode(
                     go.invokeFunc({
@@ -468,7 +470,9 @@ export class ClientGenerator extends FileGenerator<GoFile, SdkCustomConfigSchema
         return service.endpoints.find((ep) => ep.id === endpointId);
     }
 
-    private getRequestPropertyFieldName(requestProperty: { property: { type: string; name?: { name: Name } } }): string {
+    private getRequestPropertyFieldName(requestProperty: {
+        property: { type: string; name?: { name: Name } };
+    }): string {
         // The property can be either "query" or "body" type
         // Both have a name field that contains the Name object
         if (requestProperty.property.type === "body" && requestProperty.property.name != null) {

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,5 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.19.0
+  changelogEntry:
+    - summary: |
+        Add OAuth token fetching support. The SDK now automatically fetches and caches OAuth tokens
+        using client credentials when configured. Tokens are refreshed automatically when expired.
+      type: feat
+  createdAt: "2025-12-10"
+  irVersion: 60
+
 - version: 1.18.4
   changelogEntry:
     - summary: |

--- a/seed/go-sdk/oauth-client-credentials-custom/README.md
+++ b/seed/go-sdk/oauth-client-credentials-custom/README.md
@@ -9,6 +9,7 @@ The Seed Go library provides convenient access to the Seed APIs from Go.
 - [Reference](#reference)
 - [Usage](#usage)
 - [Environments](#environments)
+- [Oauth](#oauth)
 - [Errors](#errors)
 - [Request Options](#request-options)
 - [Advanced](#advanced)
@@ -31,13 +32,17 @@ package example
 
 import (
     client "github.com/oauth-client-credentials-custom/fern/client"
+    option "github.com/oauth-client-credentials-custom/fern/option"
     fern "github.com/oauth-client-credentials-custom/fern"
     context "context"
 )
 
 func do() {
     client := client.NewClient(
-        nil,
+        option.WithClientCredentials(
+            "<clientId>",
+            "<clientSecret>",
+        ),
     )
     request := &fern.GetTokenRequest{
         Cid: "cid",
@@ -63,6 +68,31 @@ URL, which is particularly useful in test environments.
 ```go
 client := client.NewClient(
     option.WithBaseURL("https://example.com"),
+)
+```
+
+## Oauth
+
+This SDK supports OAuth 2.0 authentication. You have two options for providing credentials:
+
+**Option 1: Client Credentials** - Provide your client ID and secret, and the SDK will automatically handle
+token fetching and refresh:
+
+**Option 2: Direct Token** - If you already have an access token (e.g., obtained through your own OAuth flow),
+you can provide it directly:
+
+```go
+// Option 1: Use client credentials (SDK will handle token fetching and refresh)
+client := client.NewClient(
+    option.WithClientCredentials(
+        "<YOUR_CLIENT_ID>",
+        "<YOUR_CLIENT_SECRET>",
+    ),
+)
+
+// Option 2: Use a pre-fetched token directly
+client := client.NewClient(
+    option.WithToken("<YOUR_ACCESS_TOKEN>"),
 )
 ```
 

--- a/seed/go-sdk/oauth-client-credentials-custom/core/request_option.go
+++ b/seed/go-sdk/oauth-client-credentials-custom/core/request_option.go
@@ -12,6 +12,9 @@ type RequestOption interface {
 	applyRequestOptions(*RequestOptions)
 }
 
+// TokenGetter is a function that returns an access token.
+type TokenGetter func() (string, error)
+
 // RequestOptions defines all of the possible request options.
 //
 // This type is primarily used by the generated code and is not meant
@@ -23,8 +26,10 @@ type RequestOptions struct {
 	BodyProperties  map[string]interface{}
 	QueryParameters url.Values
 	MaxAttempts     uint
+	tokenGetter     TokenGetter
 	ClientID        string
 	ClientSecret    string
+	Token           string
 }
 
 // NewRequestOptions returns a new *RequestOptions value.
@@ -47,6 +52,14 @@ func NewRequestOptions(opts ...RequestOption) *RequestOptions {
 // for the request(s).
 func (r *RequestOptions) ToHeader() http.Header {
 	header := r.cloneHeader()
+	if r.Token != "" {
+		header.Set("Authorization", "Bearer "+r.Token)
+	}
+	if header.Get("Authorization") == "" && r.tokenGetter != nil {
+		if token, err := r.tokenGetter(); err == nil && token != "" {
+			header.Set("Authorization", "Bearer "+token)
+		}
+	}
 	return header
 }
 
@@ -140,4 +153,19 @@ type ClientCredentialsOption struct {
 func (c *ClientCredentialsOption) applyRequestOptions(opts *RequestOptions) {
 	opts.ClientID = c.ClientID
 	opts.ClientSecret = c.ClientSecret
+}
+
+// TokenOption implements the RequestOption interface.
+type TokenOption struct {
+	Token string
+}
+
+func (t *TokenOption) applyRequestOptions(opts *RequestOptions) {
+	opts.Token = t.Token
+}
+
+// SetTokenGetter sets the token getter function for OAuth.
+// This is an internal method and should not be called directly.
+func (r *RequestOptions) SetTokenGetter(getter TokenGetter) {
+	r.tokenGetter = getter
 }

--- a/seed/go-sdk/oauth-client-credentials-custom/dynamic-snippets/example0/snippet.go
+++ b/seed/go-sdk/oauth-client-credentials-custom/dynamic-snippets/example0/snippet.go
@@ -12,7 +12,10 @@ func do() {
         option.WithBaseURL(
             "https://api.fern.com",
         ),
-        nil,
+        option.WithClientCredentials(
+            "<clientId>",
+            "<clientSecret>",
+        ),
     )
     request := &fern.GetTokenRequest{
         Cid: "cid",

--- a/seed/go-sdk/oauth-client-credentials-custom/dynamic-snippets/example1/snippet.go
+++ b/seed/go-sdk/oauth-client-credentials-custom/dynamic-snippets/example1/snippet.go
@@ -12,7 +12,10 @@ func do() {
         option.WithBaseURL(
             "https://api.fern.com",
         ),
-        nil,
+        option.WithClientCredentials(
+            "<clientId>",
+            "<clientSecret>",
+        ),
     )
     request := &fern.RefreshTokenRequest{
         ClientId: "client_id",

--- a/seed/go-sdk/oauth-client-credentials-custom/dynamic-snippets/example2/snippet.go
+++ b/seed/go-sdk/oauth-client-credentials-custom/dynamic-snippets/example2/snippet.go
@@ -11,7 +11,10 @@ func do() {
         option.WithBaseURL(
             "https://api.fern.com",
         ),
-        nil,
+        option.WithClientCredentials(
+            "<clientId>",
+            "<clientSecret>",
+        ),
     )
     client.NestedNoAuth.Api.GetSomething(
         context.TODO(),

--- a/seed/go-sdk/oauth-client-credentials-custom/dynamic-snippets/example3/snippet.go
+++ b/seed/go-sdk/oauth-client-credentials-custom/dynamic-snippets/example3/snippet.go
@@ -11,7 +11,10 @@ func do() {
         option.WithBaseURL(
             "https://api.fern.com",
         ),
-        nil,
+        option.WithClientCredentials(
+            "<clientId>",
+            "<clientSecret>",
+        ),
     )
     client.Nested.Api.GetSomething(
         context.TODO(),

--- a/seed/go-sdk/oauth-client-credentials-custom/dynamic-snippets/example4/snippet.go
+++ b/seed/go-sdk/oauth-client-credentials-custom/dynamic-snippets/example4/snippet.go
@@ -11,7 +11,10 @@ func do() {
         option.WithBaseURL(
             "https://api.fern.com",
         ),
-        nil,
+        option.WithClientCredentials(
+            "<clientId>",
+            "<clientSecret>",
+        ),
     )
     client.Simple.GetSomething(
         context.TODO(),

--- a/seed/go-sdk/oauth-client-credentials-custom/option/request_option.go
+++ b/seed/go-sdk/oauth-client-credentials-custom/option/request_option.go
@@ -84,3 +84,11 @@ func WithClientCredentials(clientID string, clientSecret string) *core.ClientCre
 		ClientSecret: clientSecret,
 	}
 }
+
+// WithToken sets the OAuth token directly, bypassing the client credentials flow.
+// Use this when you already have an access token.
+func WithToken(token string) *core.TokenOption {
+	return &core.TokenOption{
+		Token: token,
+	}
+}

--- a/seed/go-sdk/oauth-client-credentials-default/client/client.go
+++ b/seed/go-sdk/oauth-client-credentials-default/client/client.go
@@ -3,6 +3,8 @@
 package client
 
 import (
+	context "context"
+	fern "github.com/oauth-client-credentials-default/fern"
 	auth "github.com/oauth-client-credentials-default/fern/auth"
 	core "github.com/oauth-client-credentials-default/fern/core"
 	internal "github.com/oauth-client-credentials-default/fern/internal"
@@ -25,6 +27,28 @@ type Client struct {
 
 func NewClient(opts ...option.RequestOption) *Client {
 	options := core.NewRequestOptions(opts...)
+	oauthTokenProvider := core.NewOAuthTokenProvider(
+		options.ClientID,
+		options.ClientSecret,
+	)
+	authOptions := *options
+	authClient := auth.NewClient(
+		&authOptions,
+	)
+	options.SetTokenGetter(func() (string, error) {
+		if token := oauthTokenProvider.GetToken(); token != "" {
+			return token, nil
+		}
+		response, err := authClient.GetToken(context.Background(), &fern.GetTokenRequest{
+			ClientId:     options.ClientID,
+			ClientSecret: options.ClientSecret,
+		})
+		if err != nil {
+			return "", err
+		}
+		oauthTokenProvider.SetToken(response.AccessToken, response.ExpiresIn)
+		return response.AccessToken, nil
+	})
 	return &Client{
 		Auth:         auth.NewClient(options),
 		NestedNoAuth: client.NewClient(options),

--- a/seed/go-sdk/oauth-client-credentials-default/dynamic-snippets/example0/snippet.go
+++ b/seed/go-sdk/oauth-client-credentials-default/dynamic-snippets/example0/snippet.go
@@ -12,7 +12,10 @@ func do() {
         option.WithBaseURL(
             "https://api.fern.com",
         ),
-        nil,
+        option.WithClientCredentials(
+            "<clientId>",
+            "<clientSecret>",
+        ),
     )
     request := &fern.GetTokenRequest{
         ClientId: "client_id",

--- a/seed/go-sdk/oauth-client-credentials-default/dynamic-snippets/example1/snippet.go
+++ b/seed/go-sdk/oauth-client-credentials-default/dynamic-snippets/example1/snippet.go
@@ -11,7 +11,10 @@ func do() {
         option.WithBaseURL(
             "https://api.fern.com",
         ),
-        nil,
+        option.WithClientCredentials(
+            "<clientId>",
+            "<clientSecret>",
+        ),
     )
     client.NestedNoAuth.Api.GetSomething(
         context.TODO(),

--- a/seed/go-sdk/oauth-client-credentials-default/dynamic-snippets/example2/snippet.go
+++ b/seed/go-sdk/oauth-client-credentials-default/dynamic-snippets/example2/snippet.go
@@ -11,7 +11,10 @@ func do() {
         option.WithBaseURL(
             "https://api.fern.com",
         ),
-        nil,
+        option.WithClientCredentials(
+            "<clientId>",
+            "<clientSecret>",
+        ),
     )
     client.Nested.Api.GetSomething(
         context.TODO(),

--- a/seed/go-sdk/oauth-client-credentials-default/dynamic-snippets/example3/snippet.go
+++ b/seed/go-sdk/oauth-client-credentials-default/dynamic-snippets/example3/snippet.go
@@ -11,7 +11,10 @@ func do() {
         option.WithBaseURL(
             "https://api.fern.com",
         ),
-        nil,
+        option.WithClientCredentials(
+            "<clientId>",
+            "<clientSecret>",
+        ),
     )
     client.Simple.GetSomething(
         context.TODO(),

--- a/seed/go-sdk/oauth-client-credentials-nested-root/client/client.go
+++ b/seed/go-sdk/oauth-client-credentials-nested-root/client/client.go
@@ -3,6 +3,8 @@
 package client
 
 import (
+	context "context"
+	auth "github.com/oauth-client-credentials-nested-root/fern/auth"
 	client "github.com/oauth-client-credentials-nested-root/fern/auth/client"
 	core "github.com/oauth-client-credentials-nested-root/fern/core"
 	internal "github.com/oauth-client-credentials-nested-root/fern/internal"
@@ -25,6 +27,28 @@ type Client struct {
 
 func NewClient(opts ...option.RequestOption) *Client {
 	options := core.NewRequestOptions(opts...)
+	oauthTokenProvider := core.NewOAuthTokenProvider(
+		options.ClientID,
+		options.ClientSecret,
+	)
+	authOptions := *options
+	authClient := client.NewClient(
+		&authOptions,
+	)
+	options.SetTokenGetter(func() (string, error) {
+		if token := oauthTokenProvider.GetToken(); token != "" {
+			return token, nil
+		}
+		response, err := authClient.GetToken(context.Background(), &auth.GetTokenRequest{
+			ClientId:     options.ClientID,
+			ClientSecret: options.ClientSecret,
+		})
+		if err != nil {
+			return "", err
+		}
+		oauthTokenProvider.SetToken(response.AccessToken, response.ExpiresIn)
+		return response.AccessToken, nil
+	})
 	return &Client{
 		Auth:         client.NewClient(options),
 		NestedNoAuth: nestednoauthclient.NewClient(options),

--- a/seed/go-sdk/oauth-client-credentials-nested-root/dynamic-snippets/example0/snippet.go
+++ b/seed/go-sdk/oauth-client-credentials-nested-root/dynamic-snippets/example0/snippet.go
@@ -13,7 +13,10 @@ func do() {
         option.WithBaseURL(
             "https://api.fern.com",
         ),
-        nil,
+        option.WithClientCredentials(
+            "<clientId>",
+            "<clientSecret>",
+        ),
     )
     request := &auth.GetTokenRequest{
         ClientId: "client_id",

--- a/seed/go-sdk/oauth-client-credentials-nested-root/dynamic-snippets/example1/snippet.go
+++ b/seed/go-sdk/oauth-client-credentials-nested-root/dynamic-snippets/example1/snippet.go
@@ -11,7 +11,10 @@ func do() {
         option.WithBaseURL(
             "https://api.fern.com",
         ),
-        nil,
+        option.WithClientCredentials(
+            "<clientId>",
+            "<clientSecret>",
+        ),
     )
     client.NestedNoAuth.Api.GetSomething(
         context.TODO(),

--- a/seed/go-sdk/oauth-client-credentials-nested-root/dynamic-snippets/example2/snippet.go
+++ b/seed/go-sdk/oauth-client-credentials-nested-root/dynamic-snippets/example2/snippet.go
@@ -11,7 +11,10 @@ func do() {
         option.WithBaseURL(
             "https://api.fern.com",
         ),
-        nil,
+        option.WithClientCredentials(
+            "<clientId>",
+            "<clientSecret>",
+        ),
     )
     client.Nested.Api.GetSomething(
         context.TODO(),

--- a/seed/go-sdk/oauth-client-credentials-nested-root/dynamic-snippets/example3/snippet.go
+++ b/seed/go-sdk/oauth-client-credentials-nested-root/dynamic-snippets/example3/snippet.go
@@ -11,7 +11,10 @@ func do() {
         option.WithBaseURL(
             "https://api.fern.com",
         ),
-        nil,
+        option.WithClientCredentials(
+            "<clientId>",
+            "<clientSecret>",
+        ),
     )
     client.Simple.GetSomething(
         context.TODO(),

--- a/seed/go-sdk/oauth-client-credentials/client/client.go
+++ b/seed/go-sdk/oauth-client-credentials/client/client.go
@@ -31,11 +31,9 @@ func NewClient(opts ...option.RequestOption) *Client {
 		options.ClientID,
 		options.ClientSecret,
 	)
-	authOptions := core.NewRequestOptions()
-	authOptions.BaseURL = options.BaseURL
-	authOptions.HTTPClient = options.HTTPClient
+	authOptions := *options
 	authClient := auth.NewClient(
-		authOptions,
+		&authOptions,
 	)
 	options.SetTokenGetter(func() (string, error) {
 		if token := oauthTokenProvider.GetToken(); token != "" {

--- a/seed/go-sdk/oauth-client-credentials/dynamic-snippets/example0/snippet.go
+++ b/seed/go-sdk/oauth-client-credentials/dynamic-snippets/example0/snippet.go
@@ -12,7 +12,10 @@ func do() {
         option.WithBaseURL(
             "https://api.fern.com",
         ),
-        nil,
+        option.WithClientCredentials(
+            "<clientId>",
+            "<clientSecret>",
+        ),
     )
     request := &fern.GetTokenRequest{
         ClientId: "my_oauth_app_123",

--- a/seed/go-sdk/oauth-client-credentials/dynamic-snippets/example1/snippet.go
+++ b/seed/go-sdk/oauth-client-credentials/dynamic-snippets/example1/snippet.go
@@ -12,7 +12,10 @@ func do() {
         option.WithBaseURL(
             "https://api.fern.com",
         ),
-        nil,
+        option.WithClientCredentials(
+            "<clientId>",
+            "<clientSecret>",
+        ),
     )
     request := &fern.GetTokenRequest{
         ClientId: "client_id",

--- a/seed/go-sdk/oauth-client-credentials/dynamic-snippets/example2/snippet.go
+++ b/seed/go-sdk/oauth-client-credentials/dynamic-snippets/example2/snippet.go
@@ -12,7 +12,10 @@ func do() {
         option.WithBaseURL(
             "https://api.fern.com",
         ),
-        nil,
+        option.WithClientCredentials(
+            "<clientId>",
+            "<clientSecret>",
+        ),
     )
     request := &fern.RefreshTokenRequest{
         ClientId: "my_oauth_app_123",

--- a/seed/go-sdk/oauth-client-credentials/dynamic-snippets/example3/snippet.go
+++ b/seed/go-sdk/oauth-client-credentials/dynamic-snippets/example3/snippet.go
@@ -12,7 +12,10 @@ func do() {
         option.WithBaseURL(
             "https://api.fern.com",
         ),
-        nil,
+        option.WithClientCredentials(
+            "<clientId>",
+            "<clientSecret>",
+        ),
     )
     request := &fern.RefreshTokenRequest{
         ClientId: "client_id",

--- a/seed/go-sdk/oauth-client-credentials/dynamic-snippets/example4/snippet.go
+++ b/seed/go-sdk/oauth-client-credentials/dynamic-snippets/example4/snippet.go
@@ -11,7 +11,10 @@ func do() {
         option.WithBaseURL(
             "https://api.fern.com",
         ),
-        nil,
+        option.WithClientCredentials(
+            "<clientId>",
+            "<clientSecret>",
+        ),
     )
     client.NestedNoAuth.Api.GetSomething(
         context.TODO(),

--- a/seed/go-sdk/oauth-client-credentials/dynamic-snippets/example5/snippet.go
+++ b/seed/go-sdk/oauth-client-credentials/dynamic-snippets/example5/snippet.go
@@ -11,7 +11,10 @@ func do() {
         option.WithBaseURL(
             "https://api.fern.com",
         ),
-        nil,
+        option.WithClientCredentials(
+            "<clientId>",
+            "<clientSecret>",
+        ),
     )
     client.Nested.Api.GetSomething(
         context.TODO(),

--- a/seed/go-sdk/oauth-client-credentials/dynamic-snippets/example6/snippet.go
+++ b/seed/go-sdk/oauth-client-credentials/dynamic-snippets/example6/snippet.go
@@ -11,7 +11,10 @@ func do() {
         option.WithBaseURL(
             "https://api.fern.com",
         ),
-        nil,
+        option.WithClientCredentials(
+            "<clientId>",
+            "<clientSecret>",
+        ),
     )
     client.Simple.GetSomething(
         context.TODO(),


### PR DESCRIPTION
## Description
Refs: Completes OAuth2 support started in #11142

Requested by: @tjb9dc
Link to Devin run: https://app.devin.ai/sessions/a9090504ff1c4a78a8de4a3e6e6ff31f

This PR completes the OAuth2 client credentials flow for the Go SDK by implementing automatic token fetching and caching. When OAuth is configured, the SDK now automatically fetches tokens from the OAuth endpoint and caches them, refreshing when expired by re-exchanging client credentials.

## Changes Made
- Added `TokenGetter` function type and `tokenGetter` field to `RequestOptions` in the Go generator
- Updated `ToHeader()` to call `tokenGetter` if no token is manually set
- Added `SetTokenGetter` method to `RequestOptions` for internal use
- Updated `ClientGenerator.ts` to generate OAuth token fetching setup in root client constructor
- Root client now creates an `OAuthTokenProvider`, a separate auth client (to avoid recursion), and sets up a token getter function
- Added version 1.19.0 entry to versions.yml

## Updates since last revision
Fixed CI failures by extracting endpoint information from IR instead of hardcoding:
- Get method name from endpoint (e.g., `GetToken` vs `GetTokenWithClientCredentials`) instead of hardcoding
- Get request type reference using serviceId and wrapper name from IR
- Get field names from `requestProperties` (e.g., `Cid`/`Csr` for custom fixtures) instead of hardcoding `ClientId`/`ClientSecret`
- Use struct copy pattern (`authOptions := *options`) instead of manual field assignment for cleaner code

All 4 OAuth fixtures now pass: `oauth-client-credentials`, `oauth-client-credentials-default`, `oauth-client-credentials-custom`, `oauth-client-credentials-nested-root`

## Testing
- [x] Seed tests pass for all OAuth fixtures
- [x] Lint checks pass (`pnpm run check`)
- [ ] Unit tests added/updated

## Human Review Checklist
- [ ] Verify the OAuth token fetching logic in `sdk.go` (lines 1159-1189) - this appears to be duplicate/unused code since `ClientGenerator.ts` generates the actual client code
- [ ] Note: This implementation re-exchanges client credentials on expiry. Refresh token support (if configured in IR) is not implemented - confirm if this is acceptable or needs follow-up