### PR TITLE
fix(cli): fix duplicate type declarations for allOf in request bodies

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Fix duplicate type declarations when OpenAPI specs use `allOf` references in inline request bodies.
+      type: fix
+  irVersion: 62
+  createdAt: "2025-12-13"
+  version: 3.18.3
+
+- changelogEntry:
+    - summary: |
         Remove `fern check` validation rule that rejected HEAD endpoints with response bodies. HEAD endpoints can now define response bodies without triggering validation errors.
       type: fix
   irVersion: 62


### PR DESCRIPTION
When OpenAPI specs use allOf references in inline request bodies, nested types from the allOf schemas were being declared in the endpoint file instead of __package__.yml, causing duplicate type errors.

Now we map each property to its source allOf schema's declaration file and pass the correct declarationFile when building type references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)