### PR TITLE
feat(cli): enable AI generated endpoint examples by default

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+<<<<<<< Updated upstream
         Include examples for AI processing if 30% or more of the values are generic.
       type: feat
   irVersion: 62
@@ -16,6 +17,12 @@
       type: fix
   irVersion: 62
   createdAt: "2025-12-12"
+=======
+        Enable AI-powered examples by default for all documentation generation. The experimental ai-examples feature now defaults to true unless explicitly set to false.
+      type: feat
+  irVersion: 62
+  createdAt: "2025-12-12"
+>>>>>>> Stashed changes
   version: 3.16.0
 
 - changelogEntry:

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,7 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
-<<<<<<< Updated upstream
+        Enable AI-generated endpoint examples by default. To disable, set ai-examples to false in docs.yml's `experimental` settings.
+      type: feat
+  irVersion: 62
+  createdAt: "2025-12-12"
+  version: 3.17.0
+
+- changelogEntry:
+    - summary: |
         Include examples for AI processing if 30% or more of the values are generic.
       type: feat
   irVersion: 62
@@ -17,12 +24,6 @@
       type: fix
   irVersion: 62
   createdAt: "2025-12-12"
-=======
-        Enable AI-powered examples by default for all documentation generation. The experimental ai-examples feature now defaults to true unless explicitly set to false.
-      type: feat
-  irVersion: 62
-  createdAt: "2025-12-12"
->>>>>>> Stashed changes
   version: 3.16.0
 
 - changelogEntry:

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -58,7 +58,7 @@ export async function publishDocs({
     isPrivate = false,
     disableTemplates = false,
     skipUpload = false,
-    withAiExamples = false,
+    withAiExamples = true,
     targetAudiences
 }: {
     token: FernToken;

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForDocsWorkspace.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForDocsWorkspace.ts
@@ -100,7 +100,7 @@ export async function runRemoteGenerationForDocsWorkspace({
             isPrivate: maybeInstance.private,
             disableTemplates,
             skipUpload,
-            withAiExamples: docsWorkspace.config.experimental?.aiExamples,
+            withAiExamples: docsWorkspace.config.experimental?.aiExamples ?? true,
             targetAudiences: maybeInstance.audiences
                 ? Array.isArray(maybeInstance.audiences)
                     ? maybeInstance.audiences

--- a/packages/cli/register/src/ai-example-enhancer/enhanceExamplesWithAI.ts
+++ b/packages/cli/register/src/ai-example-enhancer/enhanceExamplesWithAI.ts
@@ -463,7 +463,7 @@ async function enhancePackageExamples(
     const totalEndpointCount = countTotalEndpoints(apiDefinition);
 
     stats.total += allWorkItems.length;
-    context.logger.info(
+    context.logger.debug(
         `AI Examples Enhancement: ${allWorkItems.length} endpoints need enhancement out of ${totalEndpointCount} total endpoints (${coveredEndpoints.size} already covered)`
     );
     context.logger.debug(`Collected ${allWorkItems.length} work items across all packages`);
@@ -504,7 +504,7 @@ async function enhancePackageExamples(
     const enhancedRootPackage = applyEnhancementResults(apiDefinition.rootPackage, enhancementResults);
 
     // Log completion summary
-    context.logger.info(
+    context.logger.debug(
         `AI Examples Enhancement Complete: ${apiStats?.count || 0}/${allWorkItems.length} endpoints enhanced successfully (${totalEndpointCount} total endpoints in API)`
     );
 
@@ -620,7 +620,7 @@ function collectWorkItems(
 
     // Log filtering statistics summary
     if (context) {
-        context.logger.info(
+        context.logger.debug(
             `Endpoint Filtering Results: ${filteringStats.processed}/${filteringStats.totalEndpoints} endpoints selected for AI enhancement`
         );
         context.logger.debug(


### PR DESCRIPTION
This enables AI generated endpoint examples for OpenAPI specs

- Respects existing examples first: any endpoints with `x-fern-examples`, `examples`, and property-level examples should remain.
- Generates an `ai_examples_override.yml` which can be optionally edited and committed to save changes, or `.gitignored` to maintain the latest up-to-date changes in your OpenAPI spec.