### PR TITLE
feat(cli): improve env var substitution for docs linting and instances config

### DIFF
--- a/packages/cli/cli/src/commands/validate/validateDocsWorkspaceAndLogIssues.ts
+++ b/packages/cli/cli/src/commands/validate/validateDocsWorkspaceAndLogIssues.ts
@@ -1,3 +1,4 @@
+import { replaceEnvVariables } from "@fern-api/core-utils";
 import { validateDocsWorkspace } from "@fern-api/docs-validator";
 import { OSSWorkspace } from "@fern-api/lazy-fern-workspace";
 import { TaskContext } from "@fern-api/task-context";
@@ -24,6 +25,14 @@ export async function validateDocsWorkspaceWithoutExiting({
     logSummary?: boolean;
     excludeRules?: string[];
 }): Promise<{ hasErrors: boolean }> {
+    // Apply env var substitution if settings.substitute-env-vars is enabled
+    // This matches the behavior of `fern generate --docs` which throws errors for missing env vars
+    if (workspace.config.settings?.substituteEnvVars) {
+        workspace.config = replaceEnvVariables(workspace.config, {
+            onError: (e) => context.failAndThrow(e)
+        });
+    }
+
     const startTime = performance.now();
     const violations = await validateDocsWorkspace(
         workspace,

--- a/packages/cli/cli/src/commands/validate/validateDocsWorkspaceAndLogIssues.ts
+++ b/packages/cli/cli/src/commands/validate/validateDocsWorkspaceAndLogIssues.ts
@@ -25,14 +25,9 @@ export async function validateDocsWorkspaceWithoutExiting({
     logSummary?: boolean;
     excludeRules?: string[];
 }): Promise<{ hasErrors: boolean }> {
-    // Always apply env var substitution to instances config (similar to analytics settings)
-    // This is separate from the settings.substitute-env-vars option
-    workspace.config.instances = replaceEnvVariables(workspace.config.instances, {
-        onError: (e) => context.failAndThrow(e)
-    });
-
-    // Apply env var substitution to the rest of the config if settings.substitute-env-vars is enabled
+    // Apply env var substitution if settings.substitute-env-vars is enabled
     // This matches the behavior of `fern generate --docs` which throws errors for missing env vars
+    // The entire config including instances (with custom domains) goes through substitution
     if (workspace.config.settings?.substituteEnvVars) {
         workspace.config = replaceEnvVariables(workspace.config, {
             onError: (e) => context.failAndThrow(e)

--- a/packages/cli/cli/src/commands/validate/validateDocsWorkspaceAndLogIssues.ts
+++ b/packages/cli/cli/src/commands/validate/validateDocsWorkspaceAndLogIssues.ts
@@ -25,7 +25,13 @@ export async function validateDocsWorkspaceWithoutExiting({
     logSummary?: boolean;
     excludeRules?: string[];
 }): Promise<{ hasErrors: boolean }> {
-    // Apply env var substitution if settings.substitute-env-vars is enabled
+    // Always apply env var substitution to instances config (similar to analytics settings)
+    // This is separate from the settings.substitute-env-vars option
+    workspace.config.instances = replaceEnvVariables(workspace.config.instances, {
+        onError: (e) => context.failAndThrow(e)
+    });
+
+    // Apply env var substitution to the rest of the config if settings.substitute-env-vars is enabled
     // This matches the behavior of `fern generate --docs` which throws errors for missing env vars
     if (workspace.config.settings?.substituteEnvVars) {
         workspace.config = replaceEnvVariables(workspace.config, {

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,16 +1,11 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
-        Improved error logging for docs publishing failures. When API definition registration fails with a "fetch failed" error, the CLI now logs detailed error information including status code, error type, reason, and error message to help debug network issues.
-      type: fix
-  irVersion: 62
-  createdAt: "2025-12-12"
-  version: 3.16.1
-
-- changelogEntry:
-    - summary: |
         Docs linting (`fern check`) now respects `settings.substitute-env-vars` and throws errors for missing environment variables, matching the behavior of `fern generate --docs`. The full `instances:` config including custom domains now goes through env var substitution when this setting is enabled.
       type: feat
+    - summary: |
+        Improved error logging for docs publishing failures. When API definition registration fails with a "fetch failed" error, the CLI now logs detailed error information including status code, error type, reason, and error message to help debug network issues.
+      type: fix
   irVersion: 62
   createdAt: "2025-12-12"
   version: 3.16.0

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Docs linting (`fern check`) now respects `settings.substitute-env-vars` and throws errors for missing environment variables, matching the behavior of `fern generate --docs`. The full `instances:` config including custom domains now goes through env var substitution when this setting is enabled.
+      type: feat
+  irVersion: 62
+  createdAt: "2025-12-12"
+  version: 3.16.0
+
+- changelogEntry:
+    - summary: |
         Use Venus JWT for AI example enhancement requests.
       type: chore
   irVersion: 62

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Improved error logging for docs publishing failures. When API definition registration fails with a "fetch failed" error, the CLI now logs detailed error information including status code, error type, reason, and error message to help debug network issues.
+      type: fix
+  irVersion: 62
+  createdAt: "2025-12-12"
+  version: 3.16.1
+
+- changelogEntry:
+    - summary: |
         Docs linting (`fern check`) now respects `settings.substitute-env-vars` and throws errors for missing environment variables, matching the behavior of `fern generate --docs`. The full `instances:` config including custom domains now goes through env var substitution when this setting is enabled.
       type: feat
   irVersion: 62

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForDocsWorkspace.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForDocsWorkspace.ts
@@ -29,13 +29,6 @@ export async function runRemoteGenerationForDocsWorkspace({
     disableTemplates: boolean | undefined;
     skipUpload: boolean | undefined;
 }): Promise<void> {
-    // Always apply env var substitution to instances config (similar to analytics settings)
-    // This is separate from the settings.substitute-env-vars option which controls
-    // substitution in the rest of the docs content
-    const instances = replaceEnvVariables(docsWorkspace.config.instances, {
-        onError: (e) => context.failAndThrow(e)
-    });
-
     // Substitute templated environment variables:
     // If substitute-env-vars is enabled, we'll attempt to read and replace the templated
     // environment variable even in preview mode. Will bubble up an error if the env var isn't found.
@@ -53,6 +46,10 @@ export async function runRemoteGenerationForDocsWorkspace({
         { onError: (e) => context.failAndThrow(e) },
         { substituteAsEmpty: shouldSubstituteAsEmpty }
     );
+
+    // Get instances after env var substitution has been applied to the config
+    // This ensures the full instance object including custom domains goes through env var replacement
+    const instances = docsWorkspace.config.instances;
 
     if (instances.length === 0) {
         context.failAndThrow("No instances specified in docs.yml! Cannot register docs.");

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForDocsWorkspace.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForDocsWorkspace.ts
@@ -29,7 +29,12 @@ export async function runRemoteGenerationForDocsWorkspace({
     disableTemplates: boolean | undefined;
     skipUpload: boolean | undefined;
 }): Promise<void> {
-    const instances = docsWorkspace.config.instances;
+    // Always apply env var substitution to instances config (similar to analytics settings)
+    // This is separate from the settings.substitute-env-vars option which controls
+    // substitution in the rest of the docs content
+    const instances = replaceEnvVariables(docsWorkspace.config.instances, {
+        onError: (e) => context.failAndThrow(e)
+    });
 
     // Substitute templated environment variables:
     // If substitute-env-vars is enabled, we'll attempt to read and replace the templated


### PR DESCRIPTION
## Description
Refs: Slack thread from Colton Berry

<!-- Provide a clear and concise description of the changes made in this PR -->
This PR improves environment variable handling in docs configuration:

1. **Docs linting now respects `settings.substitute-env-vars`**: When this setting is enabled, `fern check` will now throw errors for missing environment variables, matching the behavior of `fern generate --docs`.

2. **Instances config (including custom domains) goes through env var substitution**: The full `instances:` config in `docs.yml` now goes through env var templating when `substitute-env-vars` is enabled. This applies to both `fern check` and `fern generate --docs`.

3. **Improved error logging for docs publishing failures**: When API definition registration fails with a "fetch failed" error, the CLI now logs detailed error information including status code, error type, reason, and error message to help debug network issues.

## Changes Made
- Added env var substitution to `validateDocsWorkspaceWithoutExiting` when `substituteEnvVars` is enabled
- Changed `runRemoteGenerationForDocsWorkspace` to get instances AFTER env var substitution is applied to the config, ensuring the full instance object (including custom domains) goes through env var replacement
- Added `extractErrorDetails` helper function in `publishDocs.ts` to extract structured error information from FDR SDK errors
- Added unit tests for env var substitution in instances config including custom domains
- Added versions.yml entry for CLI version 3.16.0 (with both feat and fix changelog entries)

## Testing
- [x] Unit tests added/updated
- [x] Manual testing completed (lint checks pass)
- [x] Local CLI testing: verified `fern check` throws errors for missing env vars when `substitute-env-vars` is enabled

## Human Review Checklist
- [ ] Verify the conditional behavior (env var substitution only when `settings.substitute-env-vars` is true) matches the intended behavior
- [ ] Verify custom domains in instances are properly substituted
- [ ] Verify the `extractErrorDetails` function extracts useful debugging info without exposing sensitive data (note: `rawError` is included in the logged details)
- [ ] Verify versions.yml entry is correct (single 3.16.0 entry with feat + fix)

---
Link to Devin run: https://app.devin.ai/sessions/5ca2e851e7fd41998cbc83a0bb9bccbe
Requested by: Colton Berry (@coltondotio)