### PR TITLE
fix(python): Fix empty query params stripping existing URL query strings

### DIFF
--- a/generators/python/core_utilities/shared/http_client.py
+++ b/generators/python/core_utilities/shared/http_client.py
@@ -259,6 +259,26 @@ class HttpClient:
 
         data_body = _maybe_filter_none_from_multipart_data(data_body, request_files, force_multipart)
 
+        # Compute encoded params separately to avoid passing empty list to httpx
+        # (httpx strips existing query params from URL when params=[] is passed)
+        _encoded_params = encode_query(
+            jsonable_encoder(
+                remove_none_from_dict(
+                    remove_omit_from_dict(
+                        {
+                            **(params if params is not None else {}),
+                            **(
+                                request_options.get("additional_query_parameters", {}) or {}
+                                if request_options is not None
+                                else {}
+                            ),
+                        },
+                        omit,
+                    )
+                )
+            )
+        )
+
         response = self.httpx_client.request(
             method=method,
             url=urllib.parse.urljoin(f"{base_url}/", path),
@@ -271,23 +291,7 @@ class HttpClient:
                     }
                 )
             ),
-            params=encode_query(
-                jsonable_encoder(
-                    remove_none_from_dict(
-                        remove_omit_from_dict(
-                            {
-                                **(params if params is not None else {}),
-                                **(
-                                    request_options.get("additional_query_parameters", {}) or {}
-                                    if request_options is not None
-                                    else {}
-                                ),
-                            },
-                            omit,
-                        )
-                    )
-                )
-            ),
+            params=_encoded_params if _encoded_params else None,
             json=json_body,
             data=data_body,
             content=content,
@@ -358,6 +362,26 @@ class HttpClient:
 
         data_body = _maybe_filter_none_from_multipart_data(data_body, request_files, force_multipart)
 
+        # Compute encoded params separately to avoid passing empty list to httpx
+        # (httpx strips existing query params from URL when params=[] is passed)
+        _encoded_params = encode_query(
+            jsonable_encoder(
+                remove_none_from_dict(
+                    remove_omit_from_dict(
+                        {
+                            **(params if params is not None else {}),
+                            **(
+                                request_options.get("additional_query_parameters", {})
+                                if request_options is not None
+                                else {}
+                            ),
+                        },
+                        omit,
+                    )
+                )
+            )
+        )
+
         with self.httpx_client.stream(
             method=method,
             url=urllib.parse.urljoin(f"{base_url}/", path),
@@ -370,23 +394,7 @@ class HttpClient:
                     }
                 )
             ),
-            params=encode_query(
-                jsonable_encoder(
-                    remove_none_from_dict(
-                        remove_omit_from_dict(
-                            {
-                                **(params if params is not None else {}),
-                                **(
-                                    request_options.get("additional_query_parameters", {})
-                                    if request_options is not None
-                                    else {}
-                                ),
-                            },
-                            omit,
-                        )
-                    )
-                )
-            ),
+            params=_encoded_params if _encoded_params else None,
             json=json_body,
             data=data_body,
             content=content,
@@ -471,6 +479,26 @@ class AsyncHttpClient:
         # Get headers (supports async token providers)
         _headers = await self._get_headers()
 
+        # Compute encoded params separately to avoid passing empty list to httpx
+        # (httpx strips existing query params from URL when params=[] is passed)
+        _encoded_params = encode_query(
+            jsonable_encoder(
+                remove_none_from_dict(
+                    remove_omit_from_dict(
+                        {
+                            **(params if params is not None else {}),
+                            **(
+                                request_options.get("additional_query_parameters", {}) or {}
+                                if request_options is not None
+                                else {}
+                            ),
+                        },
+                        omit,
+                    )
+                )
+            )
+        )
+
         # Add the input to each of these and do None-safety checks
         response = await self.httpx_client.request(
             method=method,
@@ -484,23 +512,7 @@ class AsyncHttpClient:
                     }
                 )
             ),
