### PR TITLE
fix(cli): prevent optional wrapping of literal x-fern-type parameters

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/x-fern-type-literal-header.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/x-fern-type-literal-header.json
@@ -1,0 +1,178 @@
+{
+  "title": "Test x-fern-type literal on header parameters",
+  "servers": [],
+  "websocketServers": [],
+  "tags": {
+    "tagsById": {}
+  },
+  "hasEndpointsMarkedInternal": false,
+  "endpoints": [
+    {
+      "audiences": [],
+      "operationId": "get_user",
+      "tags": [],
+      "pathParameters": [
+        {
+          "name": "userId",
+          "schema": {
+            "schema": {
+              "type": "string"
+            },
+            "generatedName": "GetUserRequestUserId",
+            "groupName": [],
+            "type": "primitive"
+          },
+          "source": {
+            "file": "../openapi.yml",
+            "type": "openapi"
+          }
+        }
+      ],
+      "queryParameters": [],
+      "headers": [
+        {
+          "description": "API version to use for the request. If you do not specify a version, you will either receive a `400 Bad Request` or be set to a previous legacy version.",
+          "name": "x-extend-api-version",
+          "schema": {
+            "value": {
+              "value": "2025-04-21",
+              "type": "string"
+            },
+            "generatedName": "GetUserRequestXExtendApiVersion",
+            "type": "literal"
+          },
+          "source": {
+            "file": "../openapi.yml",
+            "type": "openapi"
+          }
+        },
+        {
+          "name": "X-Required-Literal",
+          "schema": {
+            "value": {
+              "value": "required-value",
+              "type": "string"
+            },
+            "generatedName": "GetUserRequestXRequiredLiteral",
+            "type": "literal"
+          },
+          "source": {
+            "file": "../openapi.yml",
+            "type": "openapi"
+          }
+        },
+        {
+          "name": "X-Optional-String",
+          "schema": {
+            "generatedName": "GetUserRequestXOptionalString",
+            "value": {
+              "schema": {
+                "type": "string"
+              },
+              "generatedName": "GetUserRequestXOptionalString",
+              "groupName": [],
+              "type": "primitive"
+            },
+            "groupName": [],
+            "type": "optional"
+          },
+          "source": {
+            "file": "../openapi.yml",
+            "type": "openapi"
+          }
+        }
+      ],
+      "generatedRequestName": "GetUserRequest",
+      "response": {
+        "description": "Success!",
+        "schema": {
+          "schema": {
+            "type": "string"
+          },
+          "generatedName": "GetUserResponse",
+          "groupName": [],
+          "type": "primitive"
+        },
+        "fullExamples": [],
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "statusCode": 200,
+        "type": "json"
+      },
+      "errors": {},
+      "servers": [],
+      "authed": false,
+      "method": "GET",
+      "path": "/user/{userId}",
+      "examples": [
+        {
+          "pathParameters": [
+            {
+              "name": "userId",
+              "value": {
+                "value": {
+                  "value": "userId",
+                  "type": "string"
+                },
+                "type": "primitive"
+              }
+            }
+          ],
+          "queryParameters": [],
+          "headers": [
+            {
+              "name": "x-extend-api-version",
+              "value": {
+                "value": {
+                  "value": "2025-04-21",
+                  "type": "string"
+                },
+                "type": "literal"
+              }
+            },
+            {
+              "name": "X-Required-Literal",
+              "value": {
+                "value": {
+                  "value": "required-value",
+                  "type": "string"
+                },
+                "type": "literal"
+              }
+            }
+          ],
+          "response": {
+            "value": {
+              "value": {
+                "value": "string",
+                "type": "string"
+              },
+              "type": "primitive"
+            },
+            "type": "withoutStreaming"
+          },
+          "codeSamples": [],
+          "type": "full"
+        }
+      ],
+      "source": {
+        "file": "../openapi.yml",
+        "type": "openapi"
+      }
+    }
+  ],
+  "webhooks": [],
+  "channels": {},
+  "groupedSchemas": {
+    "rootSchemas": {},
+    "namespacedSchemas": {}
+  },
+  "variables": {},
+  "nonRequestReferencedSchemas": {},
+  "securitySchemes": {},
+  "globalHeaders": [],
+  "idempotencyHeaders": [],
+  "groups": {}
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/x-fern-type-literal-header.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/x-fern-type-literal-header.json
@@ -1,0 +1,130 @@
+{
+  "absoluteFilePath": "/DUMMY_PATH",
+  "importedDefinitions": {},
+  "namedDefinitionFiles": {
+    "__package__.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {
+        "service": {
+          "auth": false,
+          "base-path": "",
+          "endpoints": {
+            "get_user": {
+              "auth": undefined,
+              "docs": undefined,
+              "examples": [
+                {
+                  "headers": {
+                    "X-Optional-String": "[object Object]",
+                    "X-Required-Literal": "required-value",
+                    "x-extend-api-version": "2025-04-21",
+                  },
+                  "path-parameters": {
+                    "userId": "userId",
+                  },
+                  "response": {
+                    "body": "string",
+                  },
+                },
+              ],
+              "method": "GET",
+              "pagination": undefined,
+              "path": "/user/{userId}",
+              "request": {
+                "name": "GetUserRequest",
+                "path-parameters": {
+                  "userId": "string",
+                },
+              },
+              "response": {
+                "docs": "Success!",
+                "status-code": 200,
+                "type": "string",
+              },
+              "source": {
+                "openapi": "../openapi.yml",
+              },
+            },
+          },
+          "source": {
+            "openapi": "../openapi.yml",
+          },
+        },
+      },
+      "rawContents": "service:
+  auth: false
+  base-path: ''
+  endpoints:
+    get_user:
+      path: /user/{userId}
+      method: GET
+      source:
+        openapi: ../openapi.yml
+      request:
+        name: GetUserRequest
+        path-parameters:
+          userId: string
+      response:
+        docs: Success!
+        type: string
+        status-code: 200
+      examples:
+        - path-parameters:
+            userId: userId
+          headers:
+            x-extend-api-version: '2025-04-21'
+            X-Required-Literal: required-value
+            X-Optional-String: '[object Object]'
+          response:
+            body: string
+  source:
+    openapi: ../openapi.yml
+",
+    },
+  },
+  "packageMarkers": {},
+  "rootApiFile": {
+    "contents": {
+      "display-name": "Test x-fern-type literal on header parameters",
+      "error-discrimination": {
+        "strategy": "status-code",
+      },
+      "headers": {
+        "X-Optional-String": {
+          "name": "optionalString",
+          "type": "optional<string>",
+        },
+        "X-Required-Literal": {
+          "name": "requiredLiteral",
+          "type": "literal<"required-value">",
+        },
+        "x-extend-api-version": {
+          "docs": "API version to use for the request. If you do not specify a version, you will either receive a `400 Bad Request` or be set to a previous legacy version.",
+          "name": "extendApiVersion",
+          "type": "literal<"2025-04-21">",
+        },
+      },
+      "name": "api",
+    },
+    "defaultUrl": undefined,
+    "rawContents": "name: api
+error-discrimination:
+  strategy: status-code
+display-name: Test x-fern-type literal on header parameters
+headers:
+  x-extend-api-version:
+    type: literal<"2025-04-21">
+    name: extendApiVersion
+    docs: >-
+      API version to use for the request. If you do not specify a version, you
+      will either receive a `400 Bad Request` or be set to a previous legacy
+      version.
+  X-Required-Literal:
+    type: literal<"required-value">
+    name: requiredLiteral
+  X-Optional-String:
+    type: optional<string>
+    name: optionalString
+",
+  },
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/x-fern-type-literal-header/fern/fern.config.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/x-fern-type-literal-header/fern/fern.config.json
@@ -1,0 +1,4 @@
+{
+    "organization": "fern",
+    "version": "*"
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/x-fern-type-literal-header/fern/generators.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/x-fern-type-literal-header/fern/generators.yml
@@ -1,0 +1,4 @@
+# yaml-language-server: $schema=https://schema.buildwithfern.dev/generators-yml.json
+api:
+  specs:
+    - openapi: ../openapi.yml

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/x-fern-type-literal-header/openapi.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/x-fern-type-literal-header/openapi.yml
@@ -1,0 +1,45 @@
+openapi: 3.1.0
+info:
+  title: Test x-fern-type literal on header parameters
+  version: 1.0.0
+components:
+  parameters:
+    ApiVersion:
+      name: x-extend-api-version
+      in: header
+      x-fern-type: literal<"2025-04-21">
+      schema:
+        type: string
+        x-fern-type: literal<"2025-04-21">
+      description: API version to use for the request. If you do not specify a version, you will either receive a `400 Bad Request` or be set to a previous legacy version.
+      example: "2025-04-21"
+paths:
+  "/user/{userId}":
+    get:
+      operationId: get_user
+      parameters:
+        - $ref: "#/components/parameters/ApiVersion"
+        - in: path
+          name: userId
+          schema:
+            type: string
+          required: true
+        - in: header
+          name: X-Required-Literal
+          x-fern-type: literal<"required-value">
+          schema:
+            type: string
+            x-fern-type: literal<"required-value">
+          required: true
+        - in: header
+          name: X-Optional-String
+          schema:
+            type: string
+          required: false
+      responses:
+        "200":
+          description: "Success!"
+          content:
+            application/json:
+              schema:
+                type: string


### PR DESCRIPTION
## Description
Refs: Slack thread from thomas@buildwithfern.com

Fixes a regression where `x-fern-type: literal<"...">` on parameters was being incorrectly parsed as `optional<literal<"...">>` instead of just `literal<"...">` when the parameter was not marked as `required: true`.

This was reported as a breaking change between CLI versions 0.84.1 and 2.6.2.

## Changes Made
- Modified `convertParameters.ts` to detect when a parameter's schema has `x-fern-type` that is a literal type
- When a literal `x-fern-type` is detected, the parameter is treated as required for optional/nullable wrapping purposes
- Added test fixture `x-fern-type-literal-header` to validate the fix

## Testing
- [x] Unit tests added/updated
- [x] All 241 existing tests pass
- [x] Lint checks pass

## Human Review Checklist
- [ ] Verify the string check `fernType.startsWith("literal<")` is robust enough for all valid literal type syntaxes
- [ ] Confirm the fix scope (parameters only, not object properties) is the correct behavior
- [ ] Check if the fallback `resolvedParameter.schema ?? resolvedParameter` correctly handles both schema-level and parameter-level `x-fern-type` extensions

---
Link to Devin run: https://app.devin.ai/sessions/bb19722f349c438cafa622e373eee1f7
Requested by: thomas@buildwithfern.com (@tjb9dc)