### PR TITLE
chore(cli): update default page actions

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,5 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
+    - summary: Update the default page actions to include ChatGPT, Claude, and Cursor.
+      type: feat
+  irVersion: 62
+  createdAt: "2025-12-16"
+  version: 3.23.0
+
+- changelogEntry:
     - summary: Improve dynamic IR generation for inferred auth.
       type: fix
   irVersion: 62

--- a/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
+++ b/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
@@ -331,9 +331,9 @@ function convertPageActions(
             askAi: pageActions.options?.askAi ?? true,
             copyPage: pageActions.options?.copyPage ?? true,
             viewAsMarkdown: pageActions.options?.viewAsMarkdown ?? true,
-            openAi: pageActions.options?.chatgpt ?? false,
-            claude: pageActions.options?.claude ?? false,
-            cursor: pageActions.options?.cursor ?? false,
+            openAi: pageActions.options?.chatgpt ?? true,
+            claude: pageActions.options?.claude ?? true,
+            cursor: pageActions.options?.cursor ?? true,
             vscode: pageActions.options?.vscode ?? false,
             custom: (pageActions.options?.custom ?? []).map((action) =>
                 convertCustomPageAction(action, absoluteFilepathToDocsConfig)


### PR DESCRIPTION
now, if you had no `page-actions` config specified and then add only a custom option, the defaults in production should remain the same (before, the defaults in the frontend would get overriden by the defaults in the CLI). 

now, the CLI and frontend agree that these are the defaults unless specifically turned off.