### PR TITLE
feat(docs): add validation rule to detect circular redirect chains

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,5 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
+    - summary: Adds a warning to `fern check` that detects infinite redirect loops.
+      type: fix
+  irVersion: 62
+  createdAt: "2025-12-16"
+  version: 3.23.1
+
+- changelogEntry:
     - summary: Update the default page actions to include ChatGPT, Claude, and Cursor.
       type: feat
   irVersion: 62

--- a/packages/cli/yaml/docs-validator/src/getAllRules.ts
+++ b/packages/cli/yaml/docs-validator/src/getAllRules.ts
@@ -2,6 +2,7 @@ import { Rule } from "./Rule";
 import { AccentColorContrastRule } from "./rules/accent-color-contrast";
 import { AllRolesMustBeDeclaredRule } from "./rules/all-roles-must-be-declared";
 import { FilepathsExistRule } from "./rules/filepaths-exist";
+import { NoCircularRedirectsRule } from "./rules/no-circular-redirects";
 import { NoNonComponentRefsRule } from "./rules/no-non-component-refs";
 import { NoOpenApiV2InDocsRule } from "./rules/no-openapi-v2-in-docs";
 import { OnlyVersionedNavigation } from "./rules/only-versioned-navigation";
@@ -25,6 +26,7 @@ const allRules = [
     ValidateVersionFileRule,
     ValidateProductFileRule,
     ValidInstanceUrlRule, // Validate instance URLs have valid subdomains
+    NoCircularRedirectsRule, // Detect circular redirect chains
     AccentColorContrastRule,
     ValidMarkdownLinks,
     ValidFileTypes,

--- a/packages/cli/yaml/docs-validator/src/rules/index.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/index.ts
@@ -1,6 +1,7 @@
 export * from "./accent-color-contrast";
 export * from "./all-roles-must-be-declared";
 export * from "./filepaths-exist";
+export * from "./no-circular-redirects";
 export * from "./only-versioned-navigation";
 export * from "./tab-with-href";
 export * from "./valid-docs-endpoints";

--- a/packages/cli/yaml/docs-validator/src/rules/no-circular-redirects/__test__/no-circular-redirects.test.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/no-circular-redirects/__test__/no-circular-redirects.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+
+import { detectCircularRedirects } from "../no-circular-redirects";
+
+describe("detectCircularRedirects", () => {
+    it("should return no violations for valid redirects", () => {
+        const redirects = [
+            { source: "/foo", destination: "/bar" },
+            { source: "/baz", destination: "/qux" }
+        ];
+        const violations = detectCircularRedirects(redirects);
+        expect(violations).toHaveLength(0);
+    });
+
+    it("should detect self-redirect (source equals destination)", () => {
+        const redirects = [{ source: "/foo", destination: "/foo" }];
+        const violations = detectCircularRedirects(redirects);
+        expect(violations).toHaveLength(1);
+        expect(violations[0]?.message).toContain("infinite loop");
+        expect(violations[0]?.message).toContain("source equals destination");
+    });
+
+    it("should detect self-redirect with trailing slash difference", () => {
+        const redirects = [{ source: "/foo", destination: "/foo/" }];
+        const violations = detectCircularRedirects(redirects);
+        expect(violations).toHaveLength(1);
+        expect(violations[0]?.message).toContain("infinite loop");
+    });
+
+    it("should detect simple circular chain (A -> B -> A)", () => {
+        const redirects = [
+            { source: "/foo", destination: "/bar" },
+            { source: "/bar", destination: "/foo" }
+        ];
+        const violations = detectCircularRedirects(redirects);
+        expect(violations).toHaveLength(1);
+        expect(violations[0]?.message).toContain("Circular redirect chain");
+        expect(violations[0]?.message).toContain("/foo");
+        expect(violations[0]?.message).toContain("/bar");
+    });
+
+    it("should detect longer circular chain (A -> B -> C -> A)", () => {
+        const redirects = [
+            { source: "/a", destination: "/b" },
+            { source: "/b", destination: "/c" },
+            { source: "/c", destination: "/a" }
+        ];
+        const violations = detectCircularRedirects(redirects);
+        expect(violations).toHaveLength(1);
+        expect(violations[0]?.message).toContain("Circular redirect chain");
+    });
+
+    it("should not report false positives for non-circular chains", () => {
+        const redirects = [
+            { source: "/a", destination: "/b" },
+            { source: "/b", destination: "/c" },
+            { source: "/c", destination: "/d" }
+        ];
+        const violations = detectCircularRedirects(redirects);
+        expect(violations).toHaveLength(0);
+    });
+
+    it("should skip dynamic redirects (with path parameters)", () => {
+        const redirects = [
+            { source: "/foo/:id", destination: "/bar/:id" },
+            { source: "/bar/:id", destination: "/foo/:id" }
+        ];
+        const violations = detectCircularRedirects(redirects);
+        expect(violations).toHaveLength(0);
+    });
+
+    it("should detect self-redirect even with dynamic segments", () => {
+        const redirects = [{ source: "/foo/:id", destination: "/foo/:id" }];
+        const violations = detectCircularRedirects(redirects);
+        expect(violations).toHaveLength(1);
+        expect(violations[0]?.message).toContain("infinite loop");
+    });
+
+    it("should handle empty redirects array", () => {
+        const violations = detectCircularRedirects([]);
+        expect(violations).toHaveLength(0);
+    });
+
+    it("should handle mixed static and dynamic redirects", () => {
+        const redirects = [
+            { source: "/foo", destination: "/bar" },
+            { source: "/bar", destination: "/foo" },
+            { source: "/dynamic/:id", destination: "/other/:id" }
+        ];
+        const violations = detectCircularRedirects(redirects);
+        expect(violations).toHaveLength(1);
+        expect(violations[0]?.message).toContain("Circular redirect chain");
+    });
+
+    it("should detect multiple separate circular chains", () => {
+        const redirects = [
+            { source: "/a", destination: "/b" },
+            { source: "/b", destination: "/a" },
+            { source: "/x", destination: "/y" },
+            { source: "/y", destination: "/x" }
+        ];
+        const violations = detectCircularRedirects(redirects);
+        expect(violations).toHaveLength(2);
+    });
+
+    it("should not duplicate reports for the same cycle", () => {
+        const redirects = [
+            { source: "/a", destination: "/b" },
+            { source: "/b", destination: "/c" },
+            { source: "/c", destination: "/a" }
+        ];
+        const violations = detectCircularRedirects(redirects);
+        expect(violations).toHaveLength(1);
+    });
+});

--- a/packages/cli/yaml/docs-validator/src/rules/no-circular-redirects/index.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/no-circular-redirects/index.ts
@@ -1,0 +1,1 @@
+export { NoCircularRedirectsRule } from "./no-circular-redirects";

--- a/packages/cli/yaml/docs-validator/src/rules/no-circular-redirects/no-circular-redirects.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/no-circular-redirects/no-circular-redirects.ts
@@ -1,0 +1,136 @@
+import { Rule, RuleViolation } from "../../Rule";
+
+interface RedirectConfig {
+    source: string;
+    destination: string;
+    permanent?: boolean;
+}
+
+function normalizeRedirectPath(path: string): string {
+    // Remove trailing slash for comparison (except for root "/")
+    if (path !== "/" && path.endsWith("/")) {
+        return path.slice(0, -1);
+    }
+    return path;
+}
+
+function isStaticRedirect(redirect: RedirectConfig): boolean {
+    // Check if the redirect contains dynamic segments (path-to-regexp patterns)
+    return !redirect.source.includes(":") && !redirect.destination.includes(":");
+}
+
+export function detectCircularRedirects(redirects: RedirectConfig[]): RuleViolation[] {
+    const violations: RuleViolation[] = [];
+
+    // Filter to only static redirects for circular detection
+    const staticRedirects = redirects.filter(isStaticRedirect);
+
+    // Build a map of source -> destination for static redirects
+    const redirectMap = new Map<string, { destination: string; index: number }>();
+    for (let i = 0; i < staticRedirects.length; i++) {
+        const redirect = staticRedirects[i];
+        if (redirect) {
+            const normalizedSource = normalizeRedirectPath(redirect.source);
+            const normalizedDestination = normalizeRedirectPath(redirect.destination);
+            redirectMap.set(normalizedSource, { destination: normalizedDestination, index: i });
+        }
+    }
+
+    // Check for self-redirects (source === destination)
+    for (let i = 0; i < redirects.length; i++) {
+        const redirect = redirects[i];
+        if (redirect) {
+            const normalizedSource = normalizeRedirectPath(redirect.source);
+            const normalizedDestination = normalizeRedirectPath(redirect.destination);
+
+            if (normalizedSource === normalizedDestination) {
+                violations.push({
+                    severity: "error",
+                    message: `redirects[${i}]: Redirect from "${redirect.source}" to "${redirect.destination}" creates an infinite loop (source equals destination)`
+                });
+            }
+        }
+    }
+
+    // Check for circular chains (A -> B -> A, or A -> B -> C -> A, etc.)
+    const visited = new Set<string>();
+    const inCurrentPath = new Set<string>();
+
+    function detectCycle(source: string, path: string[]): string[] | null {
+        if (inCurrentPath.has(source)) {
+            // Found a cycle, return the path from the cycle start
+            const cycleStart = path.indexOf(source);
+            return path.slice(cycleStart);
+        }
+
+        if (visited.has(source)) {
+            return null;
+        }
+
+        const redirectInfo = redirectMap.get(source);
+        if (!redirectInfo) {
+            return null;
+        }
+
+        visited.add(source);
+        inCurrentPath.add(source);
+        path.push(source);
+
+        const cycle = detectCycle(redirectInfo.destination, path);
+
+        inCurrentPath.delete(source);
+        path.pop();
+
+        return cycle;
+    }
+
+    // Check each redirect source for cycles
+    const reportedCycles = new Set<string>();
+    for (const [source] of redirectMap) {
+        visited.clear();
+        inCurrentPath.clear();
+
+        const cycle = detectCycle(source, []);
+        if (cycle && cycle.length > 1) {
+            // Create a canonical representation of the cycle to avoid duplicate reports
+            const sortedCycle = [...cycle].sort();
+            const cycleKey = sortedCycle.join(" -> ");
+
+            if (!reportedCycles.has(cycleKey)) {
+                reportedCycles.add(cycleKey);
+
+                // Build the cycle chain for the error message
+                const cycleChain = [...cycle, cycle[0]].join(" -> ");
+                violations.push({
+                    severity: "error",
+                    message: `Circular redirect chain detected: ${cycleChain}`
+                });
+            }
+        }
+    }
+
+    return violations;
+}
+
+export const NoCircularRedirectsRule: Rule = {
+    name: "no-circular-redirects",
+    create: () => {
+        return {
+            file: async ({ config }) => {
+                const violations: RuleViolation[] = [];
+
+                if (!config.redirects || config.redirects.length === 0) {
+                    return violations;
+                }
+
+                const redirectConfigs: RedirectConfig[] = config.redirects.map((r) => ({
+                    source: r.source,
+                    destination: r.destination,
+                    permanent: r.permanent
+                }));
+
+                return detectCircularRedirects(redirectConfigs);
+            }
+        };
+    }
+};


### PR DESCRIPTION
## Description
Refs: Requested via Slack

Adds a new docs validation rule that detects circular redirect configurations during `fern check`. This prevents users from accidentally creating infinite redirect loops in their docs.yml.

## Changes Made
- Added `NoCircularRedirectsRule` to the docs validator
- Detects two types of issues:
  - **Self-redirects**: `/foo` → `/foo` (with trailing slash normalization)
  - **Circular chains**: `/foo` → `/bar` → `/foo` or longer chains like `/a` → `/b` → `/c` → `/a`
- Dynamic redirects (with `:param` patterns) are skipped for chain detection since they can't be statically analyzed, but self-redirects are still caught
- [ ] Updated README.md generator (if applicable)

## Testing
- [x] Unit tests added/updated (12 test cases covering valid redirects, self-redirects, circular chains, dynamic redirects, edge cases)
- [x] Manual testing completed (ran `pnpm test --filter @fern-api/docs-validator`)

## Human Review Checklist
- [ ] Verify the cycle detection algorithm handles all edge cases correctly (uses DFS with path tracking)
- [ ] Confirm that skipping dynamic redirects for chain detection is the right approach
- [ ] Check if trailing-slash-only normalization is sufficient (doesn't handle encoding or query strings)

---

Link to Devin run: https://app.devin.ai/sessions/24f2ea8e52f748d6bfff2a25d480b40a
Requested by: blank@buildwithfern.com (blank@buildwithfern.com) (@fern-support)