### PR TITLE
fix(ruby): union type match

### DIFF
--- a/generators/ruby-v2/base/src/asIs/internal/types/union.Template.rb
+++ b/generators/ruby-v2/base/src/asIs/internal/types/union.Template.rb
@@ -38,6 +38,25 @@ module <%= gem_namespace %>
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when <%= gem_namespace %>::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when <%= gem_namespace %>::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module <%= gem_namespace %>
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/generators/ruby-v2/sdk/versions.yml
+++ b/generators/ruby-v2/sdk/versions.yml
@@ -1,5 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.0.0-rc66
+  createdAt: "2025-12-11"
+  changelogEntry:
+    - type: fix
+      summary: |
+        Fix union type matching for Hash and Array type wrappers. The `type_matches?` method now
+        correctly handles `Internal::Types::Hash` and `Internal::Types::Array` instances by checking
+        if the value is a `::Hash` or `::Array` respectively, instead of using `is_a?` directly on
+        the type wrapper classes.
+  irVersion: 61
+
 - version: 1.0.0-rc65
   createdAt: "2025-12-11"
   changelogEntry:

--- a/seed/ruby-sdk-v2/accept-header/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/accept-header/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/alias-extends/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/alias-extends/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/alias/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/alias/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/any-auth/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/any-auth/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/api-wide-base-path/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/api-wide-base-path/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/audiences/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/audiences/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/basic-auth-environment-variables/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/basic-auth-environment-variables/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/basic-auth/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/basic-auth/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/bearer-token-environment-variable/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/bearer-token-environment-variable/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/bytes-download/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/bytes-download/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/bytes-upload/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/bytes-upload/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/circular-references-advanced/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/circular-references-advanced/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/circular-references/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/circular-references/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/client-side-params/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/client-side-params/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/content-type/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/content-type/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/cross-package-type-names/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/cross-package-type-names/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/empty-clients/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/empty-clients/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/enum/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/enum/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/error-property/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/error-property/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/errors/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/errors/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/examples/no-custom-config/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/examples/no-custom-config/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/examples/readme-config/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/examples/readme-config/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/examples/wire-tests/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/examples/wire-tests/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/extends/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/extends/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/extra-properties/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/extra-properties/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/file-download/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/file-download/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/file-upload-openapi/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/file-upload-openapi/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/file-upload/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/file-upload/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/folders/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/folders/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/header-auth-environment-variable/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/header-auth-environment-variable/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/header-auth/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/header-auth/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/http-head/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/http-head/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/idempotency-headers/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/idempotency-headers/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/imdb/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/imdb/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/inferred-auth-explicit/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-explicit/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/inferred-auth-implicit-no-expiry/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit-no-expiry/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/inferred-auth-implicit/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/license/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/license/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/literal/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/literal/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/literals-unions/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/literals-unions/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/mixed-case/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/mixed-case/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/mixed-file-directory/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/mixed-file-directory/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/multi-line-docs/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/multi-line-docs/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/multi-url-environment-no-default/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/multi-url-environment-no-default/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/multi-url-environment/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/multi-url-environment/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/multiple-request-bodies/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/multiple-request-bodies/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/no-environment/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/no-environment/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/no-retries/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/no-retries/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/nullable-allof-extends/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/nullable-allof-extends/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/nullable-optional/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/nullable-optional/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/nullable-request-body/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/nullable-request-body/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/nullable/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/nullable/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/oauth-client-credentials-custom/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-custom/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/oauth-client-credentials-default/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-default/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/oauth-client-credentials-environment-variables/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-environment-variables/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/oauth-client-credentials-mandatory-auth/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-mandatory-auth/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/oauth-client-credentials-nested-root/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-nested-root/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/oauth-client-credentials-with-variables/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-with-variables/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/oauth-client-credentials/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/object/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/object/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/objects-with-imports/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/objects-with-imports/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/optional/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/optional/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/package-yml/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/package-yml/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/pagination-custom/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/pagination-custom/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/pagination/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/pagination/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/path-parameters/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/path-parameters/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/plain-text/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/plain-text/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/property-access/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/property-access/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/public-object/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/public-object/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/query-parameters-openapi-as-objects/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/query-parameters-openapi-as-objects/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/query-parameters-openapi/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/query-parameters-openapi/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/query-parameters/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/query-parameters/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/request-parameters/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/request-parameters/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/required-nullable/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/required-nullable/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/reserved-keywords/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/reserved-keywords/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/response-property/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/response-property/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/ruby-reserved-word-properties/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/ruby-reserved-word-properties/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/server-sent-event-examples/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/server-sent-event-examples/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/server-sent-events/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/server-sent-events/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/simple-api/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/simple-api/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/simple-fhir/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/simple-fhir/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/single-url-environment-default/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/single-url-environment-default/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/single-url-environment-no-default/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/single-url-environment-no-default/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/streaming-parameter/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/streaming-parameter/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/streaming/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/streaming/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/trace/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/trace/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/undiscriminated-union-with-response-property/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/undiscriminated-union-with-response-property/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/undiscriminated-unions/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/undiscriminated-unions/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/unions-with-local-date/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/unions-with-local-date/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/unions/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/unions/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/unknown/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/unknown/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/url-form-encoded/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/url-form-encoded/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/validation/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/validation/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/variables/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/variables/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/version-no-default/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/version-no-default/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/version/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/version/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/websocket-bearer-auth/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/websocket-bearer-auth/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/websocket-inferred-auth/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/websocket-inferred-auth/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result

