### PR TITLE
feat(ci): automated vuln patching for dependabot and java-sdk container

### DIFF
--- a/.github/actions/process-grype-vulns/action.yml
+++ b/.github/actions/process-grype-vulns/action.yml
@@ -1,0 +1,358 @@
+name: Process Grype Vulnerabilities
+description: Process grype scan results and create a PR with vulnerability details
+
+inputs:
+  container_name:
+    description: Name of the container being scanned (used in PR title and branch name for differentiation)
+    required: true
+  grype_report_path:
+    description: Path to the grype JSON report file
+    required: false
+    default: "grype-report.json"
+  base_branch:
+    description: Base branch for the PR
+    required: false
+    default: "main"
+  ignored_cves:
+    description: Newline-separated list of CVE IDs to ignore
+    required: false
+    default: ""
+  devin_prompt:
+    description: Instructions for Devin AI to include in the PR
+    required: false
+    default: |
+      @devin-ai-integration Please remediate the container vulnerabilities found by today's grype scan of the container specified in the summary below.
+
+      **Instructions:**
+      1. Analyze each vulnerability and understand its impact
+      2. For OS-level vulnerabilities, consider updating the base image or specific packages
+      3. For Python dependencies, update the affected packages in pyproject.toml/poetry.lock
+      4. Run tests to ensure the updates don't break anything
+      5. Build the container locally and re-scan to confirm your changes actually address the CVEs.
+      6. Push your fix to this PR branch and tag @davidkonigsberg for review
+      7. Delete the scaffold file (.github/grype-scans/scan-*.md) as part of your fix
+
+      **Vulnerability Details:**
+  slack_token:
+    description: Slack bot token for notifications
+    required: false
+    default: ""
+  github_token:
+    description: GitHub token for creating PRs
+    required: true
+
+runs:
+  using: "composite"
+
+  steps:
+    - name: Process vulnerabilities and create PR
+      id: process-vulns
+      uses: actions/github-script@v7
+      env:
+        CONTAINER_NAME: ${{ inputs.container_name }}
+        IGNORED_CVES: ${{ inputs.ignored_cves }}
+        DEVIN_PROMPT: ${{ inputs.devin_prompt }}
+        SLACK_TOKEN: ${{ inputs.slack_token }}
+        GRYPE_REPORT_PATH: ${{ inputs.grype_report_path }}
+        BASE_BRANCH: ${{ inputs.base_branch }}
+      with:
+        github-token: ${{ inputs.github_token }}
+        script: |
+          const fs = require('fs');
+          const containerName = process.env.CONTAINER_NAME;
+          const devinPrompt = process.env.DEVIN_PROMPT;
+          const slackToken = process.env.SLACK_TOKEN;
+          const slackChannelId = 'C0A23CZEFNF';
+          const devinMention = '<@U088PL5FS3B>';
+          const owner = context.repo.owner;
+          const repo = context.repo.repo;
+          const baseBranch = process.env.BASE_BRANCH;
+          const grypeReportPath = process.env.GRYPE_REPORT_PATH;
+
+          // Create a slug from container name for use in branch/file names
+          const containerSlug = containerName
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, '-')
+            .replace(/^-+|-+$/g, '')
+            .substring(0, 50);
+
+          console.log(`Processing vulnerabilities for container: ${containerName} (slug: ${containerSlug})`);
+
+          // Parse ignored CVEs from environment variable
+          const ignoredCVEs = new Set(
+            (process.env.IGNORED_CVES || '')
+              .split(/\s+/)
+              .map(s => s.trim())
+              .filter(s => s && !s.startsWith('#'))
+          );
+
+          console.log(`Ignored CVEs: ${[...ignoredCVEs].join(', ') || 'none'}`);
+
+          // Read grype report
+          const report = JSON.parse(fs.readFileSync(grypeReportPath, 'utf8'));
+          const matches = report.matches || [];
+
+          console.log(`Total vulnerabilities found: ${matches.length}`);
+
+          // Filter vulnerabilities:
+          // - Include Critical, High, Medium, Low severities
+          // - Exclude "wont-fix" fix state
+          // - Exclude ignored CVEs
+          const allowedSeverities = new Set(['Critical', 'High', 'Medium', 'Low']);
+
+          const relevant = [];
+          const seen = new Set(); // Deduplicate by CVE + package + version
+
+          for (const match of matches) {
+            const vuln = match.vulnerability || {};
+            const artifact = match.artifact || {};
+            const id = vuln.id;
+            const severity = vuln.severity;
+            const fixState = (vuln.fix?.state || '').toLowerCase();
+            const packageName = artifact.name || 'unknown';
+            const packageVersion = artifact.version || 'unknown';
+            const packageType = artifact.type || 'unknown';
+
+            // Skip if not in allowed severities
+            if (!allowedSeverities.has(severity)) {
+              continue;
+            }
+
+            // Skip if "wont-fix"
+            if (fixState === 'wont-fix') {
+              continue;
+            }
+
+            // Skip if in ignored list
+            if (ignoredCVEs.has(id)) {
+              console.log(`Skipping ignored CVE: ${id}`);
+              continue;
+            }
+
+            // Deduplicate
+            const key = `${id}:${packageName}:${packageVersion}`;
+            if (seen.has(key)) {
+              continue;
+            }
+            seen.add(key);
+
+            relevant.push({
+              id,
+              severity,
+              fixState,
+              packageName,
+              packageVersion,
+              packageType,
+              description: vuln.description || 'No description available',
+              fixVersions: vuln.fix?.versions || [],
+              dataSource: vuln.dataSource || '',
+            });
+          }
+
+          console.log(`Relevant vulnerabilities after filtering: ${relevant.length}`);
+
+          if (relevant.length === 0) {
+            console.log('No actionable vulnerabilities found. Exiting.');
+            return;
+          }
+
+          // Sort by severity (Critical > High > Medium > Low)
+          const severityOrder = { 'Critical': 0, 'High': 1, 'Medium': 2, 'Low': 3 };
+          relevant.sort((a, b) => (severityOrder[a.severity] || 99) - (severityOrder[b.severity] || 99));
+
+          // Check for existing open PR for this specific container
+          const existingPRs = await github.paginate(github.rest.pulls.list, {
+            owner,
+            repo,
+            state: 'open',
+            per_page: 100
+          });
+
+          const prTitlePrefix = `[Grype Scan][${containerName}]`;
+          const existingGrypePR = existingPRs.find(pr => pr.title.startsWith(prTitlePrefix));
+          if (existingGrypePR) {
+            console.log(`Open Grype scan PR for ${containerName} already exists: #${existingGrypePR.number}. Skipping PR creation.`);
+            return;
+          }
+
+          // Use stable branch name per container (no date) to prevent duplicate PRs
+          // If the workflow runs twice, the same branch name ensures we can detect existing PRs
+          const branchName = `grype-scan-${containerSlug}`;
+          
+          // Generate date string for file naming only (for historical tracking)
+          const now = new Date();
+          const dateStr = now.toISOString().split('T')[0].replace(/-/g, '');
+          const filePath = `.github/grype-scans/scan-${containerSlug}-${dateStr}.md`;
+
+          // Check for existing open PR by head branch (more reliable than title matching)
+          const existingPRByBranch = existingPRs.find(pr => pr.head.ref === branchName);
+          if (existingPRByBranch) {
+            console.log(`Open PR #${existingPRByBranch.number} already exists for branch ${branchName}. Skipping PR creation.`);
+            return;
+          }
+
+          // Check if branch already exists - if so, delete it since there's no open PR
+          try {
+            await github.rest.git.getRef({
+              owner,
+              repo,
+              ref: `heads/${branchName}`,
+            });
+            // Branch exists but no open PR (we already checked above) - safe to delete and recreate
+            console.log(`Branch ${branchName} exists but has no open PR. Deleting to recreate...`);
+            await github.rest.git.deleteRef({
+              owner,
+              repo,
+              ref: `heads/${branchName}`,
+            });
+          } catch (e) {
+            if (e.status !== 404) throw e;
+            // Branch doesn't exist, which is fine
+          }
+
+          // Build vulnerability summary
+          const criticalCount = relevant.filter(v => v.severity === 'Critical').length;
+          const highCount = relevant.filter(v => v.severity === 'High').length;
+          const mediumCount = relevant.filter(v => v.severity === 'Medium').length;
+          const lowCount = relevant.filter(v => v.severity === 'Low').length;
+
+          let vulnDetails = '';
+          for (const v of relevant) {
+            const fixInfo = v.fixVersions.length > 0
+              ? `Fix available: ${v.fixVersions.join(', ')}`
+              : 'No fix available yet';
+
+            vulnDetails += `
+          ### ${v.id} (${v.severity})
+          - **Package:** ${v.packageName} @ ${v.packageVersion} (${v.packageType})
+          - **Status:** ${v.fixState}
+          - **${fixInfo}**
+          - **Source:** ${v.dataSource}
+
+          ${v.description}
+
+          ---
+          `;
+          }
+
+          const prTitle = `${prTitlePrefix} ${relevant.length} vulnerabilities found (${criticalCount} Critical, ${highCount} High, ${mediumCount} Medium, ${lowCount} Low)`;
+
+          const alertContent = `${devinPrompt}
+
+          ## Summary
+          - **Container:** ${containerName}
+          - **Scan Date:** ${now.toISOString()}
+          - **Total Vulnerabilities:** ${relevant.length}
+          - **Critical:** ${criticalCount}
+          - **High:** ${highCount}
+          - **Medium:** ${mediumCount}
+          - **Low:** ${lowCount}
+
+          ## Vulnerabilities
+          ${vulnDetails}
+          `;
+
+          try {
+            // Get base branch ref
+            const baseRef = await github.rest.git.getRef({
+              owner,
+              repo,
+              ref: `heads/${baseBranch}`,
+            });
+            const baseCommitSha = baseRef.data.object.sha;
+
+            const baseCommit = await github.rest.git.getCommit({
+              owner,
+              repo,
+              commit_sha: baseCommitSha,
+            });
+            const baseTreeSha = baseCommit.data.tree.sha;
+
+            // Create blob with alert content
+            const blob = await github.rest.git.createBlob({
+              owner,
+              repo,
+              content: alertContent,
+              encoding: 'utf-8',
+            });
+
+            // Create tree with new file
+            const tree = await github.rest.git.createTree({
+              owner,
+              repo,
+              base_tree: baseTreeSha,
+              tree: [
+                {
+                  path: filePath,
+                  mode: '100644',
+                  type: 'blob',
+                  sha: blob.data.sha,
+                },
+              ],
+            });
+
+            // Create commit
+            const commit = await github.rest.git.createCommit({
+              owner,
+              repo,
+              message: `[Grype Scan][${containerName}] Scaffold PR for ${relevant.length} vulnerabilities`,
+              tree: tree.data.sha,
+              parents: [baseCommitSha],
+            });
+
+            // Create branch
+            await github.rest.git.createRef({
+              owner,
+              repo,
+              ref: `refs/heads/${branchName}`,
+              sha: commit.data.sha,
+            });
+
+            // Create PR
+            const pr = await github.rest.pulls.create({
+              owner,
+              repo,
+              title: prTitle,
+              head: branchName,
+              base: baseBranch,
+              body: alertContent,
+              draft: true,
+            });
+
+            console.log(`Created PR #${pr.data.number}: ${prTitle}`);
+
+            // Send Slack notification
+            if (slackToken) {
+              const message = `${devinMention} *New Grype Container Scan PR Created*\nNew PR created for \`${containerName}\` container security vulnerabilities. Please open a PR into the \`fern\` repo to address the ${relevant.length} vulnerabilities found. Follow the instructions in the <${pr.data.html_url}|PR>.`;
+
+              try {
+                const response = await fetch('https://slack.com/api/chat.postMessage', {
+                  method: 'POST',
+                  headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${slackToken}`
+                  },
+                  body: JSON.stringify({
+                    channel: slackChannelId,
+                    text: message,
+                    mrkdwn: true
+                  })
+                });
+
+                const result = await response.json();
+                if (result.ok) {
+                  console.log(`Sent Slack notification for PR #${pr.data.number}`);
+                } else {
+                  console.error(`Failed to send Slack notification: ${result.error}`);
+                }
+              } catch (error) {
+                console.error(`Error sending Slack notification: ${error.message}`);
+              }
+            } else {
+              console.log('No Slack token configured, skipping notification');
+            }
+
+          } catch (error) {
+            console.error(`Failed to create PR: ${error.message}`);
+            throw error;
+          }

--- a/.github/actions/process-grype-vulns/action.yml
+++ b/.github/actions/process-grype-vulns/action.yml
@@ -98,6 +98,7 @@ runs:
           // - Include Critical, High, Medium, Low severities
           // - Exclude "wont-fix" fix state
           // - Exclude ignored CVEs
+          // - Only include CVEs that have a fix available
           const allowedSeverities = new Set(['Critical', 'High', 'Medium', 'Low']);
 
           const relevant = [];
@@ -123,6 +124,12 @@ runs:
               continue;
             }
 