-            params=encode_query(
-                jsonable_encoder(
-                    remove_none_from_dict(
-                        remove_omit_from_dict(
-                            {
-                                **(params if params is not None else {}),
-                                **(
-                                    request_options.get("additional_query_parameters", {}) or {}
-                                    if request_options is not None
-                                    else {}
-                                ),
-                            },
-                            omit,
-                        )
-                    )
-                )
-            ),
+            params=_encoded_params if _encoded_params else None,
             json=json_body,
             data=data_body,
             content=content,
@@ -573,6 +585,26 @@ class AsyncHttpClient:
         # Get headers (supports async token providers)
         _headers = await self._get_headers()
 
+        # Compute encoded params separately to avoid passing empty list to httpx
+        # (httpx strips existing query params from URL when params=[] is passed)
+        _encoded_params = encode_query(
+            jsonable_encoder(
+                remove_none_from_dict(
+                    remove_omit_from_dict(
+                        {
+                            **(params if params is not None else {}),
+                            **(
+                                request_options.get("additional_query_parameters", {})
+                                if request_options is not None
+                                else {}
+                            ),
+                        },
+                        omit=omit,
+                    )
+                )
+            )
+        )
+
         async with self.httpx_client.stream(
             method=method,
             url=urllib.parse.urljoin(f"{base_url}/", path),
@@ -585,23 +617,7 @@ class AsyncHttpClient:
                     }
                 )
             ),
-            params=encode_query(
-                jsonable_encoder(
-                    remove_none_from_dict(
-                        remove_omit_from_dict(
-                            {
-                                **(params if params is not None else {}),
-                                **(
-                                    request_options.get("additional_query_parameters", {})
-                                    if request_options is not None
-                                    else {}
-                                ),
-                            },
-                            omit=omit,
-                        )
-                    )
-                )
-            ),
+            params=_encoded_params if _encoded_params else None,
             json=json_body,
             data=data_body,
             content=content,

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,6 +1,17 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
 
+- version: 4.45.7
+  changelogEntry:
+    - summary: |
+        Fix empty query params stripping existing URL query strings. When `params` and
+        `additional_query_parameters` are both empty, httpx now receives `params=None` instead
+        of `params=[]`, preserving any query parameters already present in the URL (e.g.,
+        pagination cursors like `?after=123`).
+      type: fix
+  createdAt: "2025-12-12"
+  irVersion: 61
+
 - version: 4.45.6
   changelogEntry:
     - summary: Fix failing wire tests under `pytest-xdist` by using a single shared WireMock plugin.

--- a/generators/python/tests/utils/test_http_client.py
+++ b/generators/python/tests/utils/test_http_client.py
@@ -152,12 +152,12 @@ def test_http_client_does_not_pass_empty_params_list() -> None:
         httpx_client=dummy_client,  # type: ignore[arg-type]
         base_timeout=lambda: None,
         base_headers=lambda: {},
-        base_url=lambda: "https://example.com/resource?after=123",
+        base_url=lambda: "https://example.com",
     )
 
-    # No params, no request_options.additional_query_parameters
+    # Use a path with query params (e.g., pagination cursor URL)
     http_client.request(
-        path="",
+        path="resource?after=123",
         method="GET",
         params=None,
         request_options=None,
@@ -166,6 +166,10 @@ def test_http_client_does_not_pass_empty_params_list() -> None:
     # We care that httpx receives params=None, not [] or {}
     assert "params" in dummy_client.last_request_kwargs
     assert dummy_client.last_request_kwargs["params"] is None
+
+    # Verify the query string in the URL is preserved
+    url = str(dummy_client.last_request_kwargs["url"])
+    assert "after=123" in url, f"Expected query param 'after=123' in URL, got: {url}"
 
 
 def test_http_client_passes_encoded_params_when_present() -> None:
@@ -202,12 +206,13 @@ async def test_async_http_client_does_not_pass_empty_params_list() -> None:
         httpx_client=dummy_client,  # type: ignore[arg-type]
         base_timeout=lambda: None,
         base_headers=lambda: {},
-        base_url=lambda: "https://example.com/resource?after=123",
+        base_url=lambda: "https://example.com",
         async_base_headers=None,
     )
 
