### PR TITLE
fix(cli): cache referenced markdown files to avoid redundant reads

### DIFF
--- a/packages/cli/docs-markdown-utils/src/replaceReferencedMarkdown.ts
+++ b/packages/cli/docs-markdown-utils/src/replaceReferencedMarkdown.ts
@@ -128,10 +128,14 @@ export async function replaceReferencedMarkdown({
         }
 
         try {
-            const rawContent = await markdownLoader(filepath);
-
-            // Store the referenced file with its raw content (before variable substitution)
-            if (!collectedFiles.has(filepath)) {
+            // Check cache first to avoid redundant file reads and gray-matter parsing
+            const cached = collectedFiles.get(filepath);
+            let rawContent: string;
+            if (cached != null) {
+                rawContent = cached.content;
+            } else {
+                rawContent = await markdownLoader(filepath);
+                // Store the referenced file with its raw content (before variable substitution)
                 collectedFiles.set(filepath, {
                     absoluteFilePath: filepath,
                     relativeFilePath: relative(absolutePathToFernFolder, filepath),


### PR DESCRIPTION
## Description

Refs investigation into slow `fern docs dev` hot reload performance (customer reported 13791ms reload times).

Previously, `replaceReferencedMarkdown()` would read and parse each referenced markdown file with gray-matter every time it was encountered, even if the same file was already processed. For sites with many shared snippets included across multiple pages, this caused redundant file I/O and parsing.

Link to Devin run: https://app.devin.ai/sessions/19d2ba995efd4bf8bdc179b7fd9d4046
Requested by: Sandeep Dinesh (@thesandlord)

## Changes Made

- Check `collectedFiles` cache **before** calling `markdownLoader(filepath)` instead of after
- Reuse cached content when the same snippet file is referenced multiple times across pages
- This avoids redundant `readFile()` calls and `gray-matter` frontmatter parsing

## Testing

- [x] Unit tests pass (142 tests, including 26 tests for `replaceReferencedMarkdown`)
- [x] Manual lint check completed

## Human Review Checklist

- [ ] Verify caching logic is correct: we check cache before reading, and only read if not cached
- [ ] Confirm cached content (raw content before variable substitution) is appropriate for reuse
- [ ] Note: caching is scoped to a single resolve run, so stale content shouldn't be an issue