### PR TITLE
feat(cli): add interactive SDK/Docs selection prompts to fern init --openapi

### DIFF
--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -11,7 +11,13 @@ import {
 } from "@fern-api/configuration-loader";
 import { ContainerRunner, haveSameNullishness, undefinedIfNullish, undefinedIfSomeNullish } from "@fern-api/core-utils";
 import { AbsoluteFilePath, cwd, doesPathExist, isURL, resolve } from "@fern-api/fs-utils";
-import { initializeAPI, initializeDocs, initializeWithMintlify, initializeWithReadme } from "@fern-api/init";
+import {
+    initializeAPI,
+    initializeDocs,
+    initializeWithMintlify,
+    initializeWithReadme,
+    promptForGeneratorSelection
+} from "@fern-api/init";
 import { LOG_LEVELS, LogLevel } from "@fern-api/logger";
 import { askToLogin, login, logout } from "@fern-api/login";
 import { protocGenFern } from "@fern-api/protoc-gen-fern";
@@ -338,12 +344,18 @@ function addInitCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext) {
                         cliContext.failAndThrow(`${absoluteOpenApiPath} does not exist`);
                     }
                 }
+
+                // Prompt for generator selection when initializing with OpenAPI
+                const generatorSelection =
+                    absoluteOpenApiPath != null ? await promptForGeneratorSelection() : undefined;
+
                 await cliContext.runTask(async (context) => {
                     await initializeAPI({
                         organization: argv.organization,
                         versionOfCli: await getLatestVersionOfCli({ cliEnvironment: cliContext.environment }),
                         context,
-                        openApiPath: absoluteOpenApiPath
+                        openApiPath: absoluteOpenApiPath,
+                        generatorSelection
                     });
                 });
             }

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Add interactive prompts to `fern init --openapi` command. Users are now asked whether they want to generate SDKs or Docs, and if SDKs, which programming languages they want. The CLI provides a nice experience with arrow key navigation and grouped language options. The `generators.yml` file is initialized with the selected generators.
+      type: feat
+  irVersion: 62
+  createdAt: "2025-12-15"
+  version: 3.23.0
+
+- changelogEntry:
+    - summary: |
         Share `.fernignore` handling between local and remote task handlers. When running remote generation with `local-file-system` output mode, the `.fernignore` file is now respected, matching the behavior of local generation.
       type: feat
   irVersion: 62

--- a/packages/cli/init/package.json
+++ b/packages/cli/init/package.json
@@ -42,6 +42,7 @@
     "@fern-api/mintlify-importer": "workspace:*",
     "@fern-api/readme-importer": "workspace:*",
     "@fern-api/task-context": "workspace:*",
+    "@inquirer/prompts": "^7.1.0",
     "axios": "^1.12.0",
     "chalk": "^5.3.0",
     "fs-extra": "^11.1.1",

--- a/packages/cli/init/src/index.ts
+++ b/packages/cli/init/src/index.ts
@@ -2,3 +2,11 @@ export { initializeAPI } from "./initializeAPI";
 export { initializeDocs } from "./initializeDocs";
 export { initializeWithMintlify } from "./initializeWithMintlify";
 export { initializeWithReadme } from "./initializeWithReadme";
+export {
+    type GeneratorSelection,
+    type OutputType,
+    promptForGeneratorSelection,
+    promptForOutputType,
+    promptForSdkLanguages,
+    type SdkLanguage
+} from "./promptForGeneratorSelection";

--- a/packages/cli/init/src/initializeAPI.ts
+++ b/packages/cli/init/src/initializeAPI.ts
@@ -13,17 +13,20 @@ import path from "path";
 
 import { createFernDirectoryAndWorkspace } from "./createFernDirectoryAndOrganization";
 import { createFernWorkspace, createOpenAPIWorkspace } from "./createWorkspace";
