### PR TITLE
fix(internal): Bump cli and ts-sdk versions

### DIFF
--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.42.2
+  changelogEntry:
+    - summary: |
+        Fix property access for file upload request parameters with hyphenated or special character names by using bracket notation instead of dot notation.
+      type: fix
+  createdAt: "2025-12-16"
+  irVersion: 62
+
 - version: 3.42.1
   changelogEntry:
     - summary: |

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.24.2
+  changelogEntry:
+    - summary: |
+        Fix handling of empty allOf in additionalProperties by treating schemas with only metadata (example, description) as "any" type.
+      type: fix
+  createdAt: "2025-12-16"
+  irVersion: 62
+
 - changelogEntry:
     - summary: |
         Collects `fern docs dev` metrics in `.fern/app-preview/<timestamp>.debug.log` file.


### PR DESCRIPTION
Forgot to bump versions in previous change: https://github.com/fern-api/fern/pull/11273