### PR TITLE
fix(go): skip generating error_codes.go when there are conflicting status codes across namespaces

### DIFF
--- a/generators/go-v2/sdk/src/SdkGeneratorContext.ts
+++ b/generators/go-v2/sdk/src/SdkGeneratorContext.ts
@@ -829,6 +829,18 @@ export class SdkGeneratorContext extends AbstractGoGeneratorContext<SdkCustomCon
         return this.ir.selfHosted ?? false;
     }
 
+    public hasConflictingErrorStatusCodes(): boolean {
+        const errors = Object.values(this.ir.errors ?? {});
+        const statusCodes = new Set<number>();
+        for (const errorDeclaration of errors) {
+            if (statusCodes.has(errorDeclaration.statusCode)) {
+                return true;
+            }
+            statusCodes.add(errorDeclaration.statusCode);
+        }
+        return false;
+    }
+
     private needsPaginationHelpers(): boolean {
         for (const service of Object.values(this.ir.services)) {
             for (const endpoint of service.endpoints) {

--- a/generators/go-v2/sdk/src/endpoint/http/HttpEndpointGenerator.ts
+++ b/generators/go-v2/sdk/src/endpoint/http/HttpEndpointGenerator.ts
@@ -297,7 +297,7 @@ export class HttpEndpointGenerator extends AbstractEndpointGenerator {
             { name: "Response", value: go.TypeInstantiation.reference(go.codeblock("&pageResponse")) }
         ];
 
-        if (hasErrorDecoder) {
+        if (hasErrorDecoder && !this.context.hasConflictingErrorStatusCodes()) {
             callParamsFields.push({
                 name: "ErrorDecoder",
                 value: go.TypeInstantiation.reference(

--- a/generators/go-v2/sdk/src/internal/Caller.ts
+++ b/generators/go-v2/sdk/src/internal/Caller.ts
@@ -169,13 +169,14 @@ export class Caller {
             });
         }
         if (args.errorCodes != null) {
+            // When there are conflicting status codes across namespaces, we don't generate the global
+            // ErrorCodes variable. In that case, only use the per-endpoint error codes.
+            const errorDecoderArgs = this.context.hasConflictingErrorStatusCodes()
+                ? [go.TypeInstantiation.reference(args.errorCodes)]
+                : [go.TypeInstantiation.reference(this.context.getErrorCodesVariableReference())];
             arguments_.push({
                 name: "ErrorDecoder",
-                value: go.TypeInstantiation.reference(
-                    this.context.callNewErrorDecoder([
-                        go.TypeInstantiation.reference(this.context.getErrorCodesVariableReference())
-                    ])
-                )
+                value: go.TypeInstantiation.reference(this.context.callNewErrorDecoder(errorDecoderArgs))
             });
         }
         return go.TypeInstantiation.structPointer({

--- a/generators/go-v2/sdk/src/internal/InternalFilesGenerator.ts
+++ b/generators/go-v2/sdk/src/internal/InternalFilesGenerator.ts
@@ -16,8 +16,15 @@ export class InternalFilesGenerator {
     }
 
     private generateErrorFiles(): GoFile[] {
+        // Skip generating the global error_codes.go file if there are conflicting status codes
+        // (e.g., multiple namespaced APIs with the same HTTP status codes like 400, 403, 500).
+        // In this case, per-endpoint error handling will still work correctly, and unhandled
+        // status codes will fall back to core.APIError.
+        if (this.context.hasConflictingErrorStatusCodes()) {
+            return [];
+        }
+
         const errorCodesContent = go.codeblock((writer) => {
-            // Then write the variable
             writer.write("var ErrorCodes ");
             writer.writeNode(this.context.getErrorCodesTypeReference());
             writer.write(" = ");

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,5 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.19.1
+  changelogEntry:
+    - summary: |
+        Fix invalid Go code generation when multiple namespaced APIs have conflicting HTTP status codes.
+        The global error_codes.go file is now skipped when there are duplicate status codes across namespaces,
+        and per-endpoint error handling continues to work correctly.
+      type: fix
+  createdAt: "2025-12-12"
+  irVersion: 60
+
 - version: 1.19.0
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs: Slack thread from @tjb9dc

Fixes invalid Go code generation when multiple namespaced APIs define errors with the same HTTP status codes (e.g., 400, 403, 404, 500). Previously, this would generate a `error_codes.go` file with duplicate map keys, which is invalid Go code.

**Link to Devin run**: https://app.devin.ai/sessions/a2353ec7c0bf41cabc240e42410a92ca
**Requested by**: thomas@buildwithfern.com (@tjb9dc)

## Changes Made

- Added `hasConflictingErrorStatusCodes()` method to `SdkGeneratorContext` to detect duplicate status codes across error declarations
- Skip generating the global `error_codes.go` file when conflicting status codes are detected
- Updated `Caller.ts` to use per-endpoint error codes when global ErrorCodes is unavailable
- Updated `Streamer.ts` to conditionally add ErrorDecoder only when error codes are available
- Updated `HttpEndpointGenerator.ts` to skip ErrorDecoder for custom pagination when conflicts exist
- Added version 1.19.1 changelog entry

## Testing

- [x] Lint checks pass (`pnpm run check`)
- [ ] Unit tests added/updated
- [ ] Seed test fixture for multi-namespace APIs with conflicting error codes

## Human Review Checklist

- [ ] Verify `Streamer.ts` behavior: when conflicts exist and no per-endpoint error codes, no ErrorDecoder is added (different from non-conflicting case where it's always added)
- [ ] Confirm per-endpoint error handling continues to work correctly when global ErrorCodes is skipped
- [ ] Consider whether a seed test fixture should be added to prevent regression