### PR TITLE
fix(java): Fix java wire tests

### DIFF
--- a/generators/java-v2/dynamic-snippets/src/context/DynamicTypeMapper.ts
+++ b/generators/java-v2/dynamic-snippets/src/context/DynamicTypeMapper.ts
@@ -80,6 +80,14 @@ export class DynamicTypeMapper {
     }
 
     private convertUnknown(): java.Type {
+        if (this.context.customConfig?.["generate-unknown-as-json-node"] === true) {
+            return java.Type.reference(
+                java.classReference({
+                    name: "JsonNode",
+                    packageName: "com.fasterxml.jackson.databind"
+                })
+            );
+        }
         return java.Type.object();
     }
 


### PR DESCRIPTION
## Description
Fixes Java SDK wire test failures by addressing two issues in generated code:

1. **Form-urlencoded serialization**: Endpoints with `application/x-www-form-urlencoded` content type were incorrectly sending JSON bodies instead of proper form-urlencoded data.

2. **JsonNode unknown types**: Dynamic snippets were generating `Object` types instead of `JsonNode` when the `generate-unknown-as-json-node` custom config is enabled.

## Changes Made
- **Form-urlencoded handling**: Added `initializeFormUrlEncodedBody` method in `OnlyRequestEndpointWriter.java` that uses OkHttp's `FormBody` to properly serialize request bodies with form-urlencoded content type
- **Dynamic snippets JsonNode support**: Updated `DynamicTypeMapper.ts` and `DynamicTypeLiteralMapper.ts` to respect `generate-unknown-as-json-node` config and emit `JsonNode` types with proper `ObjectMappers.JSON_MAPPER.valueToTree()` calls

## Testing
- [x] Manual testing with regenerated custom SDK
- [x] Wire tests passing for form-urlencoded endpoints (Authorization: getToken, refreshToken, revokeToken)