+            // Skip if no fix is available
+            const fixVersions = vuln.fix?.versions || [];
+            if (fixVersions.length === 0) {
+              continue;
+            }
+
             // Skip if in ignored list
             if (ignoredCVEs.has(id)) {
               console.log(`Skipping ignored CVE: ${id}`);
@@ -144,7 +151,7 @@ runs:
               packageVersion,
               packageType,
               description: vuln.description || 'No description available',
-              fixVersions: vuln.fix?.versions || [],
+              fixVersions,
               dataSource: vuln.dataSource || '',
             });
           }

--- a/.github/workflows/publish-generator-java-sdk.yml
+++ b/.github/workflows/publish-generator-java-sdk.yml
@@ -48,18 +48,3 @@ jobs:
           manual-trigger: "true"
           fern-token: ${{ secrets.FERN_TOKEN }}
           docker-pwd: ${{ secrets.FERN_API_DOCKERHUB_PASSWORD }}
-      - name: Configure AWS Credentials
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: "arn:aws:iam::985111089818:role/github-ci"
-          aws-region: "us-east-1"
-      - name: Upload to ECR for scanning
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: |-
-          aws sts get-caller-identity
-          docker pull fernapi/fern-java-sdk:${{ inputs.version }}
-          SANITIZED_BRANCH="${BRANCH_NAME//\//-}"
-          docker tag fernapi/fern-java-sdk:${{ inputs.version }} 985111089818.dkr.ecr.us-east-1.amazonaws.com/dev/java-sdk-generator:${{ inputs.version }}-$SANITIZED_BRANCH-${{ github.sha }}
-          aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 985111089818.dkr.ecr.us-east-1.amazonaws.com
-          docker push 985111089818.dkr.ecr.us-east-1.amazonaws.com/dev/java-sdk-generator:${{ inputs.version }}-$SANITIZED_BRANCH-${{ github.sha }}

