### PR TITLE
fix(cli): deduplicate types with identical schemas across files

### DIFF
--- a/packages/cli/api-importers/commons/src/__test__/FernDefinitionBuilder.test.ts
+++ b/packages/cli/api-importers/commons/src/__test__/FernDefinitionBuilder.test.ts
@@ -16,7 +16,7 @@ describe("FernDefinitionBuilder", () => {
             });
 
             const definition = builder.build();
-            expect(definition.definitionFiles["types.yml"]?.types).toEqual({
+            expect(definition.definitionFiles[RelativeFilePath.of("types.yml")]?.types).toEqual({
                 MyType: {
                     properties: {
                         id: "string"
@@ -45,7 +45,7 @@ describe("FernDefinitionBuilder", () => {
             });
 
             const definition = builder.build();
-            expect(definition.definitionFiles["diagrams.yml"]?.types).toEqual({
+            expect(definition.definitionFiles[RelativeFilePath.of("diagrams.yml")]?.types).toEqual({
                 DiagramContentPartialComments: schema
             });
             expect(definition.packageMarkerFile.types).toBeUndefined();
@@ -76,7 +76,7 @@ describe("FernDefinitionBuilder", () => {
             });
 
             const definition = builder.build();
-            expect(definition.definitionFiles["types.yml"]?.types).toEqual({
+            expect(definition.definitionFiles[RelativeFilePath.of("types.yml")]?.types).toEqual({
                 MyType: updatedSchema
             });
         });
@@ -103,14 +103,14 @@ describe("FernDefinitionBuilder", () => {
             });
 
             const definition = builder.build();
-            expect(definition.definitionFiles["file1.yml"]?.types).toEqual({
+            expect(definition.definitionFiles[RelativeFilePath.of("file1.yml")]?.types).toEqual({
                 SharedTypeName: {
                     properties: {
                         field1: "string"
                     }
                 }
             });
-            expect(definition.definitionFiles["file2.yml"]?.types).toEqual({
+            expect(definition.definitionFiles[RelativeFilePath.of("file2.yml")]?.types).toEqual({
                 SharedTypeName: {
                     properties: {
                         field2: "integer"
@@ -131,7 +131,7 @@ describe("FernDefinitionBuilder", () => {
             });
 
             const definition = builder.build();
-            expect(definition.definitionFiles["api.yml"]).toBeUndefined();
+            expect(definition.definitionFiles[RelativeFilePath.of("api.yml")]).toBeUndefined();
         });
     });
 });

--- a/packages/cli/api-importers/commons/src/__test__/FernDefinitionBuilder.test.ts
+++ b/packages/cli/api-importers/commons/src/__test__/FernDefinitionBuilder.test.ts
@@ -1,0 +1,137 @@
+import { RelativeFilePath } from "@fern-api/path-utils";
+
+import { FernDefinitionBuilderImpl } from "../FernDefinitionBuilder";
+
+describe("FernDefinitionBuilder", () => {
+    describe("addType", () => {
+        it("should add a type to a file", () => {
+            const builder = new FernDefinitionBuilderImpl(false);
+            builder.addType(RelativeFilePath.of("types.yml"), {
+                name: "MyType",
+                schema: {
+                    properties: {
+                        id: "string"
+                    }
+                }
+            });
+
+            const definition = builder.build();
+            expect(definition.definitionFiles["types.yml"]?.types).toEqual({
+                MyType: {
+                    properties: {
+                        id: "string"
+                    }
+                }
+            });
+        });
+
+        it("should skip duplicate type with same schema in different file", () => {
+            const builder = new FernDefinitionBuilderImpl(false);
+            const schema = {
+                properties: {
+                    id: "string",
+                    name: "string"
+                }
+            };
+
+            builder.addType(RelativeFilePath.of("diagrams.yml"), {
+                name: "DiagramContentPartialComments",
+                schema
+            });
+
+            builder.addType(RelativeFilePath.of("__package__.yml"), {
+                name: "DiagramContentPartialComments",
+                schema
+            });
+
+            const definition = builder.build();
+            expect(definition.definitionFiles["diagrams.yml"]?.types).toEqual({
+                DiagramContentPartialComments: schema
+            });
+            expect(definition.packageMarkerFile.types).toBeUndefined();
+        });
+
+        it("should allow same type name in same file (update)", () => {
+            const builder = new FernDefinitionBuilderImpl(false);
+
+            builder.addType(RelativeFilePath.of("types.yml"), {
+                name: "MyType",
+                schema: {
+                    properties: {
+                        id: "string"
+                    }
+                }
+            });
+
+            const updatedSchema = {
+                properties: {
+                    id: "string",
+                    name: "string"
+                }
+            };
+
+            builder.addType(RelativeFilePath.of("types.yml"), {
+                name: "MyType",
+                schema: updatedSchema
+            });
+
+            const definition = builder.build();
+            expect(definition.definitionFiles["types.yml"]?.types).toEqual({
+                MyType: updatedSchema
+            });
+        });
+
+        it("should allow different types with same name but different schemas in different files", () => {
+            const builder = new FernDefinitionBuilderImpl(false);
+
+            builder.addType(RelativeFilePath.of("file1.yml"), {
+                name: "SharedTypeName",
+                schema: {
+                    properties: {
+                        field1: "string"
+                    }
+                }
+            });
+
+            builder.addType(RelativeFilePath.of("file2.yml"), {
+                name: "SharedTypeName",
+                schema: {
+                    properties: {
+                        field2: "integer"
+                    }
+                }
+            });
+
+            const definition = builder.build();
+            expect(definition.definitionFiles["file1.yml"]?.types).toEqual({
+                SharedTypeName: {
+                    properties: {
+                        field1: "string"
+                    }
+                }
+            });
+            expect(definition.definitionFiles["file2.yml"]?.types).toEqual({
+                SharedTypeName: {
+                    properties: {
+                        field2: "integer"
+                    }
+                }
+            });
+        });
+
+        it("should not add types to api.yml", () => {
+            const builder = new FernDefinitionBuilderImpl(false);
+            builder.addType(RelativeFilePath.of("api.yml"), {
+                name: "MyType",
+                schema: {
+                    properties: {
+                        id: "string"
+                    }
+                }
+            });
+
+            const definition = builder.build();
+            expect(definition.definitionFiles["api.yml"]).toBeUndefined();
+        });
+    });
+});

--- a/packages/cli/ete-tests/src/tests/write-definition/__snapshots__/writeDefinition.test.ts.snap
+++ b/packages/cli/ete-tests/src/tests/write-definition/__snapshots__/writeDefinition.test.ts.snap
@@ -535,16 +535,6 @@ name: api
     source:
       openapi: openapi/petstore/openapi.yml
   Pets: list<Pet>
-  V2ChatMessages:
-    docs: >
-      A list of chat messages in chronological order, representing a
-      conversation between the user and the model.
-
-
-      Messages can be from \`User\`, \`Assistant\`, \`Tool\` and \`System\` roles. Learn
-      more about messages and roles in [the Chat API
-      guide](https://docs.cohere.com/docs/chat-api).
-    type: list<unknown>
 ",
         "name": "__package__.yml",
         "type": "file",

--- a/packages/cli/ete-tests/src/tests/write-definition/fixtures/namespaced/fern/.definition/neopets/__package__.yml
+++ b/packages/cli/ete-tests/src/tests/write-definition/fixtures/namespaced/fern/.definition/neopets/__package__.yml
@@ -14,13 +14,3 @@ types:
     source:
       openapi: openapi/petstore/openapi.yml
   Pets: list<Pet>
-  V2ChatMessages:
-    docs: >
-      A list of chat messages in chronological order, representing a
-      conversation between the user and the model.
-
-
-      Messages can be from `User`, `Assistant`, `Tool` and `System` roles. Learn
-      more about messages and roles in [the Chat API
-      guide](https://docs.cohere.com/docs/chat-api).
-    type: list<unknown>


### PR DESCRIPTION
## Description

Fixes duplicate type declaration errors in `fern check` when converting OpenAPI specs with inline nested object types that are referenced by endpoints with different tags.

**Link to Devin run**: https://app.devin.ai/sessions/82fa55ba9d7348c1bb6288dc704a6789
**Requested by**: Deep Singhvi (@dsinghvi)

## Changes Made

- Added a global type registry to `FernDefinitionBuilder` that tracks all type declarations across files
- Modified `addType` to skip adding a type if an identical schema with the same name already exists in another file (using lodash `isEqual` for deep comparison)
- Types with the same name but different schemas are still added to both files (will be caught by `fern check` as expected)

## Root Cause

When converting OpenAPI specs, inline nested object types (e.g., `DiagramContentPartialComments`) were being added to multiple files:
1. First to the endpoint's file (e.g., `diagrams.yml`) during endpoint processing
2. Then to `__package__.yml` during schema processing

Since `FernDefinitionBuilder.addType` had no cross-file deduplication, identical types ended up in both files.

## Testing

- [x] Unit tests added for `FernDefinitionBuilder.addType`:
  - Basic type addition
  - Skipping duplicate types with identical schemas in different files
  - Allowing type updates in the same file
  - Allowing different schemas with the same name in different files
  - Verifying types are not added to `api.yml`
- [x] ETE test snapshots updated to reflect deduplication behavior (removed duplicate `V2ChatMessages` from `neopets/__package__.yml` since it's already defined in `trains/__package__.yml`)

## Human Review Checklist

- [ ] Verify `isEqual` deep comparison is appropriate for schema comparison (could there be semantically equivalent schemas that are structurally different?)
- [ ] Confirm first-wins behavior (first `addType` call determines the file) is correct - this is order-dependent on processing order
- [ ] Consider if there are edge cases where identical schemas should legitimately exist in different files
- [ ] Verify the ETE snapshot changes are expected (type kept in `trains/__package__.yml`, removed from `neopets/__package__.yml`)