### PR TITLE
fix(python): use auth-derived bearer token kwarg when instantiating client wrapper

### DIFF
--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,6 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
 
+- version: 4.45.7
+  changelogEntry:
+    - summary: Fix client wrapper instantiation to use the correct bearer token parameter name, preventing incorrect `token=` references when custom auth parameter names are configured.
+      type: fix
+  createdAt: "2025-12-12"
+  irVersion: 61
+
 - version: 4.45.6
   changelogEntry:
     - summary: Fix failing wire tests under `pytest-xdist` by using a single shared WireMock plugin.


### PR DESCRIPTION
## Description
Linear ticket: [FER-8028](https://linear.app/buildwithfern/issue/FER-8028/anduril-token-mismatch-in-client-wrapper-construction) 
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
<!-- Provide a clear and concise description of the changes made in this PR -->
This fixes a bug where the Python SDK generator hardcoded `token=` when constructing `SyncClientWrapper/AsyncClientWrapper`, which breaks SDKs that customize the bearer auth constructor parameter name. The root client generator now derives the correct kwarg name from the auth scheme and uses it consistently for OAuth token override and OAuth token provider wiring.

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Updated `root_client_generator.py` to derive the kwarg name

## Testing
<!-- Describe how you tested these changes -->
- [ ] Unit tests added/updated
- [x] Manual testing completed
