### PR TITLE
fix(cli): fix handling of `allOf` property with `additionalProperties: true`

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertSchemas.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertSchemas.ts
@@ -766,7 +766,12 @@ export function convertSchemaObject(
         }
 
         // maps
-        if (schema.additionalProperties != null && schema.additionalProperties !== false && hasNoProperties(schema)) {
+        if (
+            schema.additionalProperties != null &&
+            schema.additionalProperties !== false &&
+            hasNoProperties(schema) &&
+            hasNoAllOf(schema)
+        ) {
             return convertAdditionalProperties({
                 nameOverride,
                 generatedName,
@@ -1129,10 +1134,12 @@ export function convertSchemaObject(
             if (
                 (schema.properties == null || hasNoProperties(schema)) &&
                 filteredAllOfs.length === 1 &&
-                filteredAllOfs[0] != null
+                filteredAllOfs[0] != null &&
+                (schema.additionalProperties == null || schema.additionalProperties === false)
             ) {
                 // If we end up with a single element, we short-circuit and convert it directly.
                 // Note that this handles any schema type, not just objects (e.g. arrays).
+                // We don't short-circuit if additionalProperties is set, as we'd lose that information.
                 const convertedSchema = convertSchema(
                     filteredAllOfs[0],
                     wrapAsOptional,
@@ -1159,9 +1166,11 @@ export function convertSchemaObject(
             if (
                 (schema.properties == null || hasNoProperties(schema)) &&
                 filteredAllOfObjects.length === 1 &&
-                filteredAllOfObjects[0] != null
+                filteredAllOfObjects[0] != null &&
+                (schema.additionalProperties == null || schema.additionalProperties === false)
             ) {
                 // Try to short-circuit again.
+                // We don't short-circuit if additionalProperties is set, as we'd lose that information.
                 const convertedSchema = convertSchema(
                     filteredAllOfObjects[0],
                     wrapAsOptional,

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/additional-properties-edge-cases.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/additional-properties-edge-cases.json
@@ -612,6 +612,343 @@
         "file": "../openapi.yml",
         "type": "openapi"
       }
+    },
+    {
+      "audiences": [],
+      "operationId": "createExtendedWithAny",
+      "tags": [],
+      "pathParameters": [],
+      "queryParameters": [],
+      "headers": [],
+      "generatedRequestName": "CreateExtendedWithAnyRequest",
+      "request": {
+        "schema": {
+          "generatedName": "CreateExtendedWithAnyRequest",
+          "schema": "ExtendedWithAdditionalPropertiesAny",
+          "source": {
+            "file": "../openapi.yml",
+            "type": "openapi"
+          },
+          "type": "reference"
+        },
+        "contentType": "application/json",
+        "fullExamples": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "json"
+      },
+      "response": {
+        "description": "Success",
+        "schema": {
+          "generatedName": "CreateExtendedWithAnyResponse",
+          "schema": "ExtendedWithAdditionalPropertiesAny",
+          "source": {
+            "file": "../openapi.yml",
+            "type": "openapi"
+          },
+          "type": "reference"
+        },
+        "fullExamples": [],
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "statusCode": 200,
+        "type": "json"
+      },
+      "errors": {},
+      "servers": [],
+      "authed": false,
+      "method": "POST",
+      "path": "/extended-with-any",
+      "examples": [
+        {
+          "pathParameters": [],
+          "queryParameters": [],
+          "headers": [],
+          "request": {
+            "properties": {
+              "id": {
+                "value": {
+                  "value": "id",
+                  "type": "string"
+                },
+                "type": "primitive"
+              },
+              "name": {
+                "value": {
+                  "value": "name",
+                  "type": "string"
+                },
+                "type": "primitive"
+              }
+            },
+            "type": "object"
+          },
+          "response": {
+            "value": {
+              "properties": {
+                "id": {
+                  "value": {
+                    "value": "id",
+                    "type": "string"
+                  },
+                  "type": "primitive"
+                },
+                "createdAt": {
+                  "value": {
+                    "value": "2024-01-15T09:30:00Z",
+                    "type": "datetime"
+                  },
+                  "type": "primitive"
+                },
+                "name": {
+                  "value": {
+                    "value": "name",
+                    "type": "string"
+                  },
+                  "type": "primitive"
+                }
+              },
+              "type": "object"
+            },
+            "type": "withoutStreaming"
+          },
+          "codeSamples": [],
+          "type": "full"
+        }
+      ],
+      "source": {
+        "file": "../openapi.yml",
+        "type": "openapi"
+      }
+    },
+    {
+      "audiences": [],
+      "operationId": "createExtendedWithTyped",
+      "tags": [],
+      "pathParameters": [],
+      "queryParameters": [],
+      "headers": [],
+      "generatedRequestName": "CreateExtendedWithTypedRequest",
+      "request": {
+        "schema": {
+          "generatedName": "CreateExtendedWithTypedRequest",
+          "schema": "ExtendedWithAdditionalPropertiesTyped",
+          "source": {
+            "file": "../openapi.yml",
+            "type": "openapi"
+          },
+          "type": "reference"
+        },
+        "contentType": "application/json",
+        "fullExamples": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "json"
+      },
+      "response": {
+        "description": "Success",
+        "schema": {
+          "generatedName": "CreateExtendedWithTypedResponse",
+          "schema": "ExtendedWithAdditionalPropertiesTyped",
+          "source": {
+            "file": "../openapi.yml",
+            "type": "openapi"
+          },
+          "type": "reference"
+        },
+        "fullExamples": [],
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "statusCode": 200,
+        "type": "json"
+      },
+      "errors": {},
+      "servers": [],
+      "authed": false,
+      "method": "POST",
+      "path": "/extended-with-typed",
+      "examples": [
+        {
+          "pathParameters": [],
+          "queryParameters": [],
+          "headers": [],
+          "request": {
+            "properties": {
+              "id": {
+                "value": {
+                  "value": "id",
+                  "type": "string"
+                },
+                "type": "primitive"
+              }
+            },
+            "type": "object"
+          },
+          "response": {
+            "value": {
+              "properties": {
+                "id": {
+                  "value": {
+                    "value": "id",
+                    "type": "string"
+                  },
+                  "type": "primitive"
+                },
+                "createdAt": {
+                  "value": {
+                    "value": "2024-01-15T09:30:00Z",
+                    "type": "datetime"
+                  },
+                  "type": "primitive"
+                },
+                "name": {
+                  "value": {
+                    "value": "name",
+                    "type": "string"
+                  },
+                  "type": "primitive"
+                }
+              },
+              "type": "object"
+            },
+            "type": "withoutStreaming"
+          },
+          "codeSamples": [],
+          "type": "full"
+        }
+      ],
+      "source": {
+        "file": "../openapi.yml",
+        "type": "openapi"
+      }
+    },
+    {
+      "audiences": [],
+      "operationId": "createExtendedWithRef",
+      "tags": [],
+      "pathParameters": [],
+      "queryParameters": [],
+      "headers": [],
+      "generatedRequestName": "CreateExtendedWithRefRequest",
+      "request": {
+        "schema": {
+          "generatedName": "CreateExtendedWithRefRequest",
+          "schema": "ExtendedWithAdditionalPropertiesRef",
+          "source": {
+            "file": "../openapi.yml",
+            "type": "openapi"
+          },
+          "type": "reference"
+        },
+        "contentType": "application/json",
+        "fullExamples": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "json"
+      },
+      "response": {
+        "description": "Success",
+        "schema": {
+          "generatedName": "CreateExtendedWithRefResponse",
+          "schema": "ExtendedWithAdditionalPropertiesRef",
+          "source": {
+            "file": "../openapi.yml",
+            "type": "openapi"
+          },
+          "type": "reference"
+        },
+        "fullExamples": [],
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "statusCode": 200,
+        "type": "json"
+      },
+      "errors": {},
+      "servers": [],
+      "authed": false,
+      "method": "POST",
+      "path": "/extended-with-ref",
+      "examples": [
+        {
+          "pathParameters": [],
+          "queryParameters": [],
+          "headers": [],
+          "request": {
+            "properties": {
+              "id": {
+                "value": {
+                  "value": "id",
+                  "type": "string"
+                },
+                "type": "primitive"
+              }
+            },
+            "type": "object"
+          },
+          "response": {
+            "value": {
+              "properties": {
+                "id": {
+                  "value": {
+                    "value": "id",
+                    "type": "string"
+                  },
+                  "type": "primitive"
+                },
+                "createdAt": {
+                  "value": {
+                    "value": "2024-01-15T09:30:00Z",
+                    "type": "datetime"
+                  },
+                  "type": "primitive"
+                },
+                "primaryUser": {
+                  "properties": {
+                    "id": {
+                      "value": {
+                        "value": "id",
+                        "type": "string"
+                      },
+                      "type": "primitive"
+                    },
+                    "name": {
+                      "value": {
+                        "value": "name",
+                        "type": "string"
+                      },
+                      "type": "primitive"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "type": "withoutStreaming"
+          },
+          "codeSamples": [],
+          "type": "full"
+        }
+      ],
+      "source": {
+        "file": "../openapi.yml",
+        "type": "openapi"
+      }
     }
   ],
   "webhooks": [],
@@ -921,6 +1258,203 @@
         "generatedName": "ArrayMap",
         "groupName": [],
         "type": "map"
+      },
+      "BaseObject": {
+        "allOf": [],
+        "properties": [
+          {
+            "conflict": {},
+            "generatedName": "baseObjectId",
+            "key": "id",
+            "schema": {
+              "schema": {
+                "type": "string"
+              },
+              "generatedName": "BaseObjectId",
+              "groupName": [],
+              "type": "primitive"
+            },
+            "audiences": []
+          },
+          {
+            "conflict": {},
+            "generatedName": "baseObjectCreatedAt",
+            "key": "createdAt",
+            "schema": {
+              "generatedName": "BaseObjectCreatedAt",
+              "value": {
+                "schema": {
+                  "type": "datetime"
+                },
+                "generatedName": "BaseObjectCreatedAt",
+                "groupName": [],
+                "type": "primitive"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "audiences": []
+          }
+        ],
+        "allOfPropertyConflicts": [],
+        "generatedName": "BaseObject",
+        "groupName": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "object"
+      },
+      "ExtendedWithAdditionalPropertiesAny": {
+        "allOf": [
+          {
+            "generatedName": "BaseObject",
+            "schema": "BaseObject",
+            "source": {
+              "file": "../openapi.yml",
+              "type": "openapi"
+            },
+            "type": "reference"
+          }
+        ],
+        "properties": [
+          {
+            "conflict": {},
+            "generatedName": "extendedWithAdditionalPropertiesAnyName",
+            "key": "name",
+            "schema": {
+              "schema": {
+                "type": "string"
+              },
+              "generatedName": "ExtendedWithAdditionalPropertiesAnyName",
+              "groupName": [],
+              "type": "primitive"
+            },
+            "audiences": []
+          }
+        ],
+        "allOfPropertyConflicts": [],
+        "generatedName": "ExtendedWithAdditionalPropertiesAny",
+        "groupName": [],
+        "additionalProperties": true,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "object"
+      },
+      "ExtendedWithAdditionalPropertiesTyped": {
+        "allOf": [
+          {
+            "generatedName": "BaseObject",
+            "schema": "BaseObject",
+            "source": {
+              "file": "../openapi.yml",
+              "type": "openapi"
+            },
+            "type": "reference"
+          }
+        ],
+        "properties": [
+          {
+            "conflict": {},
+            "generatedName": "extendedWithAdditionalPropertiesTypedName",
+            "key": "name",
+            "schema": {
+              "generatedName": "ExtendedWithAdditionalPropertiesTypedName",
+              "value": {
+                "schema": {
+                  "type": "string"
+                },
+                "generatedName": "ExtendedWithAdditionalPropertiesTypedName",
+                "groupName": [],
+                "type": "primitive"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "audiences": []
+          }
+        ],
+        "allOfPropertyConflicts": [],
+        "generatedName": "ExtendedWithAdditionalPropertiesTyped",
+        "groupName": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "object"
+      },
+      "ExtendedWithAdditionalPropertiesRef": {
+        "allOf": [
+          {
+            "generatedName": "BaseObject",
+            "schema": "BaseObject",
+            "source": {
+              "file": "../openapi.yml",
+              "type": "openapi"
+            },
+            "type": "reference"
+          }
+        ],
+        "properties": [
+          {
+            "conflict": {},
+            "generatedName": "extendedWithAdditionalPropertiesRefPrimaryUser",
+            "key": "primaryUser",
+            "schema": {
+              "generatedName": "ExtendedWithAdditionalPropertiesRefPrimaryUser",
+              "value": {
+                "generatedName": "ExtendedWithAdditionalPropertiesRefPrimaryUser",
+                "schema": "User",
+                "source": {
+                  "file": "../openapi.yml",
+                  "type": "openapi"
+                },
+                "type": "reference"
+              },
+              "type": "optional"
+            },
+            "audiences": [],
+            "readonly": false,
+            "writeonly": false
+          }
+        ],
+        "allOfPropertyConflicts": [],
+        "generatedName": "ExtendedWithAdditionalPropertiesRef",
+        "groupName": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "object"
+      },
+      "ExtendedOnlyRefWithAdditionalProperties": {
+        "allOf": [
+          {
+            "generatedName": "BaseObject",
+            "schema": "BaseObject",
+            "source": {
+              "file": "../openapi.yml",
+              "type": "openapi"
+            },
+            "type": "reference"
+          }
+        ],
+        "properties": [],
+        "allOfPropertyConflicts": [],
+        "description": "Options with only ref-based inheritance and additionalProperties",
+        "generatedName": "ExtendedOnlyRefWithAdditionalProperties",
+        "groupName": [],
+        "additionalProperties": true,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "object"
       }
     },
     "namespacedSchemas": {}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/additional-properties-edge-cases.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/additional-properties-edge-cases.json
@@ -44,6 +44,109 @@
                 "openapi": "../openapi.yml",
               },
             },
+            "createExtendedWithAny": {
+              "auth": undefined,
+              "docs": undefined,
+              "examples": [
+                {
+                  "request": {
+                    "id": "id",
+                    "name": "name",
+                  },
+                  "response": {
+                    "body": {
+                      "createdAt": "2024-01-15T09:30:00Z",
+                      "id": "id",
+                      "name": "name",
+                    },
+                  },
+                },
+              ],
+              "method": "POST",
+              "pagination": undefined,
+              "path": "/extended-with-any",
+              "request": {
+                "body": "ExtendedWithAdditionalPropertiesAny",
+                "content-type": "application/json",
+              },
+              "response": {
+                "docs": "Success",
+                "status-code": 200,
+                "type": "ExtendedWithAdditionalPropertiesAny",
+              },
+              "source": {
+                "openapi": "../openapi.yml",
+              },
+            },
+            "createExtendedWithRef": {
+              "auth": undefined,
+              "docs": undefined,
+              "examples": [
+                {
+                  "request": {
+                    "id": "id",
+                  },
+                  "response": {
+                    "body": {
+                      "createdAt": "2024-01-15T09:30:00Z",
+                      "id": "id",
+                      "primaryUser": {
+                        "id": "id",
+                        "name": "name",
+                      },
+                    },
+                  },
+                },
+              ],
+              "method": "POST",
+              "pagination": undefined,
+              "path": "/extended-with-ref",
+              "request": {
+                "body": "ExtendedWithAdditionalPropertiesRef",
+                "content-type": "application/json",
+              },
+              "response": {
+                "docs": "Success",
+                "status-code": 200,
+                "type": "ExtendedWithAdditionalPropertiesRef",
+              },
+              "source": {
+                "openapi": "../openapi.yml",
+              },
+            },
+            "createExtendedWithTyped": {
+              "auth": undefined,
+              "docs": undefined,
+              "examples": [
+                {
+                  "request": {
+                    "id": "id",
+                  },
+                  "response": {
+                    "body": {
+                      "createdAt": "2024-01-15T09:30:00Z",
+                      "id": "id",
+                      "name": "name",
+                    },
+                  },
+                },
+              ],
+              "method": "POST",
+              "pagination": undefined,
+              "path": "/extended-with-typed",
+              "request": {
+                "body": "ExtendedWithAdditionalPropertiesTyped",
+                "content-type": "application/json",
+              },
+              "response": {
+                "docs": "Success",
+                "status-code": 200,
+                "type": "ExtendedWithAdditionalPropertiesTyped",
+              },
+              "source": {
+                "openapi": "../openapi.yml",
+              },
+            },
             "createFlexible": {
               "auth": undefined,
               "docs": undefined,
@@ -208,6 +311,69 @@
         },
         "types": {
           "ArrayMap": "map<string, list<string>>",
+          "BaseObject": {
+            "docs": undefined,
+            "inline": undefined,
+            "properties": {
+              "createdAt": "optional<datetime>",
+              "id": "string",
+            },
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+          "ExtendedOnlyRefWithAdditionalProperties": {
+            "docs": "Options with only ref-based inheritance and additionalProperties",
+            "extends": [
+              "BaseObject",
+            ],
+            "extra-properties": true,
+            "inline": undefined,
+            "properties": {},
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+          "ExtendedWithAdditionalPropertiesAny": {
+            "docs": undefined,
+            "extends": [
+              "BaseObject",
+            ],
+            "extra-properties": true,
+            "inline": undefined,
+            "properties": {
+              "name": "string",
+            },
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+          "ExtendedWithAdditionalPropertiesRef": {
+            "docs": undefined,
+            "extends": [
+              "BaseObject",
+            ],
+            "inline": undefined,
+            "properties": {
+              "primaryUser": "optional<User>",
+            },
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+          "ExtendedWithAdditionalPropertiesTyped": {
+            "docs": undefined,
+            "extends": [
+              "BaseObject",
+            ],
+            "inline": undefined,
+            "properties": {
+              "name": "optional<string>",
+            },
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
           "FlexibleObject": {
             "docs": undefined,
             "extra-properties": true,
@@ -384,6 +550,69 @@
             body:
               key:
                 - value
+    createExtendedWithAny:
+      path: /extended-with-any
+      method: POST
+      source:
+        openapi: ../openapi.yml
+      request:
+        body: ExtendedWithAdditionalPropertiesAny
+        content-type: application/json
+      response:
+        docs: Success
+        type: ExtendedWithAdditionalPropertiesAny
+        status-code: 200
+      examples:
+        - request:
+            id: id
+            name: name
+          response:
+            body:
+              id: id
+              createdAt: '2024-01-15T09:30:00Z'
+              name: name
+    createExtendedWithTyped:
+      path: /extended-with-typed
+      method: POST
+      source:
+        openapi: ../openapi.yml
+      request:
+        body: ExtendedWithAdditionalPropertiesTyped
+        content-type: application/json
+      response:
+        docs: Success
+        type: ExtendedWithAdditionalPropertiesTyped
+        status-code: 200
+      examples:
+        - request:
+            id: id
+          response:
+            body:
+              id: id
+              createdAt: '2024-01-15T09:30:00Z'
+              name: name
+    createExtendedWithRef:
+      path: /extended-with-ref
+      method: POST
+      source:
+        openapi: ../openapi.yml
+      request:
+        body: ExtendedWithAdditionalPropertiesRef
+        content-type: application/json
+      response:
+        docs: Success
+        type: ExtendedWithAdditionalPropertiesRef
+        status-code: 200
+      examples:
+        - request:
+            id: id
+          response:
+            body:
+              id: id
+              createdAt: '2024-01-15T09:30:00Z'
+              primaryUser:
+                id: id
+                name: name
   source:
     openapi: ../openapi.yml
 types:
@@ -421,6 +650,42 @@ types:
       openapi: ../openapi.yml
   UserMap: map<string, User>
   ArrayMap: map<string, list<string>>
+  BaseObject:
+    properties:
+      id: string
+      createdAt: optional<datetime>
+    source:
+      openapi: ../openapi.yml
+  ExtendedWithAdditionalPropertiesAny:
+    properties:
+      name: string
+    extends:
+      - BaseObject
+    extra-properties: true
+    source:
+      openapi: ../openapi.yml
+  ExtendedWithAdditionalPropertiesTyped:
+    properties:
+      name: optional<string>
+    extends:
+      - BaseObject
+    source:
+      openapi: ../openapi.yml
+  ExtendedWithAdditionalPropertiesRef:
+    properties:
+      primaryUser: optional<User>
+    extends:
+      - BaseObject
+    source:
+      openapi: ../openapi.yml
+  ExtendedOnlyRefWithAdditionalProperties:
+    docs: Options with only ref-based inheritance and additionalProperties
+    properties: {}
+    extends:
+      - BaseObject
+    extra-properties: true
+    source:
+      openapi: ../openapi.yml
 ",
     },
   },

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/additional-properties-edge-cases/openapi.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/additional-properties-edge-cases/openapi.yml
@@ -100,6 +100,54 @@ paths:
               schema:
                 $ref: "#/components/schemas/ArrayMap"
 
+  /extended-with-any:
+    post:
+      operationId: createExtendedWithAny
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ExtendedWithAdditionalPropertiesAny"
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExtendedWithAdditionalPropertiesAny"
+
+  /extended-with-typed:
+    post:
+      operationId: createExtendedWithTyped
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ExtendedWithAdditionalPropertiesTyped"
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExtendedWithAdditionalPropertiesTyped"
+
+  /extended-with-ref:
+    post:
+      operationId: createExtendedWithRef
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ExtendedWithAdditionalPropertiesRef"
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExtendedWithAdditionalPropertiesRef"
+
 components:
   schemas:
     FlexibleObject:
@@ -157,3 +205,52 @@ components:
         type: array
         items:
           type: string
+
+    BaseObject:
+      type: object
+      properties:
+        id:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - id
+
+    ExtendedWithAdditionalPropertiesAny:
+      allOf:
+        - $ref: "#/components/schemas/BaseObject"
+        - type: object
+          properties:
+            name:
+              type: string
+          required:
+            - name
+      additionalProperties: true
+
+    ExtendedWithAdditionalPropertiesTyped:
+      allOf:
+        - $ref: "#/components/schemas/BaseObject"
+        - type: object
+          properties:
+            name:
+              type: string
+      additionalProperties:
+        type: string
+
+    ExtendedWithAdditionalPropertiesRef:
+      allOf:
+        - $ref: "#/components/schemas/BaseObject"
+        - type: object
+          properties:
+            primaryUser:
+              $ref: "#/components/schemas/User"
+      additionalProperties:
+        $ref: "#/components/schemas/User"
+
+    ExtendedOnlyRefWithAdditionalProperties:
+      description: "Options with only ref-based inheritance and additionalProperties"
+      type: object
+      additionalProperties: true
+      allOf:
+        - $ref: "#/components/schemas/BaseObject"

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Prevents incorrect collapsing of an `allOf` with `additionalProperties: true` into a `map`.
+      type: fix
+  irVersion: 62
+  createdAt: "2025-12-16"
+  version: 3.24.2
+
+- changelogEntry:
+    - summary: |
         Collects `fern docs dev` metrics in `.fern/app-preview/<timestamp>.debug.log` file.
       type: chore
   irVersion: 62


### PR DESCRIPTION
## Description
An object like this:
```
  ComplexUser:
    allOf:
      - $ref: "#/components/schemas/BaseUser"      # Referenced parent
      - $ref: "#/components/schemas/Timestamps"    # Another referenced parent
      - type: object                               # Inline object
        properties:
          email: { type: string }
          role: { type: string }
        additionalProperties: false                # This gets overridden
    additionalProperties: true                     # Top-level wins
```
should generate to a Fern Definition like
```
  ComplexUser:
    extends:
      - BaseUser
      - Timestamps
    properties:
      email: optional<string>
      role: optional<string>
    extra-properties: true    # From top-level additionalProperties
```
but some parsing assumptions were making it generate into a generic `map<string, unknown>` object; that shouldn't happen anymore.

## Changes Made
To the `openapi-ir-parser`.

## Testing
Added to the `additional-properties-edge-case` IR test fixture.
- [X] Unit tests added/updated
- [X] Manual testing completed