--- a/.github/workflows/security-scanning-and-remediation.yml
+++ b/.github/workflows/security-scanning-and-remediation.yml
@@ -19,9 +19,9 @@ name: Create PRs to Remediate vulns
 # ============================================================
 
 on:
-  #schedule:
-  # Run at 5AM EST (10AM UTC) every day
-  #- cron: "0 10 * * *"
+  schedule:
+    # Run at 5AM EST (10AM UTC) every day
+    - cron: "0 10 * * *"
   workflow_dispatch: # Allow manual triggering
 
 jobs:
@@ -362,6 +362,21 @@ jobs:
 
       - name: Build container
         run: docker build -f generators/java/sdk/Dockerfile -t java-sdk:grype-scan .
+
+      - name: Configure AWS Credentials
+        #if: ${{ github.event_name != 'workflow_dispatch' }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: "arn:aws:iam::985111089818:role/github-ci"
+          aws-region: "us-east-1"
+
+      - name: Push to ECR (to keep AWS scans up to date)
+        #if: ${{ github.event_name != 'workflow_dispatch' }}
+        run: |
+          aws sts get-caller-identity
+          docker tag java-sdk:grype-scan 985111089818.dkr.ecr.us-east-1.amazonaws.com/dev/java-sdk-generator:latest-${{ github.sha }}
+          aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 985111089818.dkr.ecr.us-east-1.amazonaws.com
+          docker push 985111089818.dkr.ecr.us-east-1.amazonaws.com/dev/java-sdk-generator:latest-${{ github.sha }}
 
       - name: Install grype
         run: |

