### PR TITLE
fix(java): preprocess IR in-place to avoid `OutOfMemoryError`s

### DIFF
--- a/generators/java/generator-utils/src/main/java/com/fern/java/AbstractGeneratorCli.java
+++ b/generators/java/generator-utils/src/main/java/com/fern/java/AbstractGeneratorCli.java
@@ -6,7 +6,6 @@ import static com.fern.java.GeneratorLogging.logError;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fern.generator.exec.model.config.GeneratorConfig;
 import com.fern.generator.exec.model.config.GeneratorPublishConfig;
@@ -145,9 +144,7 @@ public abstract class AbstractGeneratorCli<T extends ICustomConfig, K extends ID
         return mapper.writeValueAsString(rootNode);
     }
 
-    /**
-     * Processes JSON nodes in-place to convert integer overflow values to long type.
-     */
+    /** Processes JSON nodes in-place to convert integer overflow values to long type. */
     private static class IntegerOverflowProcessor {
         private int conversions = 0;
 
@@ -156,9 +153,8 @@ public abstract class AbstractGeneratorCli<T extends ICustomConfig, K extends ID
         }
 
         /**
-         * Processes a node in-place, modifying the tree structure directly.
-         * For container nodes (objects/arrays), this recursively processes children.
-         * Only creates new nodes when an actual integer-to-long conversion is needed.
+         * Processes a node in-place, modifying the tree structure directly. For container nodes (objects/arrays), this
+         * recursively processes children. Only creates new nodes when an actual integer-to-long conversion is needed.
          */
         public void processNodeInPlace(JsonNode node) {
             if (node == null) {

--- a/generators/java/generator-utils/src/main/java/com/fern/java/AbstractGeneratorCli.java
+++ b/generators/java/generator-utils/src/main/java/com/fern/java/AbstractGeneratorCli.java
@@ -4,7 +4,6 @@ import static com.fern.java.GeneratorLogging.log;
 import static com.fern.java.GeneratorLogging.logError;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -94,9 +93,7 @@ public abstract class AbstractGeneratorCli<T extends ICustomConfig, K extends ID
         }
     }
 
-    /**
-     * Loads and preprocesses the IR from file, handling integer overflow values.
-     */
+    /** Loads and preprocesses the IR from file, handling integer overflow values. */
     private static IntermediateRepresentation getIr(GeneratorConfig generatorConfig) {
         try {
             File irFile = new File(generatorConfig.getIrFilepath());
@@ -116,9 +113,7 @@ public abstract class AbstractGeneratorCli<T extends ICustomConfig, K extends ID
         }
     }
 
-    /**
-     * Processes JSON nodes in-place to convert integer overflow values to long type.
-     */
+    /** Processes JSON nodes in-place to convert integer overflow values to long type. */
     private static class IntegerOverflowProcessor {
         private int conversions = 0;
 

--- a/generators/java/generator-utils/src/main/java/com/fern/java/AbstractGeneratorCli.java
+++ b/generators/java/generator-utils/src/main/java/com/fern/java/AbstractGeneratorCli.java
@@ -6,6 +6,7 @@ import static com.fern.java.GeneratorLogging.logError;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fern.generator.exec.model.config.GeneratorConfig;
 import com.fern.generator.exec.model.config.GeneratorPublishConfig;
@@ -202,6 +203,9 @@ public abstract class AbstractGeneratorCli<T extends ICustomConfig, K extends ID
                     processObjectNodeInPlace((ObjectNode) fieldValue);
                 } else if (fieldValue.isArray()) {
                     processArrayNodeInPlace((ArrayNode) fieldValue);
+                } else if (fieldValue.isNumber() && isIntegerOverflow(fieldValue)) {
+                    objectNode.put(fieldName, fieldValue.asLong());
+                    conversions++;
                 }
             }
         }
@@ -217,6 +221,9 @@ public abstract class AbstractGeneratorCli<T extends ICustomConfig, K extends ID
                     processObjectNodeInPlace((ObjectNode) element);
                 } else if (element.isArray()) {
                     processArrayNodeInPlace((ArrayNode) element);
+                } else if (element.isNumber() && isIntegerOverflow(element)) {
+                    arrayNode.set(i, JsonNodeFactory.instance.numberNode(element.asLong()));
+                    conversions++;
                 }
             }
         }

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,3 +1,12 @@
+- version: 3.24.4
+  changelogEntry:
+    - summary: |
+        Mitigate OutOfMemoryError when generating SDKs for large specs. (Specifically, the IR preprocessing
+        preprocessing step now modifies the JSON tree in-place and avoids calling `.deepCopy()`.)
+      type: fix
+  createdAt: "2025-12-16"
+  irVersion: 61
+
 - version: 3.24.3
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description
Certain very large IRs will pull a `Exception in thread "main" java.lang.OutOfMemoryError: Java heap space: failed reallocation of scalar replaced objects` during generation; this PR attempts a fix that at the very least works for Samsara, which is to change the IR-preprocessing-for-integer-overflow step to modify the JSON tree in-place instead of passing every deep copy of every node onto the stack.

## Changes Made
To the preprocessing stuff in `AbstractGeneratorCli.java`.

## Testing
Unblocks Samsara generation (at least on seed); regenerating seed now!
