### PR TITLE
fix(typescript, cli): Fix typescript wire test generation

### DIFF
--- a/generators/typescript/asIs/tests/mock-server/withFormUrlEncoded.ts
+++ b/generators/typescript/asIs/tests/mock-server/withFormUrlEncoded.ts
@@ -18,13 +18,22 @@ export function withFormUrlEncoded(expectedBody: unknown, resolver: HttpResponse
             clonedRequest = request.clone();
             bodyText = await clonedRequest.text();
             if (bodyText === "") {
-                console.error("Request body is empty, expected a form-urlencoded body.");
-                return passthrough();
-            }
-            const params = new URLSearchParams(bodyText);
-            actualBody = {};
-            for (const [key, value] of params.entries()) {
-                actualBody[key] = value;
+                // Empty body is valid if expected body is also empty
+                const isExpectedEmpty =
+                    expectedBody != null &&
+                    typeof expectedBody === "object" &&
+                    Object.keys(expectedBody as Record<string, unknown>).length === 0;
+                if (!isExpectedEmpty) {
+                    console.error("Request body is empty, expected a form-urlencoded body.");
+                    return passthrough();
+                }
+                actualBody = {};
+            } else {
+                const params = new URLSearchParams(bodyText);
+                actualBody = {};
+                for (const [key, value] of params.entries()) {
+                    actualBody[key] = value;
+                }
             }
         } catch (error) {
             console.error(`Error processing form-urlencoded request body:\n\tError: ${error}\n\tBody: ${bodyText}`);

--- a/generators/typescript/sdk/generator/src/test-generator/TestGenerator.ts
+++ b/generators/typescript/sdk/generator/src/test-generator/TestGenerator.ts
@@ -473,13 +473,17 @@ export function ${functionName}(server: MockServer): void {
     ${rawResponseBody ? code`const rawResponseBody = ${rawResponseBody};` : ""}
     server
         .mockEndpoint()
-        .${endpoint.method.toLowerCase()}("${example.url}")${example.serviceHeaders.map((h) => {
-            return code`.header("${h.name.wireValue}", "${h.value.jsonExample}")
+        .${endpoint.method.toLowerCase()}("${example.url}")${example.serviceHeaders
+            .filter((h) => h.value.jsonExample != null)
+            .map((h) => {
+                return code`.header("${h.name.wireValue}", "${h.value.jsonExample}")
                 `;
-        })}${example.endpointHeaders.map((h) => {
-            return code`.header("${h.name.wireValue}", "${h.value.jsonExample}")
+            })}${example.endpointHeaders
+            .filter((h) => h.value.jsonExample != null)
+            .map((h) => {
+                return code`.header("${h.name.wireValue}", "${h.value.jsonExample}")
                 `;
-        })}${
+            })}${
             rawRequestBody
                 ? code`.${mockBodyMethod}(rawRequestBody)
             `
@@ -535,13 +539,17 @@ export function ${functionName}(server: MockServer): void {
     ${rawResponseBody ? code`const rawResponseBody = ${rawResponseBody};` : ""}
     server
         .mockEndpoint()
-        .${endpoint.method.toLowerCase()}("${example.url}")${example.serviceHeaders.map((h) => {
-            return code`.header("${h.name.wireValue}", "${h.value.jsonExample}")
+        .${endpoint.method.toLowerCase()}("${example.url}")${example.serviceHeaders
+            .filter((h) => h.value.jsonExample != null)
+            .map((h) => {
+                return code`.header("${h.name.wireValue}", "${h.value.jsonExample}")
                 `;
-        })}${example.endpointHeaders.map((h) => {
-            return code`.header("${h.name.wireValue}", "${h.value.jsonExample}")
+            })}${example.endpointHeaders
+            .filter((h) => h.value.jsonExample != null)
+            .map((h) => {
+                return code`.header("${h.name.wireValue}", "${h.value.jsonExample}")
                 `;
-        })}${
+            })}${
             rawRequestBody
                 ? code`.${mockBodyMethod}(rawRequestBody)
             `
@@ -1206,13 +1214,17 @@ describe("${serviceName}", () => {
         ${rawResponseBody ? code`const rawResponseBody = ${rawResponseBody};` : ""}
         server
             .mockEndpoint(${hasPagination ? "{ once: false }" : ""})
-            .${endpoint.method.toLowerCase()}("${example.url}")${example.serviceHeaders.map((h) => {
-                return code`.header("${h.name.wireValue}", "${h.value.jsonExample}")
+            .${endpoint.method.toLowerCase()}("${example.url}")${example.serviceHeaders
+                .filter((h) => h.value.jsonExample != null)
+                .map((h) => {
+                    return code`.header("${h.name.wireValue}", "${h.value.jsonExample}")
                     `;
-            })}${example.endpointHeaders.map((h) => {
-                return code`.header("${h.name.wireValue}", "${h.value.jsonExample}")
+                })}${example.endpointHeaders
+                .filter((h) => h.value.jsonExample != null)
+                .map((h) => {
+                    return code`.header("${h.name.wireValue}", "${h.value.jsonExample}")
                     `;
-            })}${
+                })}${
                 rawRequestBody
                     ? code`.${mockBodyMethod}(rawRequestBody)
                 `

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.42.3
+  changelogEntry:
+    - summary: |
+        Fix wire test generation: filter out headers with null/undefined values to prevent invalid assertions, and allow empty form body in mock server when expected body is empty.
+      type: fix
+  createdAt: "2025-12-16"
+  irVersion: 62
+
 - version: 3.42.2
   changelogEntry:
     - summary: |

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.24.4
+  changelogEntry:
+    - summary: |
+        Fix discriminated unions with nullable object types to use samePropertiesAsObject instead of wrapping in a value property.
+      type: fix
+  createdAt: "2025-12-16"
+  irVersion: 62
+
 - version: 3.24.3
   changelogEntry:
     - summary: |

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -2,9 +2,9 @@
 - version: 3.24.3
   changelogEntry:
     - summary: |
-        Fix discriminated unions with nullable object types to use samePropertiesAsObject instead of wrapping in a value property.
+        Use Set for O(1) deduplication of referenced markdown files in `fern docs dev` to improve hot reload performance.
       type: fix
-  createdAt: "2025-12-16"
+  createdAt: "2025-12-17"
   irVersion: 62
 
 - version: 3.24.2

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.24.3
+  changelogEntry:
+    - summary: |
+        Fix discriminated unions with nullable object types to use samePropertiesAsObject instead of wrapping in a value property.
+      type: fix
+  createdAt: "2025-12-16"
+  irVersion: 62
+
 - version: 3.24.2
   changelogEntry:
     - summary: |

--- a/seed/ts-sdk/seed.yml
+++ b/seed/ts-sdk/seed.yml
@@ -1,5 +1,5 @@
 displayName: TypeScript SDK
-irVersion: v61
+irVersion: v62
 image: fernapi/fern-typescript-sdk
 imageAliases: [fernapi/fern-typescript-node-sdk]
 changelogLocation: ../../generators/typescript/sdk/versions.yml


### PR DESCRIPTION
## Description
Fixes several issues with TypeScript wire test generation that caused test failures when generating SDKs for APIs with nullable headers and empty form bodies.

## Changes Made
- **Discriminated union nullable handling**: Unwrap nullable/optional container types before checking if underlying type is an object, ensuring `samePropertiesAsObject` pattern is used instead of incorrectly wrapping in a `value` property
- **Wire test header generation**: Filter out headers with null/undefined `jsonExample` values to prevent tests from expecting headers that won't be sent by the client
- **Empty form body handling**: Allow empty request body in mock server when expected body is also empty `{}`

## Testing
- [x] Manual testing completed with custom API SDK generation
- [x] All 997 wire tests pass after fixes