### PR TITLE
feat(go): add errorCodes config option for per-endpoint vs global error handling

### DIFF
--- a/generators/go-v2/ast/src/custom-config/BaseGoCustomConfigSchema.ts
+++ b/generators/go-v2/ast/src/custom-config/BaseGoCustomConfigSchema.ts
@@ -13,6 +13,7 @@ export const baseGoCustomConfigSchema = z.object({
     clientConstructorName: z.string().optional(),
     clientName: z.string().optional(),
     enableExplicitNull: z.boolean().optional(),
+    errorCodes: z.enum(["per-endpoint", "global"]).optional(),
     exportedClientName: z.string().optional(),
     includeLegacyClientOptions: z.boolean().optional(),
     inlinePathParameters: z.boolean().optional(),

--- a/generators/go-v2/sdk/src/endpoint/http/HttpEndpointGenerator.ts
+++ b/generators/go-v2/sdk/src/endpoint/http/HttpEndpointGenerator.ts
@@ -111,6 +111,10 @@ export class HttpEndpointGenerator extends AbstractEndpointGenerator {
         return this.generateDelegatingEndpointBody({ endpoint, signature, subpackage });
     }
 
+    private isPerEndpointErrorCodes(): boolean {
+        return this.context.customConfig.errorCodes === "per-endpoint";
+    }
+
     private getStreamingEndpointBody({
         signature,
         endpoint,
@@ -131,7 +135,7 @@ export class HttpEndpointGenerator extends AbstractEndpointGenerator {
                     signature,
                     endpoint,
                     subpackage,
-                    errorDecoder: undefined, // Do not need to build the error decoder here since its built globally for all endpoint errors
+                    errorDecoder: this.isPerEndpointErrorCodes() ? errorDecoder : undefined,
                     rawClient: false
                 })
             );
@@ -186,7 +190,7 @@ export class HttpEndpointGenerator extends AbstractEndpointGenerator {
                     signature,
                     endpoint,
                     subpackage,
-                    errorDecoder: undefined, // Do not need to build the error decoder here since its built globally for all endpoint errors
+                    errorDecoder: this.isPerEndpointErrorCodes() ? errorDecoder : undefined,
                     rawClient: false,
                     encodeQuery: false
                 })
@@ -464,7 +468,7 @@ export class HttpEndpointGenerator extends AbstractEndpointGenerator {
                     signature,
                     endpoint,
                     subpackage,
-                    errorDecoder: undefined, // Do not need to build the error decoder here since its built globally for all endpoint errors
+                    errorDecoder: this.isPerEndpointErrorCodes() ? errorDecoder : undefined,
                     rawClient: true
                 })
             );

--- a/generators/go-v2/sdk/src/internal/InternalFilesGenerator.ts
+++ b/generators/go-v2/sdk/src/internal/InternalFilesGenerator.ts
@@ -11,6 +11,10 @@ export class InternalFilesGenerator {
     }
 
     public generate(): GoFile[] {
+        // Skip error_codes.go generation when using per-endpoint error codes
+        if (this.context.customConfig.errorCodes === "per-endpoint") {
+            return [];
+        }
         const errorFiles = this.generateErrorFiles();
         return [...errorFiles];
     }

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,5 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.20.0
+  changelogEntry:
+    - summary: |
+        Add `errorCodes` config option with values `per-endpoint` or `global`. The `global` mode (default)
+        generates a shared `error_codes.go` file for all errors. The `per-endpoint` mode generates error
+        handling code inline for each endpoint, which is more robust for namespaced APIs or APIs where
+        different endpoints have different error schemas for the same status code.
+      type: feat
+  createdAt: "2025-12-12"
+  irVersion: 60
+
 - version: 1.19.0
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description
Refs FER-6493

This PR adds a new `errorCodes` configuration option to the Go SDK generator that allows users to choose between two error handling strategies:
- `global` (default): Generates a shared `error_codes.go` file with all errors (current behavior from PR #9594)
- `per-endpoint`: Generates error handling code inline for each endpoint (pre-PR #9594 behavior)

The `per-endpoint` mode is more robust for:
1. Namespaced APIs where different namespaces may have different error types for the same status code
2. APIs where different endpoints have different error schemas for the same response code

**Note:** This feature flag only affects the Go v2 generator (TypeScript-based). The Go v1 generator (Go-based) already uses per-endpoint error handling by default and is unaffected.

Link to Devin run: https://app.devin.ai/sessions/00c65371d91b400ca34ba51b42e1793b
Requested by: thomas@buildwithfern.com (@tjb9dc)

## Changes Made
- Added `errorCodes` config option to `BaseGoCustomConfigSchema.ts` with values `"per-endpoint"` or `"global"`
- Added `isPerEndpointErrorCodes()` helper method in `HttpEndpointGenerator.ts`
- Updated `getStreamingEndpointBody`, `getPaginationEndpointBody`, `getRawUnaryEndpointBody` to conditionally pass per-endpoint error decoder
- Updated `getCustomPaginationEndpointBody` to write error decoder inline when in per-endpoint mode
- Updated `buildFetcherFunction` to reference local `errorCodes` variable in per-endpoint mode instead of global `ErrorCodes`
- Updated `InternalFilesGenerator.ts` to skip `error_codes.go` generation when using `per-endpoint` mode
- Added changelog entry for version 1.20.0

## Testing
- [ ] Unit tests added/updated
- [ ] Manual testing completed
- [ ] Seed test fixture added for per-endpoint mode

## Human Review Checklist
- [x] ~~Verify `getCustomPaginationEndpointBody` handles per-endpoint mode correctly~~ (Fixed: now writes error decoder inline before `buildFetcherFunction` call)
- [ ] Consider adding a seed test fixture to validate per-endpoint error handling
- [ ] Verify this implementation matches the pre-PR #9594 behavior when `errorCodes: "per-endpoint"` is set
- [ ] Verify all code paths (streaming, pagination, custom pagination, raw endpoints) correctly handle per-endpoint mode