+    # Use a path with query params (e.g., pagination cursor URL)
     await http_client.request(
-        path="",
+        path="resource?after=123",
         method="GET",
         params=None,
         request_options=None,
@@ -216,6 +221,10 @@ async def test_async_http_client_does_not_pass_empty_params_list() -> None:
     # We care that httpx receives params=None, not [] or {}
     assert "params" in dummy_client.last_request_kwargs
     assert dummy_client.last_request_kwargs["params"] is None
+
+    # Verify the query string in the URL is preserved
+    url = str(dummy_client.last_request_kwargs["url"])
+    assert "after=123" in url, f"Expected query param 'after=123' in URL, got: {url}"
 
 
 @pytest.mark.asyncio

--- a/generators/python/tests/utils/test_http_client.py
+++ b/generators/python/tests/utils/test_http_client.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 import pytest
 
 from core_utilities.shared.http_client import AsyncHttpClient, HttpClient, get_request_body, remove_none_from_dict
@@ -9,32 +11,29 @@ class _DummySyncClient:
     """A minimal stub for httpx.Client that records request arguments."""
 
     def __init__(self) -> None:
-        self.last_request_kwargs: dict = {}
+        self.last_request_kwargs: Dict[str, Any] = {}
 
-    def request(self, **kwargs):
+    def request(self, **kwargs: Any) -> "_DummyResponse":
         self.last_request_kwargs = kwargs
-
-        class _Response:
-            status_code = 200
-            headers = {}
-
-        return _Response()
+        return _DummyResponse()
 
 
 class _DummyAsyncClient:
     """A minimal stub for httpx.AsyncClient that records request arguments."""
 
     def __init__(self) -> None:
-        self.last_request_kwargs: dict = {}
+        self.last_request_kwargs: Dict[str, Any] = {}
 
-    async def request(self, **kwargs):
+    async def request(self, **kwargs: Any) -> "_DummyResponse":
         self.last_request_kwargs = kwargs
+        return _DummyResponse()
 
-        class _Response:
-            status_code = 200
-            headers = {}
 
-        return _Response()
+class _DummyResponse:
+    """A minimal stub for httpx.Response."""
+
+    status_code = 200
+    headers: Dict[str, str] = {}
 
 
 def get_request_options() -> RequestOptions:

--- a/seed/python-sdk/pagination/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/pagination/no-custom-config/src/seed/core/http_client.py
@@ -261,6 +261,26 @@ class HttpClient:
 
         data_body = _maybe_filter_none_from_multipart_data(data_body, request_files, force_multipart)
 
+        # Compute encoded params separately to avoid passing empty list to httpx
+        # (httpx strips existing query params from URL when params=[] is passed)
+        _encoded_params = encode_query(
+            jsonable_encoder(
+                remove_none_from_dict(
+                    remove_omit_from_dict(
+                        {
+                            **(params if params is not None else {}),
+                            **(
+                                request_options.get("additional_query_parameters", {}) or {}
+                                if request_options is not None
+                                else {}
+                            ),
+                        },
+                        omit,
+                    )
+                )
+            )
+        )
+
         response = self.httpx_client.request(
             method=method,
             url=urllib.parse.urljoin(f"{base_url}/", path),
@@ -273,23 +293,7 @@ class HttpClient:
                     }
                 )
             ),
-            params=encode_query(
-                jsonable_encoder(
-                    remove_none_from_dict(
-                        remove_omit_from_dict(
-                            {
-                                **(params if params is not None else {}),
-                                **(
-                                    request_options.get("additional_query_parameters", {}) or {}
-                                    if request_options is not None
-                                    else {}
-                                ),
-                            },
-                            omit,
-                        )
-                    )
-                )
-            ),
+            params=_encoded_params if _encoded_params else None,
             json=json_body,
             data=data_body,
             content=content,
