### PR TITLE
fix(python): fix retry logic off-by-two error in HTTP client

### DIFF
--- a/generators/python/core_utilities/shared/http_client.py
+++ b/generators/python/core_utilities/shared/http_client.py
@@ -235,7 +235,7 @@ class HttpClient:
         ] = None,
         headers: typing.Optional[typing.Dict[str, typing.Any]] = None,
         request_options: typing.Optional[RequestOptions] = None,
-        retries: int = 2,
+        retries: int = 0,
         omit: typing.Optional[typing.Any] = None,
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
@@ -338,7 +338,7 @@ class HttpClient:
         ] = None,
         headers: typing.Optional[typing.Dict[str, typing.Any]] = None,
         request_options: typing.Optional[RequestOptions] = None,
-        retries: int = 2,
+        retries: int = 0,
         omit: typing.Optional[typing.Any] = None,
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
@@ -452,7 +452,7 @@ class AsyncHttpClient:
         ] = None,
         headers: typing.Optional[typing.Dict[str, typing.Any]] = None,
         request_options: typing.Optional[RequestOptions] = None,
-        retries: int = 2,
+        retries: int = 0,
         omit: typing.Optional[typing.Any] = None,
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
@@ -558,7 +558,7 @@ class AsyncHttpClient:
         ] = None,
         headers: typing.Optional[typing.Dict[str, typing.Any]] = None,
         request_options: typing.Optional[RequestOptions] = None,
-        retries: int = 2,
+        retries: int = 0,
         omit: typing.Optional[typing.Any] = None,
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:

--- a/generators/python/core_utilities/shared/http_client.py
+++ b/generators/python/core_utilities/shared/http_client.py
@@ -299,9 +299,9 @@ class HttpClient:
             timeout=timeout,
         )
 
-        max_retries: int = request_options.get("max_retries", 0) if request_options is not None else 0
+        max_retries: int = request_options.get("max_retries", 2) if request_options is not None else 2
         if _should_retry(response=response):
-            if max_retries > retries:
+            if retries < max_retries:
                 time.sleep(_retry_timeout(response=response, retries=retries))
                 return self.request(
                     path=path,
@@ -520,9 +520,9 @@ class AsyncHttpClient:
             timeout=timeout,
         )
 
-        max_retries: int = request_options.get("max_retries", 0) if request_options is not None else 0
+        max_retries: int = request_options.get("max_retries", 2) if request_options is not None else 2
         if _should_retry(response=response):
-            if max_retries > retries:
+            if retries < max_retries:
                 await asyncio.sleep(_retry_timeout(response=response, retries=retries))
                 return await self.request(
                     path=path,

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -4,9 +4,9 @@
 - version: 4.45.10
   changelogEntry:
     - summary: |
-        Fix retry logic "off-by-two" error. The `retries` parameter in HTTP client methods
-        now correctly defaults to 0 instead of 2, ensuring users get the expected number of
-        retries when configuring `max_retries` in request options.
+        Fix retry logic "off-by-two" error. The internal `retries` counter now starts at 0
+        instead of 2, and `max_retries` defaults to 2 when not specified. This ensures users
+        get the expected number of retries (2 by default, or the configured `max_retries` value).
       type: fix
   createdAt: "2025-12-15"
   irVersion: 61

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,6 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
 
+- version: 4.45.10
+  changelogEntry:
+    - summary: |
+        Fix retry logic "off-by-two" error. The `retries` parameter in HTTP client methods
+        now correctly defaults to 0 instead of 2, ensuring users get the expected number of
+        retries when configuring `max_retries` in request options.
+      type: fix
+  createdAt: "2025-12-15"
+  irVersion: 61
+
 - version: 4.45.9
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs: Issue #14 reported in Slack

Fixes the retry logic "off-by-two" error in the Python SDK's HTTP client. The `retries` parameter was incorrectly defaulting to 2 instead of 0, causing users to get `max_retries - 2` actual retries instead of the expected number.

**Example of the bug:**
| User Config | Expected Retries | Actual Retries (before fix) |
|-------------|------------------|----------------------------|
| `max_retries=3` | 3 | 1 |
| `max_retries=5` | 5 | 3 |

## Changes Made

- Changed `retries: int = 2` to `retries: int = 0` in all 4 HTTP client methods:
  - `HttpClient.request()`
  - `HttpClient.stream()` (for consistency, though it doesn't implement retry logic)
  - `AsyncHttpClient.request()`
  - `AsyncHttpClient.stream()` (for consistency, though it doesn't implement retry logic)
- Changed `max_retries` default from 0 to 2 (so users get 2 retries by default when not specified)
- Changed comparison from `max_retries > retries` to `retries < max_retries` (more readable, same logic)
- Added changelog entry in `versions.yml` for version 4.45.10

## Testing

- [ ] Unit tests added/updated
- [x] Pre-commit hooks pass

## Human Review Checklist

- [ ] Verify the default behavior change is intentional: previously no retries by default, now 2 retries by default
- [ ] Verify `max_retries=0` still correctly disables retries
- [ ] Consider whether unit tests should be added for retry behavior
- [ ] Note: stream methods have the `retries` parameter but don't implement retry logic (no recursive call)

---
Link to Devin run: https://app.devin.ai/sessions/888c90b41dbb4e2f9c11a3d883d1998e
Requested by: thomas@buildwithfern.com (@tjb9dc)