### PR TITLE
fix(java): pass full clientOptions to custom pagination create() method

### DIFF
--- a/generators/java/generator-utils/src/main/java/com/fern/java/generators/PaginationCoreGenerator.java
+++ b/generators/java/generator-utils/src/main/java/com/fern/java/generators/PaginationCoreGenerator.java
@@ -75,7 +75,8 @@ public final class PaginationCoreGenerator extends AbstractFilesGenerator {
                             String clientOptionsImport = "import " + corePackage + ".ClientOptions;\n";
                             // Insert the import after the first import statement
                             int firstImportEnd = contents.indexOf(";\n") + 2;
-                            contents = contents.substring(0, firstImportEnd) + clientOptionsImport
+                            contents = contents.substring(0, firstImportEnd)
+                                    + clientOptionsImport
                                     + contents.substring(firstImportEnd);
                         }
 

--- a/generators/java/generator-utils/src/main/java/com/fern/java/generators/PaginationCoreGenerator.java
+++ b/generators/java/generator-utils/src/main/java/com/fern/java/generators/PaginationCoreGenerator.java
@@ -59,6 +59,8 @@ public final class PaginationCoreGenerator extends AbstractFilesGenerator {
         List<String> fileNames = List.of(
                 "BasePage", "SyncPage", "SyncPagingIterable", "BiDirectionalPage", "CustomPager", "AsyncCustomPager");
 
+        String corePackage = generatorContext.getPoetClassNameFactory().getCorePackage();
+
         return fileNames.stream()
                 .map(fileName -> {
                     String fullFileName = "/" + fileName + ".java";
@@ -67,6 +69,15 @@ public final class PaginationCoreGenerator extends AbstractFilesGenerator {
                             throw new RuntimeException("Resource not found: " + fullFileName);
                         }
                         String contents = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+
+                        // Add ClientOptions import for CustomPager and AsyncCustomPager
+                        if (fileName.equals("CustomPager") || fileName.equals("AsyncCustomPager")) {
+                            String clientOptionsImport = "import " + corePackage + ".ClientOptions;\n";
+                            // Insert the import after the first import statement
+                            int firstImportEnd = contents.indexOf(";\n") + 2;
+                            contents = contents.substring(0, firstImportEnd) + clientOptionsImport
+                                    + contents.substring(firstImportEnd);
+                        }
 
                         // Apply custom pager name if configured
                         String customPagerName = generatorContext.getCustomConfig() != null

--- a/generators/java/generator-utils/src/main/resources/AsyncCustomPager.java
+++ b/generators/java/generator-utils/src/main/resources/AsyncCustomPager.java
@@ -57,13 +57,13 @@ public class AsyncCustomPager<T> implements BiDirectionalPage<T> {
      * Create an AsyncCustomPager from an initial response.
      *
      * @param initialResponse The first page response from the API
-     * @param client The async HTTP client to use for subsequent requests
+     * @param clientOptions The client options containing HTTP client and other configuration
      * @param requestOptions Request options for authentication, headers, etc.
      * @return A CompletableFuture containing the new AsyncCustomPager instance
      */
     public static <T> CompletableFuture<AsyncCustomPager<T>> createAsync(
             Object initialResponse,
-            okhttp3.OkHttpClient client,
+            ClientOptions clientOptions,
             Object requestOptions) {
         throw new UnsupportedOperationException(
             "AsyncCustomPager must be implemented. " +

--- a/generators/java/generator-utils/src/main/resources/CustomPager.java
+++ b/generators/java/generator-utils/src/main/resources/CustomPager.java
@@ -55,14 +55,14 @@ public class CustomPager<T> implements BiDirectionalPage<T>, Iterable<T> {
      * Create a CustomPager from an initial response.
      *
      * @param initialResponse The first page response from the API
-     * @param client The HTTP client to use for subsequent requests
+     * @param clientOptions The client options containing HTTP client and other configuration
      * @param requestOptions Request options for authentication, headers, etc.
      * @return A new CustomPager instance
      * @throws IOException if the request fails
      */
     public static <T> CustomPager<T> create(
             Object initialResponse,
-            okhttp3.OkHttpClient client,
+            ClientOptions clientOptions,
             Object requestOptions) throws IOException {
         throw new UnsupportedOperationException(
             "CustomPager must be implemented. " +

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/AbstractHttpResponseParserGenerator.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/AbstractHttpResponseParserGenerator.java
@@ -1681,7 +1681,7 @@ public abstract class AbstractHttpResponseParserGenerator {
                 // Generate AsyncCustomPager.createAsync() call
                 CodeBlock asyncPagerCreation = CodeBlock.builder()
                         .add(
-                                "$T.createAsync($L, $L.httpClient(), $L)",
+                                "$T.createAsync($L, $L, $L)",
                                 asyncPagerClassName,
                                 variables.getParsedResponseVariableName(),
                                 clientOptionsField.name,
@@ -1699,7 +1699,7 @@ public abstract class AbstractHttpResponseParserGenerator {
 
             CodeBlock customPagerCreation = CodeBlock.builder()
                     .add(
-                            "$T.create($L, $L.httpClient(), $L)",
+                            "$T.create($L, $L, $L)",
                             customPagerClassName,
                             variables.getParsedResponseVariableName(),
                             clientOptionsField.name,

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,3 +1,13 @@
+- version: 3.24.2
+  changelogEntry:
+    - summary: |
+        Pass full `ClientOptions` instead of just `httpClient()` to custom pagination `create()` method.
+        This gives custom pager implementations access to all client configuration including base URL,
+        headers, and other options needed for making subsequent pagination requests.
+      type: fix
+  createdAt: "2025-12-15"
+  irVersion: 61
+
 - version: 3.24.1
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs: Slack thread from @tjb9dc

Changes the custom pagination `create()` method signature to accept the full `ClientOptions` object instead of just `clientOptions.httpClient()`. This gives custom pager implementations access to all client configuration (base URL, headers, timeouts, etc.) needed for making subsequent pagination requests.

## Changes Made

- Updated `CustomPager.java` template: changed second parameter from `okhttp3.OkHttpClient client` to `ClientOptions clientOptions`
- Updated `AsyncCustomPager.java` template: same parameter change for `createAsync()`
- Updated `AbstractHttpResponseParserGenerator.java`: changed generated call sites from `clientOptions.httpClient()` to `clientOptions`
- Updated `PaginationCoreGenerator.java`: dynamically injects `ClientOptions` import for custom pager templates at generation time
- Added version 3.24.2 changelog entry

## Testing

- [ ] Seed tests for `pagination:default` and `pagination-custom` fixtures should pass

## Human Review Checklist

- [ ] Verify the import injection logic in `PaginationCoreGenerator.java` correctly inserts the import after the first import statement (assumes template files have at least one import)
- [ ] Consider if this is a breaking change for users who have already implemented custom pagers with the old signature (feature was added in 3.18.0)
- [ ] Confirm generated code compiles correctly with the new `ClientOptions` parameter

---

Link to Devin run: https://app.devin.ai/sessions/870912c451be4a4f8a63c3683ea4ed11
Requested by: thomas@buildwithfern.com (@tjb9dc)