@@ -360,6 +364,26 @@ class HttpClient:
 
         data_body = _maybe_filter_none_from_multipart_data(data_body, request_files, force_multipart)
 
+        # Compute encoded params separately to avoid passing empty list to httpx
+        # (httpx strips existing query params from URL when params=[] is passed)
+        _encoded_params = encode_query(
+            jsonable_encoder(
+                remove_none_from_dict(
+                    remove_omit_from_dict(
+                        {
+                            **(params if params is not None else {}),
+                            **(
+                                request_options.get("additional_query_parameters", {})
+                                if request_options is not None
+                                else {}
+                            ),
+                        },
+                        omit,
+                    )
+                )
+            )
+        )
+
         with self.httpx_client.stream(
             method=method,
             url=urllib.parse.urljoin(f"{base_url}/", path),
@@ -372,23 +396,7 @@ class HttpClient:
                     }
                 )
             ),
-            params=encode_query(
-                jsonable_encoder(
-                    remove_none_from_dict(
-                        remove_omit_from_dict(
-                            {
-                                **(params if params is not None else {}),
-                                **(
-                                    request_options.get("additional_query_parameters", {})
-                                    if request_options is not None
-                                    else {}
-                                ),
-                            },
-                            omit,
-                        )
-                    )
-                )
-            ),
+            params=_encoded_params if _encoded_params else None,
             json=json_body,
             data=data_body,
             content=content,
@@ -473,6 +481,26 @@ class AsyncHttpClient:
         # Get headers (supports async token providers)
         _headers = await self._get_headers()
 
+        # Compute encoded params separately to avoid passing empty list to httpx
+        # (httpx strips existing query params from URL when params=[] is passed)
+        _encoded_params = encode_query(
+            jsonable_encoder(
+                remove_none_from_dict(
+                    remove_omit_from_dict(
+                        {
+                            **(params if params is not None else {}),
+                            **(
+                                request_options.get("additional_query_parameters", {}) or {}
+                                if request_options is not None
+                                else {}
+                            ),
+                        },
+                        omit,
+                    )
+                )
+            )
+        )
+
         # Add the input to each of these and do None-safety checks
         response = await self.httpx_client.request(
             method=method,
@@ -486,23 +514,7 @@ class AsyncHttpClient:
                     }
                 )
             ),
-            params=encode_query(
-                jsonable_encoder(
-                    remove_none_from_dict(
-                        remove_omit_from_dict(
-                            {
-                                **(params if params is not None else {}),
-                                **(
-                                    request_options.get("additional_query_parameters", {}) or {}
-                                    if request_options is not None
-                                    else {}
-                                ),
-                            },
-                            omit,
-                        )
-                    )
-                )
-            ),
+            params=_encoded_params if _encoded_params else None,
             json=json_body,
             data=data_body,
             content=content,
@@ -575,6 +587,26 @@ class AsyncHttpClient:
         # Get headers (supports async token providers)
         _headers = await self._get_headers()
 
+        # Compute encoded params separately to avoid passing empty list to httpx
+        # (httpx strips existing query params from URL when params=[] is passed)
+        _encoded_params = encode_query(
+            jsonable_encoder(
+                remove_none_from_dict(
+                    remove_omit_from_dict(
+                        {
+                            **(params if params is not None else {}),
+                            **(
+                                request_options.get("additional_query_parameters", {})
+                                if request_options is not None
+                                else {}
+                            ),
+                        },
+                        omit=omit,
+                    )
+                )
+            )
+        )
+
         async with self.httpx_client.stream(
             method=method,
             url=urllib.parse.urljoin(f"{base_url}/", path),
@@ -587,23 +619,7 @@ class AsyncHttpClient:
                     }
                 )
             ),
