### PR TITLE
chore(cli): bump versions.yml for fernignore sharing feature

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Share `.fernignore` handling between local and remote task handlers. When running remote generation with `local-file-system` output mode, the `.fernignore` file is now respected, matching the behavior of local generation.
+      type: feat
+  irVersion: 62
+  createdAt: "2025-12-15"
+  version: 3.22.0
+
+- changelogEntry:
+    - summary: |
         Fix ExampleValidator to validate response examples against their corresponding status code schemas instead of always using the 200/201 success schema. Error response examples (400, 404, 500, etc.) are now correctly validated against their respective schemas.
       type: fix
   irVersion: 62


### PR DESCRIPTION
## Description
Refs https://github.com/fern-api/fern/pull/11229

Requested by: @dsinghvi (Deep Singhvi)
Link to Devin run: https://app.devin.ai/sessions/5ddd7bf4eb174808a3a9ca5c85c87bbf

Follow-up PR to add the version bump entry for the fernignore sharing feature that was merged in PR #11229.

## Changes Made
- Added changelog entry for version 3.22.0 documenting the fernignore handling feature
- Version bump: 3.21.1 → 3.22.0 (minor version for feat type change)

## Human Review Checklist
- [ ] Verify version number is correct (3.22.0 follows 3.21.1 for a feature)
- [ ] Verify changelog summary accurately describes the feature from PR #11229

## Testing
- [x] Lint checks pass (`pnpm run check`)