--- a/.github/workflows/security-scanning-and-remediation.yml
+++ b/.github/workflows/security-scanning-and-remediation.yml
@@ -72,3 +72,314 @@ jobs:
 
             console.log(`Found ${alerts.length} open Dependabot alerts.`);
             core.setOutput('alerts_json', JSON.stringify(alerts));
+      - name: Create PRs and send Slack notifications
+        id: create-prs
+        if: steps.fetch-alerts.outputs.alerts_json != '[]'
+        uses: actions/github-script@v7
+        env:
+          # ============================================================
+          # DEVIN PROMPT CONFIGURATION
+          # Edit the prompt below to customize instructions for Devin
+          # ============================================================
+          DEVIN_PROMPT: |
+            @devin-ai-integration Please resolve this Dependabot security alert.
+
+            **Instructions:**
+            1. Analyze the vulnerability and understand its impact
+            2. Update the affected dependency to a secure version
+            3. Ideally resolve this without using an override - prefer updating the dependency directly
+            4. If an override is absolutely necessary, document why in the PR description
+            5. Run tests to ensure the update doesn't break anything
+            6. Push your fix to this PR branch and tag @davidkonigsberg for review
+            7. Delete the scaffold file (.github/dependabot-alerts/alert-*.md) as part of your fix
+
+            **Alert Details:**
+          ALERTS_JSON: ${{ steps.fetch-alerts.outputs.alerts_json }}
+          SLACK_TOKEN: ${{ secrets.DEVIN_AI_PR_BOT_SLACK_TOKEN }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const devinPrompt = process.env.DEVIN_PROMPT;
+            const slackToken = process.env.SLACK_TOKEN;
+            const slackChannelId = 'C0A23CZEFNF';
+            const devinMention = '<@U088PL5FS3B>';
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const baseBranch = 'app';
+
+            const alerts = JSON.parse(process.env.ALERTS_JSON || '[]');
+            if (alerts.length === 0) {
+              console.log('No alerts to process.');
+              return;
+            }
+
+            console.log(`Processing ${alerts.length} Dependabot alerts.`);
+
+            // Fetch existing OPEN PRs to check for duplicates (closed PRs should not block new ones)
+            const existingPRs = await github.paginate(github.rest.pulls.list, {
+              owner,
+              repo,
+              state: 'open',
+              per_page: 100
+            });
+
+            // Create a set of alert numbers that already have open PRs
+            const existingAlertNumbers = new Set();
+            // Also track packages that already have open PRs to avoid creating multiple PRs for the same package
+            const existingPackages = new Set();
+            for (const pr of existingPRs) {
+              const alertMatch = pr.title.match(/\[Dependabot Alert #(\d+)\]/);
+              if (alertMatch) {
+                existingAlertNumbers.add(parseInt(alertMatch[1]));
+                // Extract package name from PR title (format: "[Dependabot Alert #N] SEVERITY: packageName vulnerability")
+                const packageMatch = pr.title.match(/\[Dependabot Alert #\d+\] \w+: (.+) vulnerability/);
+                if (packageMatch) {
+                  existingPackages.add(packageMatch[1]);
+                }
+              }
+            }
+
+            console.log(`Found ${existingAlertNumbers.size} existing open PRs for Dependabot alerts.`);
+            console.log(`Found ${existingPackages.size} packages with existing open PRs: ${[...existingPackages].join(', ')}`);
+
+            // Track packages we create PRs for in this run to avoid duplicates within the same run
+            const packagesWithNewPRs = new Set();
+
+            // Get the base branch ref for creating new branches
+            const baseRef = await github.rest.git.getRef({
+              owner,
+              repo,
+              ref: `heads/${baseBranch}`,
+            });
+            const baseCommitSha = baseRef.data.object.sha;
+
+            const baseCommit = await github.rest.git.getCommit({
+              owner,
+              repo,
+              commit_sha: baseCommitSha,
+            });
+            const baseTreeSha = baseCommit.data.tree.sha;
+
+            // Helper function to send Slack notification
+            async function sendSlackNotification(prInfo) {
+              const message = `${devinMention} *New Dependabot Alert PR Created*\nNew PR created for Dependabot security alert. Please open a PR into the \`fern-platform\` repo to address the dependabot alert "<${prInfo.alertUrl}|${prInfo.alertName}>". Follow the instructions in the <${prInfo.url}|PR>.`;
+              
+              try {
+                const response = await fetch('https://slack.com/api/chat.postMessage', {
+                  method: 'POST',
+                  headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${slackToken}`
+                  },
+                  body: JSON.stringify({
+                    channel: slackChannelId,
+                    text: message,
+                    mrkdwn: true
+                  })
+                });
+                
+                const result = await response.json();
+                if (result.ok) {
+                  console.log(`Sent Slack notification for PR #${prInfo.number}: ${prInfo.alertName}`);
+                } else {
+                  console.error(`Failed to send Slack notification for PR #${prInfo.number}: ${result.error}`);
+                }
+              } catch (error) {
+                console.error(`Error sending Slack notification for PR #${prInfo.number}: ${error.message}`);
+              }
+            }
+
+            // Create PRs for new alerts
+            let createdCount = 0;
+            let skippedDueToPackage = 0;
+            for (const alert of alerts) {
+              if (existingAlertNumbers.has(alert.number)) {
+                console.log(`PR already exists for alert #${alert.number}, skipping.`);
+                continue;
+              }
+
+              const severity = alert.security_advisory?.severity || 'unknown';
+              const packageName = alert.security_vulnerability?.package?.name || 'unknown package';
+
+              // Skip if there's already an open PR for this package (either existing or created in this run)
+              if (existingPackages.has(packageName) || packagesWithNewPRs.has(packageName)) {
+                console.log(`PR already exists for package "${packageName}" (alert #${alert.number}), skipping to avoid duplicate PRs.`);
+                skippedDueToPackage++;
+                continue;
+              }
+              const ecosystem = alert.security_vulnerability?.package?.ecosystem || 'unknown';
+              const vulnerableVersionRange = alert.security_vulnerability?.vulnerable_version_range || 'unknown';
+              const patchedVersions = alert.security_vulnerability?.first_patched_version?.identifier || 'No patch available';
+              const cveId = alert.security_advisory?.cve_id || 'N/A';
+              const ghsaId = alert.security_advisory?.ghsa_id || 'N/A';
+              const summary = alert.security_advisory?.summary || 'No summary available';
+              const description = alert.security_advisory?.description || 'No description available';
+              const manifestPath = alert.dependency?.manifest_path || 'unknown';
+
+              const branchName = `dependabot-alert-${alert.number}-devin`;
+              const filePath = `.github/dependabot-alerts/alert-${alert.number}.md`;
+
+              // Check if branch already exists - if so, delete it (it's from a closed PR)
+              try {
+                await github.rest.git.getRef({
+                  owner,
+                  repo,
+                  ref: `heads/${branchName}`,
+                });
+                // Branch exists but no open PR (we already checked for open PRs above)
+                // Delete the old branch so we can create a fresh one
+                console.log(`Deleting old branch ${branchName} from closed PR...`);
+                await github.rest.git.deleteRef({
+                  owner,
+                  repo,
+                  ref: `heads/${branchName}`,
+                });
+              } catch (e) {
+                if (e.status !== 404) throw e;
+                // Branch doesn't exist, which is fine
+              }
+
+              const prTitle = `[Dependabot Alert #${alert.number}] ${severity.toUpperCase()}: ${packageName} vulnerability`;
+
+              const alertContent = `${devinPrompt}
+            - **Package:** ${packageName} (${ecosystem})
+            - **Severity:** ${severity.toUpperCase()}
+            - **Vulnerable versions:** ${vulnerableVersionRange}
+            - **Patched version:** ${patchedVersions}
+            - **CVE:** ${cveId}
+            - **GHSA:** ${ghsaId}
+            - **Manifest:** ${manifestPath}
+
+            **Summary:**
+            ${summary}
+
+            **Description:**
+            ${description}
+
+            ---
+            [View Dependabot Alert](https://github.com/${owner}/${repo}/security/dependabot/${alert.number})
+            `;
+
+              try {
+                // Create a blob with the alert content
+                const blob = await github.rest.git.createBlob({
+                  owner,
+                  repo,
+                  content: alertContent,
+                  encoding: 'utf-8',
+                });
+
+                // Create a tree with the new file
+                const tree = await github.rest.git.createTree({
+                  owner,
+                  repo,
+                  base_tree: baseTreeSha,
+                  tree: [
+                    {
+                      path: filePath,
+                      mode: '100644',
+                      type: 'blob',
+                      sha: blob.data.sha,
+                    },
+                  ],
+                });
+
+                // Create a commit
+                const commit = await github.rest.git.createCommit({
+                  owner,
+                  repo,
+                  message: `[Dependabot Alert #${alert.number}] Scaffold PR for ${packageName}`,
+                  tree: tree.data.sha,
+                  parents: [baseCommitSha],
+                });
+
+                // Create the branch
+                await github.rest.git.createRef({
+                  owner,
+                  repo,
+                  ref: `refs/heads/${branchName}`,
+                  sha: commit.data.sha,
+                });
+
+                // Create the PR
+                const pr = await github.rest.pulls.create({
+                  owner,
+                  repo,
+                  title: prTitle,
+                  head: branchName,
+                  base: baseBranch,
+                  body: alertContent,
+                  draft: true,
+                });
+
+                console.log(`Created PR for alert #${alert.number}: ${packageName}`);
+                createdCount++;
+
+                // Track this package so we don't create duplicate PRs for other alerts affecting the same package
+                packagesWithNewPRs.add(packageName);
+
+                // Send Slack notification immediately after creating the PR
+                const alertUrl = `https://github.com/${owner}/${repo}/security/dependabot/${alert.number}`;
+                await sendSlackNotification({
+                  number: pr.data.number,
+                  url: pr.data.html_url,
+                  alertName: summary,
+                  alertUrl
+                });
+              } catch (error) {
+                console.error(`Failed to create PR for alert #${alert.number}: ${error.message}`);
+              }
+            }
+
+            console.log(`Created ${createdCount} new PRs from Dependabot alerts.`);
+            if (skippedDueToPackage > 0) {
+              console.log(`Skipped ${skippedDueToPackage} alerts because PRs already exist for those packages.`);
+            }
+
+  # ============================================================
+  # GRYPE CONTAINER VULNERABILITY SCANS
+  # Builds the Docker containers and scans them with grype for
+  # OS-level and package vulnerabilities.
+  # ============================================================
+
+  create-grype-pr-java-sdk:
+    name: Run grype scan - fdr
+    runs-on: Seed
+    permissions:
+      contents: write
+      pull-requests: write
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Build the Java SDK distribution tar (Gradle)
+        run: cd generators/java && ./gradlew :sdk:distTar
+
+      - name: Build the Java v2 SDK CLI (TypeScript/Node)
+        run: pnpm turbo run dist:cli --filter @fern-api/java-sdk
+
+      - name: Build container
+        run: docker build -f generators/java/sdk/Dockerfile -t java-sdk:grype-scan .
+
+      - name: Install grype
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin
+
+      - name: Run grype scan
+        run: |
+          grype docker:java-sdk:grype-scan -o json > grype-report.json
+
+      # ============================================================
+      # IGNORED CVEs CONFIGURATION
+      # Add CVEs here that have been reviewed and accepted as risks.
+      # Format: One CVE ID per line in the ignored_cves input
+      # ============================================================
+      - name: Process vulnerabilities and create PR
+        uses: ./.github/actions/process-grype-vulns
+        with:
+          container_name: java-sdk
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          slack_token: ${{ secrets.DEVIN_AI_PR_BOT_SLACK_TOKEN }}
+          ignored_cves: ""

--- a/.github/workflows/security-scanning-and-remediation.yml
+++ b/.github/workflows/security-scanning-and-remediation.yml
@@ -354,6 +354,9 @@ jobs:
         with:
           fetch-depth: 2
 
+      - name: Install
+        uses: ./.github/actions/install
+
       - name: Build the Java SDK distribution tar (Gradle)
         run: cd generators/java && ./gradlew :sdk:distTar
 

--- a/.github/workflows/security-scanning-and-remediation.yml
+++ b/.github/workflows/security-scanning-and-remediation.yml
@@ -356,7 +356,7 @@ jobs:
           fetch-depth: 2
 
       - name: Configure AWS Credentials
-        #if: ${{ github.event_name != 'workflow_dispatch' }}
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         uses: aws-actions/configure-aws-credentials@v5
         with:
           role-to-assume: "arn:aws:iam::985111089818:role/github-ci"
@@ -375,7 +375,7 @@ jobs:
         run: docker build -f generators/java/sdk/Dockerfile -t java-sdk:grype-scan .
 
       - name: Push to ECR (to keep AWS scans up to date)
-        #if: ${{ github.event_name != 'workflow_dispatch' }}
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         run: |
           aws sts get-caller-identity
           docker tag java-sdk:grype-scan 985111089818.dkr.ecr.us-east-1.amazonaws.com/dev/java-sdk-generator:latest-${{ github.sha }}

--- a/.github/workflows/security-scanning-and-remediation.yml
+++ b/.github/workflows/security-scanning-and-remediation.yml
@@ -357,6 +357,13 @@ jobs:
         with:
           fetch-depth: 2
 
+      - name: Configure AWS Credentials
+        #if: ${{ github.event_name != 'workflow_dispatch' }}
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          role-to-assume: "arn:aws:iam::985111089818:role/github-ci"
+          aws-region: "us-east-1"
+
       - name: Install
         uses: ./.github/actions/install
 
@@ -368,13 +375,6 @@ jobs:
 
       - name: Build container
         run: docker build -f generators/java/sdk/Dockerfile -t java-sdk:grype-scan .
-
-      - name: Configure AWS Credentials
-        #if: ${{ github.event_name != 'workflow_dispatch' }}
-        uses: aws-actions/configure-aws-credentials@v5
-        with:
-          role-to-assume: "arn:aws:iam::985111089818:role/github-ci"
-          aws-region: "us-east-1"
 
       - name: Push to ECR (to keep AWS scans up to date)
         #if: ${{ github.event_name != 'workflow_dispatch' }}

--- a/.github/workflows/security-scanning-and-remediation.yml
+++ b/.github/workflows/security-scanning-and-remediation.yml
@@ -371,7 +371,7 @@ jobs:
 
       - name: Configure AWS Credentials
         #if: ${{ github.event_name != 'workflow_dispatch' }}
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           role-to-assume: "arn:aws:iam::985111089818:role/github-ci"
           aws-region: "us-east-1"

--- a/.github/workflows/security-scanning-and-remediation.yml
+++ b/.github/workflows/security-scanning-and-remediation.yml
@@ -24,6 +24,9 @@ on:
     - cron: "0 10 * * *"
   workflow_dispatch: # Allow manual triggering
 
+permissions: # Required for OIDC
+  id-token: write
+
 jobs:
   create-dependabot-prs:
     name: Check Dependabot alerts
@@ -343,7 +346,7 @@ jobs:
   # ============================================================
 
   create-grype-pr-java-sdk:
-    name: Run grype scan - fdr
+    name: Run grype scan - java SDK
     runs-on: Seed
     permissions:
       contents: write

--- a/.github/workflows/security-scanning-and-remediation.yml
+++ b/.github/workflows/security-scanning-and-remediation.yml
@@ -36,7 +36,7 @@ jobs:
         id: fetch-alerts
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.FERN_GITHUB_TOKEN }}
+          github-token: ${{ secrets.PR_BOT_GH_PAT }}
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;

--- a/.github/workflows/security-scanning-and-remediation.yml
+++ b/.github/workflows/security-scanning-and-remediation.yml
@@ -26,6 +26,7 @@ on:
 
 permissions: # Required for OIDC
   id-token: write
+  contents: read
 
 jobs:
   create-dependabot-prs:

--- a/.github/workflows/security-scanning-and-remediation.yml
+++ b/.github/workflows/security-scanning-and-remediation.yml
@@ -24,10 +24,6 @@ on:
     - cron: "0 10 * * *"
   workflow_dispatch: # Allow manual triggering
 
-permissions: # Required for OIDC
-  id-token: write
-  contents: read
-
 jobs:
   create-dependabot-prs:
     name: Check Dependabot alerts
@@ -350,6 +346,7 @@ jobs:
     name: Run grype scan - java SDK
     runs-on: Seed
     permissions:
+      id-token: write
       contents: write
       pull-requests: write
     timeout-minutes: 30


### PR DESCRIPTION
## Description
Updated CI to check for dependabot alerts and run grype scans. Creates automated PRs for security vulnerabilities with Slack notifications to trigger Devin remediation.

## Changes Made
- Added reusable action `.github/actions/process-grype-vulns/action.yml` for processing grype container scan results
- Extended `security-scanning-and-remediation.yml` workflow with:
  - Dependabot alert PR creation with Slack notifications
  - Grype container scanning job for java-sdk
  - Daily schedule (5AM EST)
- Moved ECR upload from `publish-generator-java-sdk.yml` to the security scanning workflow
- Grype scan filtering includes: severity (Critical/High/Medium/Low), excludes wont-fix, excludes ignored CVEs, and **only includes CVEs with available fixes**

## Updates since last revision
- Added filter to only create remediation PRs for CVEs that have a fix available (i.e., `vuln.fix.versions` is non-empty). This prevents creating PRs for vulnerabilities that cannot be remediated yet.

## Testing
- [ ] Manual testing completed
- CI workflow validation pending

## Human Review Checklist
- [ ] Verify grype JSON structure: confirm `vuln.fix?.versions` correctly identifies CVEs with available fixes
- [ ] Confirm the filtering logic matches expected behavior (e.g., libpng with fix version should be included, CVEs without fixes should be excluded)

---
Link to Devin run: https://app.devin.ai/sessions/de3bc6a2ca6e405294a4dce4d401ae63
Requested by: David Konigsberg (@davidkonigsberg)