+import { GeneratorSelection } from "./promptForGeneratorSelection";
 
 export async function initializeAPI({
     organization,
     versionOfCli,
     openApiPath,
-    context
+    context,
+    generatorSelection
 }: {
     organization: string | undefined;
     versionOfCli: string;
     openApiPath: AbsoluteFilePath | undefined;
     context: TaskContext;
+    generatorSelection?: GeneratorSelection;
 }): Promise<void> {
     const { absolutePathToFernDirectory } = await createFernDirectoryAndWorkspace({
         organization,
@@ -40,7 +43,8 @@ export async function initializeAPI({
             directoryOfWorkspace,
             openAPIFilePath: openApiPath,
             cliVersion: versionOfCli,
-            context
+            context,
+            generatorSelection
         });
 
         context.logger.info(chalk.green("Created new API: ./" + path.relative(process.cwd(), directoryOfWorkspace)));

--- a/packages/cli/init/src/promptForGeneratorSelection.ts
+++ b/packages/cli/init/src/promptForGeneratorSelection.ts
@@ -10,6 +10,19 @@ export interface GeneratorSelection {
     sdkLanguages: SdkLanguage[];
 }
 
+/**
+ * Check if the current environment is interactive (has a TTY).
+ * Returns false in CI environments or when stdin/stdout are not TTYs.
+ */
+function isInteractiveEnvironment(): boolean {
+    // Check if we're in a CI environment
+    if (process.env.CI != null) {
+        return false;
+    }
+    // Check if stdin and stdout are TTYs
+    return process.stdin.isTTY === true && process.stdout.isTTY === true;
+}
+
 const SDK_LANGUAGE_CHOICES: Array<{ name: string; value: SdkLanguage; description?: string }> = [
     { name: "TypeScript", value: "typescript", description: "Generate a TypeScript SDK" },
     { name: "Python", value: "python", description: "Generate a Python SDK" },
@@ -87,7 +100,16 @@ export async function promptForSdkLanguages(): Promise<SdkLanguage[]> {
     return answer;
 }
 
-export async function promptForGeneratorSelection(): Promise<GeneratorSelection> {
+/**
+ * Prompts the user for generator selection (SDKs/Docs and languages).
+ * Returns undefined in non-interactive environments (CI, no TTY) to use defaults.
+ */
+export async function promptForGeneratorSelection(): Promise<GeneratorSelection | undefined> {
+    // Skip prompts in non-interactive environments
+    if (!isInteractiveEnvironment()) {
+        return undefined;
+    }
+
     const outputType = await promptForOutputType();
 
     let sdkLanguages: SdkLanguage[] = [];

--- a/packages/cli/init/src/promptForGeneratorSelection.ts
+++ b/packages/cli/init/src/promptForGeneratorSelection.ts
@@ -1,0 +1,102 @@
+import { checkbox, Separator, select } from "@inquirer/prompts";
+import chalk from "chalk";
+
+export type OutputType = "sdks" | "docs" | "both";
+
+export type SdkLanguage = "typescript" | "python" | "java" | "go" | "csharp" | "ruby" | "php" | "swift";
+
+export interface GeneratorSelection {
+    outputType: OutputType;
+    sdkLanguages: SdkLanguage[];
+}
+
+const SDK_LANGUAGE_CHOICES: Array<{ name: string; value: SdkLanguage; description?: string }> = [
+    { name: "TypeScript", value: "typescript", description: "Generate a TypeScript SDK" },
+    { name: "Python", value: "python", description: "Generate a Python SDK" },
+    { name: "Java", value: "java", description: "Generate a Java SDK" },
+    { name: "Go", value: "go", description: "Generate a Go SDK" },
+    { name: "C#", value: "csharp", description: "Generate a C# SDK" },
+    { name: "Ruby", value: "ruby", description: "Generate a Ruby SDK" },
+    { name: "PHP", value: "php", description: "Generate a PHP SDK" },
+    { name: "Swift", value: "swift", description: "Generate a Swift SDK" }
+];
+
+export async function promptForOutputType(): Promise<OutputType> {
+    const answer = await select<OutputType>({
+        message: "What would you like to generate?",
+        choices: [
+            {
+                name: "SDKs",
+                value: "sdks",
+                description: "Generate client SDKs in one or more languages"
+            },
+            {
+                name: "Docs",
+                value: "docs",
+                description: "Generate API documentation"
+            },
+            {
+                name: "Both SDKs and Docs",
+                value: "both",
+                description: "Generate both client SDKs and API documentation"
+            }
+        ],
+        theme: {
+            prefix: chalk.green("?"),
+            style: {
+                message: (text: string) => chalk.bold(text),
+                highlight: (text: string) => chalk.cyan(text),
+                description: (text: string) => chalk.dim(text)
+            }
+        }
+    });
+    return answer;
+}
+
+export async function promptForSdkLanguages(): Promise<SdkLanguage[]> {
+    const answer = await checkbox<SdkLanguage>({
+        message: "Which SDK languages would you like to generate?",
+        choices: [
+            new Separator(chalk.dim("--- Popular ---")),
+            ...SDK_LANGUAGE_CHOICES.slice(0, 4),
+            new Separator(chalk.dim("--- Other ---")),
+            ...SDK_LANGUAGE_CHOICES.slice(4)
+        ],
+        instructions: chalk.dim("(Press <space> to select, <a> to toggle all, <enter> to confirm)"),
+        required: true,
+        validate: (choices) => {
+            if (choices.length === 0) {
+                return "Please select at least one SDK language";
+            }
+            return true;
+        },
+        theme: {
+            prefix: chalk.green("?"),
+            icon: {
+                checked: chalk.green("[x]"),
+                unchecked: "[ ]",
+                cursor: chalk.cyan(">")
+            },
+            style: {
+                message: (text: string) => chalk.bold(text),
+                highlight: (text: string) => chalk.cyan(text),
+                description: (text: string) => chalk.dim(text)
+            }
+        }
+    });
+    return answer;
+}
+
+export async function promptForGeneratorSelection(): Promise<GeneratorSelection> {
+    const outputType = await promptForOutputType();
+
+    let sdkLanguages: SdkLanguage[] = [];
+    if (outputType === "sdks" || outputType === "both") {
+        sdkLanguages = await promptForSdkLanguages();
+    }
+
+    return {
+        outputType,
+        sdkLanguages
+    };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6450,6 +6450,9 @@ importers:
       '@fern-api/task-context':
         specifier: workspace:*
         version: link:../task-context
+      '@inquirer/prompts':
+        specifier: ^7.1.0
+        version: 7.8.6(@types/node@18.15.3)
       axios:
         specifier: ^1.12.0
         version: 1.12.2


### PR DESCRIPTION
## Description
Refs: User request from Deep Singhvi (@dsinghvi)

Adds interactive prompts to the `fern init --openapi` command that ask users whether they want to generate SDKs or Docs, and if SDKs, which programming languages they want. The CLI provides arrow key navigation and grouped language options.

Link to Devin run: https://app.devin.ai/sessions/c8c3f230dbb043bc95536fbe6a365ad7

## Changes Made
- Added new `promptForGeneratorSelection.ts` module with interactive prompts using `@inquirer/prompts`
- First prompt asks: SDKs / Docs / Both SDKs and Docs
- Second prompt (if SDKs selected): Multi-select for languages grouped as "Popular" (TypeScript, Python, Java, Go) and "Other" (C#, Ruby, PHP, Swift)
- Updated `createWorkspace.ts` to generate `generators.yml` with selected generators
- Added `@inquirer/prompts` dependency to the init package
- Added changelog entry for version 3.23.0
- Added TTY detection to skip prompts in non-interactive environments (CI, tests)

## Updates Since Last Revision
- Added `isInteractiveEnvironment()` check to skip interactive prompts when running in CI or non-TTY environments
- This ensures backward compatibility and prevents test timeouts by falling back to the default TypeScript SDK configuration

## Human Review Checklist
- [ ] **Important**: When "Docs" only is selected, the generators array will be empty since docs generator support is not implemented. Verify this is acceptable or if docs generator should be added.
- [ ] Verify the interactive prompts work correctly by running `fern init --openapi <url>` in a terminal
- [ ] Confirm backward compatibility: when no OpenAPI path is provided, it should still default to TypeScript SDK
- [ ] Verify TTY detection works correctly (prompts should appear in terminal, not in CI)

## Testing
- [x] Code compiles successfully (`pnpm compile`)
- [x] Lint checks pass (`pnpm check`)
- [x] TTY detection added to prevent test timeouts in CI
- [ ] Manual testing of interactive prompts (not yet performed)
- [ ] Unit tests added/updated (not added)