--- a/seed/ruby-sdk-v2/websocket/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/websocket/lib/seed/internal/types/union.rb
@@ -38,6 +38,25 @@ module Seed
           !@discriminant.nil?
         end
 
+        # Check if value matches a type, handling type wrapper instances
+        # (Internal::Types::Hash and Internal::Types::Array instances)
+        #
+        # @param value [Object]
+        # @param member_type [Object]
+        # @return [Boolean]
+        private def type_matches?(value, member_type)
+          case member_type
+          when Seed::Internal::Types::Hash
+            value.is_a?(::Hash)
+          when Seed::Internal::Types::Array
+            value.is_a?(::Array)
+          when Class, Module
+            value.is_a?(member_type)
+          else
+            false
+          end
+        end
+
         # Resolves the type of a value to be one of the members
         #
         # @param value [Object]
@@ -53,7 +72,7 @@ module Seed
             # First try exact type matching
             result = members.find do |_key, mem|
               member_type = Utils.unwrap_type(mem)
-              value.is_a?(member_type)
+              type_matches?(value, member_type)
             end&.last&.call
 
             return result if result


### PR DESCRIPTION
## Description

Fixes union type matching for Hash and Array type wrappers in the Ruby v2 SDK generator. Previously, `value.is_a?(member_type)` was called directly on type wrapper instances (`Internal::Types::Hash` and `Internal::Types::Array`), which doesn't work correctly since these are wrapper classes, not the actual `::Hash` or `::Array` types.

## Changes Made

- Added `type_matches?` private method to handle type wrapper instances correctly:
  - For `Internal::Types::Hash` wrappers, checks if value is a `::Hash`
  - For `Internal::Types::Array` wrappers, checks if value is a `::Array`
  - For regular Class/Module types, uses standard `is_a?` check
- Updated `resolve_type` to use the new `type_matches?` method
- Added version entry (1.0.0-rc66) to `generators/ruby-v2/sdk/versions.yml`
- [ ] Updated README.md generator (if applicable)

## Testing

- [x] Seed tests regenerated (100 fixtures updated)
- [ ] Manual testing completed

## Human Review Checklist

- [ ] Verify `type_matches?` handles edge cases correctly (returns `false` for non-Class/Module types)
- [ ] Confirm version.yml entry format is correct

---
Link to Devin run: https://app.devin.ai/sessions/ae47d9d5614d4d149d456fc032dfb6c6
Requested by: naman.anand@buildwithfern.com (@iamnamananand996)