-            params=encode_query(
-                jsonable_encoder(
-                    remove_none_from_dict(
-                        remove_omit_from_dict(
-                            {
-                                **(params if params is not None else {}),
-                                **(
-                                    request_options.get("additional_query_parameters", {})
-                                    if request_options is not None
-                                    else {}
-                                ),
-                            },
-                            omit=omit,
-                        )
-                    )
-                )
-            ),
+            params=_encoded_params if _encoded_params else None,
             json=json_body,
             data=data_body,
             content=content,

--- a/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/core/http_client.py
+++ b/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/core/http_client.py
@@ -261,6 +261,26 @@ class HttpClient:
 
         data_body = _maybe_filter_none_from_multipart_data(data_body, request_files, force_multipart)
 
+        # Compute encoded params separately to avoid passing empty list to httpx
+        # (httpx strips existing query params from URL when params=[] is passed)
+        _encoded_params = encode_query(
+            jsonable_encoder(
+                remove_none_from_dict(
+                    remove_omit_from_dict(
+                        {
+                            **(params if params is not None else {}),
+                            **(
+                                request_options.get("additional_query_parameters", {}) or {}
+                                if request_options is not None
+                                else {}
+                            ),
+                        },
+                        omit,
+                    )
+                )
+            )
+        )
+
         response = self.httpx_client.request(
             method=method,
             url=urllib.parse.urljoin(f"{base_url}/", path),
@@ -273,23 +293,7 @@ class HttpClient:
                     }
                 )
             ),
-            params=encode_query(
-                jsonable_encoder(
-                    remove_none_from_dict(
-                        remove_omit_from_dict(
-                            {
-                                **(params if params is not None else {}),
-                                **(
-                                    request_options.get("additional_query_parameters", {}) or {}
-                                    if request_options is not None
-                                    else {}
-                                ),
-                            },
-                            omit,
-                        )
-                    )
-                )
-            ),
+            params=_encoded_params if _encoded_params else None,
             json=json_body,
             data=data_body,
             content=content,
@@ -360,6 +364,26 @@ class HttpClient:
 
         data_body = _maybe_filter_none_from_multipart_data(data_body, request_files, force_multipart)
 
+        # Compute encoded params separately to avoid passing empty list to httpx
+        # (httpx strips existing query params from URL when params=[] is passed)
+        _encoded_params = encode_query(
+            jsonable_encoder(
+                remove_none_from_dict(
+                    remove_omit_from_dict(
+                        {
+                            **(params if params is not None else {}),
+                            **(
+                                request_options.get("additional_query_parameters", {})
+                                if request_options is not None
+                                else {}
+                            ),
+                        },
+                        omit,
+                    )
+                )
+            )
+        )
+
         with self.httpx_client.stream(
             method=method,
             url=urllib.parse.urljoin(f"{base_url}/", path),
@@ -372,23 +396,7 @@ class HttpClient:
                     }
                 )
             ),
-            params=encode_query(
-                jsonable_encoder(
-                    remove_none_from_dict(
-                        remove_omit_from_dict(
-                            {
-                                **(params if params is not None else {}),
-                                **(
-                                    request_options.get("additional_query_parameters", {})
-                                    if request_options is not None
-                                    else {}
-                                ),
-                            },
-                            omit,
-                        )
-                    )
-                )
-            ),
+            params=_encoded_params if _encoded_params else None,
             json=json_body,
             data=data_body,
             content=content,
@@ -473,6 +481,26 @@ class AsyncHttpClient:
         # Get headers (supports async token providers)
         _headers = await self._get_headers()
 
+        # Compute encoded params separately to avoid passing empty list to httpx
+        # (httpx strips existing query params from URL when params=[] is passed)
+        _encoded_params = encode_query(
+            jsonable_encoder(
+                remove_none_from_dict(
+                    remove_omit_from_dict(
+                        {
+                            **(params if params is not None else {}),
+                            **(
+                                request_options.get("additional_query_parameters", {}) or {}
+                                if request_options is not None
+                                else {}
+                            ),
+                        },
+                        omit,
+                    )
+                )
+            )
+        )
+
         # Add the input to each of these and do None-safety checks
         response = await self.httpx_client.request(
             method=method,
@@ -486,23 +514,7 @@ class AsyncHttpClient:
                     }
                 )
             ),
-            params=encode_query(
-                jsonable_encoder(
-                    remove_none_from_dict(
-                        remove_omit_from_dict(
-                            {
-                                **(params if params is not None else {}),
-                                **(
-                                    request_options.get("additional_query_parameters", {}) or {}
-                                    if request_options is not None
-                                    else {}
-                                ),
-                            },
-                            omit,
-                        )
-                    )
-                )
-            ),
+            params=_encoded_params if _encoded_params else None,
             json=json_body,
             data=data_body,
             content=content,
@@ -575,6 +587,26 @@ class AsyncHttpClient:
         # Get headers (supports async token providers)
         _headers = await self._get_headers()
 
+        # Compute encoded params separately to avoid passing empty list to httpx
+        # (httpx strips existing query params from URL when params=[] is passed)
+        _encoded_params = encode_query(
+            jsonable_encoder(
+                remove_none_from_dict(
+                    remove_omit_from_dict(
+                        {
+                            **(params if params is not None else {}),
+                            **(
+                                request_options.get("additional_query_parameters", {})
+                                if request_options is not None
+                                else {}
+                            ),
+                        },
+                        omit=omit,
+                    )
+                )
+            )
+        )
+
         async with self.httpx_client.stream(
             method=method,
             url=urllib.parse.urljoin(f"{base_url}/", path),
@@ -587,23 +619,7 @@ class AsyncHttpClient:
                     }
                 )
             ),
-            params=encode_query(
-                jsonable_encoder(
-                    remove_none_from_dict(
-                        remove_omit_from_dict(
-                            {
-                                **(params if params is not None else {}),
-                                **(
-                                    request_options.get("additional_query_parameters", {})
-                                    if request_options is not None
-                                    else {}
-                                ),
-                            },
-                            omit=omit,
-                        )
-                    )
-                )
-            ),
+            params=_encoded_params if _encoded_params else None,
             json=json_body,
             data=data_body,
             content=content,


### PR DESCRIPTION
## Description

Fixes a bug where empty query parameters would cause httpx to strip existing query parameters from URLs, breaking features like pagination cursors.

**Link to Devin run**: https://app.devin.ai/sessions/fd42729d974d4d8a9aaf037d47ec850a
**Requested by**: adi@buildwithfern.com (@aditya-arolkar-swe)

## Problem

The `HttpClient.request()` and `AsyncHttpClient.request()` methods (and their `stream()` variants) always passed `params=encode_query(...)` to httpx, even when the result was an empty list `[]`. 

httpx behavior: When `params={}` or `params=[]` is passed, httpx strips any existing query parameters from the URL. This breaks features that rely on URLs with pre-existing query strings (e.g., pagination cursors like `?after=123`).

## Changes Made

- Compute encoded params into `_encoded_params` variable first
- Pass `params=_encoded_params if _encoded_params else None` to httpx
- When params are empty, `None` is passed instead of `[]`, preserving the URL's existing query string
- Applied fix to all 4 affected methods: `HttpClient.request()`, `HttpClient.stream()`, `AsyncHttpClient.request()`, `AsyncHttpClient.stream()`
- Added version 4.45.7 changelog entry

## Testing

- [x] Pre-commit hooks passed
- [x] Seed tests passed for `pagination` fixture (2/2 test cases)
- [ ] No unit test added for this specific edge case

## Human Review Checklist

- [x] Verify the fix is consistently applied across all 4 methods in `http_client.py`
- [ ] Confirm `encode_query()` returns `[]` (falsy) for empty input, not a truthy empty value
- [x] Consider if a dedicated unit test should be added for this behavior