### PR TITLE
fix(cli): filter empty name parts in x-fern-sdk-group-name to prevent underscore exports

### DIFF
--- a/generators/python/src/fern_python/generators/fastapi/register/service_initializer.py
+++ b/generators/python/src/fern_python/generators/fastapi/register/service_initializer.py
@@ -20,6 +20,11 @@ class ServiceInitializer:
         )
 
     def get_parameter_name(self) -> str:
-        if len(self._service.name.fern_filepath.all_parts) == 0:
+        parts = [
+            part.snake_case.unsafe_name
+            for part in self._service.name.fern_filepath.all_parts
+            if part.snake_case.unsafe_name
+        ]
+        if len(parts) == 0:
             return "root"
-        return "_".join(part.snake_case.unsafe_name for part in self._service.name.fern_filepath.all_parts)
+        return "_".join(parts)

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/empty-sdk-group-name.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/empty-sdk-group-name.json
@@ -1,0 +1,391 @@
+{
+  "title": "Test empty x-fern-sdk-group-name values",
+  "servers": [],
+  "websocketServers": [],
+  "tags": {
+    "tagsById": {}
+  },
+  "hasEndpointsMarkedInternal": false,
+  "endpoints": [
+    {
+      "audiences": [],
+      "tags": [],
+      "sdkName": {
+        "groupName": [
+          ""
+        ],
+        "methodName": "get"
+      },
+      "pathParameters": [],
+      "queryParameters": [],
+      "headers": [],
+      "generatedRequestName": "GetRequest",
+      "response": {
+        "description": "Success",
+        "schema": {
+          "schema": {
+            "type": "string"
+          },
+          "generatedName": "GetResponse",
+          "groupName": [],
+          "type": "primitive"
+        },
+        "fullExamples": [],
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "statusCode": 200,
+        "type": "json"
+      },
+      "errors": {},
+      "servers": [],
+      "description": "This endpoint has an empty string group name",
+      "authed": false,
+      "method": "GET",
+      "path": "/empty-string",
+      "examples": [
+        {
+          "pathParameters": [],
+          "queryParameters": [],
+          "headers": [],
+          "response": {
+            "value": {
+              "value": {
+                "value": "string",
+                "type": "string"
+              },
+              "type": "primitive"
+            },
+            "type": "withoutStreaming"
+          },
+          "codeSamples": [],
+          "type": "full"
+        }
+      ],
+      "source": {
+        "file": "../openapi.yml",
+        "type": "openapi"
+      }
+    },
+    {
+      "audiences": [],
+      "tags": [],
+      "sdkName": {
+        "groupName": [
+          ""
+        ],
+        "methodName": "get"
+      },
+      "pathParameters": [],
+      "queryParameters": [],
+      "headers": [],
+      "generatedRequestName": "GetRequest",
+      "response": {
+        "description": "Success",
+        "schema": {
+          "schema": {
+            "type": "string"
+          },
+          "generatedName": "GetResponse",
+          "groupName": [],
+          "type": "primitive"
+        },
+        "fullExamples": [],
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "statusCode": 200,
+        "type": "json"
+      },
+      "errors": {},
+      "servers": [],
+      "description": "This endpoint has an array with empty string element",
+      "authed": false,
+      "method": "GET",
+      "path": "/empty-array-element",
+      "examples": [
+        {
+          "pathParameters": [],
+          "queryParameters": [],
+          "headers": [],
+          "response": {
+            "value": {
+              "value": {
+                "value": "string",
+                "type": "string"
+              },
+              "type": "primitive"
+            },
+            "type": "withoutStreaming"
+          },
+          "codeSamples": [],
+          "type": "full"
+        }
+      ],
+      "source": {
+        "file": "../openapi.yml",
+        "type": "openapi"
+      }
+    },
+    {
+      "audiences": [],
+      "tags": [],
+      "sdkName": {
+        "groupName": [
+          "valid",
+          "",
+          "group"
+        ],
+        "methodName": "get"
+      },
+      "pathParameters": [],
+      "queryParameters": [],
+      "headers": [],
+      "generatedRequestName": "GetGroupRequest",
+      "response": {
+        "description": "Success",
+        "schema": {
+          "schema": {
+            "type": "string"
+          },
+          "generatedName": "GetGroupResponse",
+          "groupName": [],
+          "type": "primitive"
+        },
+        "fullExamples": [],
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "statusCode": 200,
+        "type": "json"
+      },
+      "errors": {},
+      "servers": [],
+      "description": "This endpoint has an array with mixed empty and non-empty elements",
+      "authed": false,
+      "method": "GET",
+      "path": "/mixed-empty-array",
+      "examples": [
+        {
+          "pathParameters": [],
+          "queryParameters": [],
+          "headers": [],
+          "response": {
+            "value": {
+              "value": {
+                "value": "string",
+                "type": "string"
+              },
+              "type": "primitive"
+            },
+            "type": "withoutStreaming"
+          },
+          "codeSamples": [],
+          "type": "full"
+        }
+      ],
+      "source": {
+        "file": "../openapi.yml",
+        "type": "openapi"
+      }
+    },
+    {
+      "audiences": [],
+      "tags": [],
+      "sdkName": {
+        "groupName": [
+          "   "
+        ],
+        "methodName": "get"
+      },
+      "pathParameters": [],
+      "queryParameters": [],
+      "headers": [],
+      "generatedRequestName": "Get   Request",
+      "response": {
+        "description": "Success",
+        "schema": {
+          "schema": {
+            "type": "string"
+          },
+          "generatedName": "Get   Response",
+          "groupName": [],
+          "type": "primitive"
+        },
+        "fullExamples": [],
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "statusCode": 200,
+        "type": "json"
+      },
+      "errors": {},
+      "servers": [],
+      "description": "This endpoint has a whitespace-only group name",
+      "authed": false,
+      "method": "GET",
+      "path": "/whitespace-only",
+      "examples": [
+        {
+          "pathParameters": [],
+          "queryParameters": [],
+          "headers": [],
+          "response": {
+            "value": {
+              "value": {
+                "value": "string",
+                "type": "string"
+              },
+              "type": "primitive"
+            },
+            "type": "withoutStreaming"
+          },
+          "codeSamples": [],
+          "type": "full"
+        }
+      ],
+      "source": {
+        "file": "../openapi.yml",
+        "type": "openapi"
+      }
+    },
+    {
+      "audiences": [],
+      "tags": [],
+      "sdkName": {
+        "groupName": [
+          "_"
+        ],
+        "methodName": "get"
+      },
+      "pathParameters": [],
+      "queryParameters": [],
+      "headers": [],
+      "generatedRequestName": "Get_Request",
+      "response": {
+        "description": "Success",
+        "schema": {
+          "schema": {
+            "type": "string"
+          },
+          "generatedName": "Get_Response",
+          "groupName": [],
+          "type": "primitive"
+        },
+        "fullExamples": [],
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "statusCode": 200,
+        "type": "json"
+      },
+      "errors": {},
+      "servers": [],
+      "description": "This endpoint has an underscore-only group name (lodash strips this)",
+      "authed": false,
+      "method": "GET",
+      "path": "/underscore-only",
+      "examples": [
+        {
+          "pathParameters": [],
+          "queryParameters": [],
+          "headers": [],
+          "response": {
+            "value": {
+              "value": {
+                "value": "string",
+                "type": "string"
+              },
+              "type": "primitive"
+            },
+            "type": "withoutStreaming"
+          },
+          "codeSamples": [],
+          "type": "full"
+        }
+      ],
+      "source": {
+        "file": "../openapi.yml",
+        "type": "openapi"
+      }
+    },
+    {
+      "audiences": [],
+      "tags": [],
+      "sdkName": {
+        "groupName": [
+          "validGroup"
+        ],
+        "methodName": "get"
+      },
+      "pathParameters": [],
+      "queryParameters": [],
+      "headers": [],
+      "generatedRequestName": "GetValidGroupRequest",
+      "response": {
+        "description": "Success",
+        "schema": {
+          "schema": {
+            "type": "string"
+          },
+          "generatedName": "GetValidGroupResponse",
+          "groupName": [],
+          "type": "primitive"
+        },
+        "fullExamples": [],
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "statusCode": 200,
+        "type": "json"
+      },
+      "errors": {},
+      "servers": [],
+      "description": "This endpoint has a valid group name for comparison",
+      "authed": false,
+      "method": "GET",
+      "path": "/valid",
+      "examples": [
+        {
+          "pathParameters": [],
+          "queryParameters": [],
+          "headers": [],
+          "response": {
+            "value": {
+              "value": {
+                "value": "string",
+                "type": "string"
+              },
+              "type": "primitive"
+            },
+            "type": "withoutStreaming"
+          },
+          "codeSamples": [],
+          "type": "full"
+        }
+      ],
+      "source": {
+        "file": "../openapi.yml",
+        "type": "openapi"
+      }
+    }
+  ],
+  "webhooks": [],
+  "channels": {},
+  "groupedSchemas": {
+    "rootSchemas": {},
+    "namespacedSchemas": {}
+  },
+  "variables": {},
+  "nonRequestReferencedSchemas": {},
+  "securitySchemes": {},
+  "globalHeaders": [],
+  "idempotencyHeaders": [],
+  "groups": {}
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/empty-sdk-group-name.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/empty-sdk-group-name.json
@@ -1,0 +1,190 @@
+{
+  "absoluteFilePath": "/DUMMY_PATH",
+  "importedDefinitions": {},
+  "namedDefinitionFiles": {
+    "__package__.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {
+        "service": {
+          "auth": false,
+          "base-path": "",
+          "endpoints": {
+            "get": {
+              "auth": undefined,
+              "docs": "This endpoint has an underscore-only group name (lodash strips this)",
+              "examples": [
+                {
+                  "response": {
+                    "body": "string",
+                  },
+                },
+              ],
+              "method": "GET",
+              "pagination": undefined,
+              "path": "/underscore-only",
+              "response": {
+                "docs": "Success",
+                "status-code": 200,
+                "type": "string",
+              },
+              "source": {
+                "openapi": "../openapi.yml",
+              },
+            },
+          },
+          "source": {
+            "openapi": "../openapi.yml",
+          },
+        },
+      },
+      "rawContents": "service:
+  auth: false
+  base-path: ''
+  endpoints:
+    get:
+      path: /underscore-only
+      method: GET
+      docs: This endpoint has an underscore-only group name (lodash strips this)
+      source:
+        openapi: ../openapi.yml
+      response:
+        docs: Success
+        type: string
+        status-code: 200
+      examples:
+        - response:
+            body: string
+  source:
+    openapi: ../openapi.yml
+",
+    },
+    "valid/group.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {
+        "service": {
+          "auth": false,
+          "base-path": "",
+          "endpoints": {
+            "get": {
+              "auth": undefined,
+              "docs": "This endpoint has an array with mixed empty and non-empty elements",
+              "examples": [
+                {
+                  "response": {
+                    "body": "string",
+                  },
+                },
+              ],
+              "method": "GET",
+              "pagination": undefined,
+              "path": "/mixed-empty-array",
+              "response": {
+                "docs": "Success",
+                "status-code": 200,
+                "type": "string",
+              },
+              "source": {
+                "openapi": "../openapi.yml",
+              },
+            },
+          },
+          "source": {
+            "openapi": "../openapi.yml",
+          },
+        },
+      },
+      "rawContents": "service:
+  auth: false
+  base-path: ''
+  endpoints:
+    get:
+      path: /mixed-empty-array
+      method: GET
+      docs: This endpoint has an array with mixed empty and non-empty elements
+      source:
+        openapi: ../openapi.yml
+      response:
+        docs: Success
+        type: string
+        status-code: 200
+      examples:
+        - response:
+            body: string
+  source:
+    openapi: ../openapi.yml
+",
+    },
+    "validGroup.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {
+        "service": {
+          "auth": false,
+          "base-path": "",
+          "endpoints": {
+            "get": {
+              "auth": undefined,
+              "docs": "This endpoint has a valid group name for comparison",
+              "examples": [
+                {
+                  "response": {
+                    "body": "string",
+                  },
+                },
+              ],
+              "method": "GET",
+              "pagination": undefined,
+              "path": "/valid",
+              "response": {
+                "docs": "Success",
+                "status-code": 200,
+                "type": "string",
+              },
+              "source": {
+                "openapi": "../openapi.yml",
+              },
+            },
+          },
+          "source": {
+            "openapi": "../openapi.yml",
+          },
+        },
+      },
+      "rawContents": "service:
+  auth: false
+  base-path: ''
+  endpoints:
+    get:
+      path: /valid
+      method: GET
+      docs: This endpoint has a valid group name for comparison
+      source:
+        openapi: ../openapi.yml
+      response:
+        docs: Success
+        type: string
+        status-code: 200
+      examples:
+        - response:
+            body: string
+  source:
+    openapi: ../openapi.yml
+",
+    },
+  },
+  "packageMarkers": {},
+  "rootApiFile": {
+    "contents": {
+      "display-name": "Test empty x-fern-sdk-group-name values",
+      "error-discrimination": {
+        "strategy": "status-code",
+      },
+      "name": "api",
+    },
+    "defaultUrl": undefined,
+    "rawContents": "name: api
+error-discrimination:
+  strategy: status-code
+display-name: Test empty x-fern-sdk-group-name values
+",
+  },
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/empty-sdk-group-name/fern/fern.config.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/empty-sdk-group-name/fern/fern.config.json
@@ -1,0 +1,4 @@
+{
+    "organization": "fern",
+    "version": "*"
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/empty-sdk-group-name/fern/generators.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/empty-sdk-group-name/fern/generators.yml
@@ -1,0 +1,4 @@
+# yaml-language-server: $schema=https://schema.buildwithfern.dev/generators-yml.json
+api:
+  specs:
+    - openapi: ../openapi.yml

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/empty-sdk-group-name/openapi.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/empty-sdk-group-name/openapi.yml
@@ -1,0 +1,82 @@
+openapi: 3.0.3
+info:
+  title: Test empty x-fern-sdk-group-name values
+  version: 1.0.0
+paths:
+  /empty-string:
+    get:
+      description: This endpoint has an empty string group name
+      x-fern-sdk-group-name: ""
+      x-fern-sdk-method-name: get
+      responses:
+        "200":
+          description: "Success"
+          content:
+            application/json:
+              schema:
+                type: string
+
+  /empty-array-element:
+    get:
+      description: This endpoint has an array with empty string element
+      x-fern-sdk-group-name: [""]
+      x-fern-sdk-method-name: get
+      responses:
+        "200":
+          description: "Success"
+          content:
+            application/json:
+              schema:
+                type: string
+
+  /mixed-empty-array:
+    get:
+      description: This endpoint has an array with mixed empty and non-empty elements
+      x-fern-sdk-group-name: ["valid", "", "group"]
+      x-fern-sdk-method-name: get
+      responses:
+        "200":
+          description: "Success"
+          content:
+            application/json:
+              schema:
+                type: string
+
+  /whitespace-only:
+    get:
+      description: This endpoint has a whitespace-only group name
+      x-fern-sdk-group-name: "   "
+      x-fern-sdk-method-name: get
+      responses:
+        "200":
+          description: "Success"
+          content:
+            application/json:
+              schema:
+                type: string
+
+  /underscore-only:
+    get:
+      description: This endpoint has an underscore-only group name (lodash strips this)
+      x-fern-sdk-group-name: "_"
+      x-fern-sdk-method-name: get
+      responses:
+        "200":
+          description: "Success"
+          content:
+            application/json:
+              schema:
+                type: string
+
+  /valid:
+    get:
+      description: This endpoint has a valid group name for comparison
+      x-fern-sdk-group-name: validGroup
+      x-fern-sdk-method-name: get
+      responses:
+        "200":
+          description: "Success"
+          content:
+            application/json:
+              schema:
+                type: string

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/utils/convertSdkGroupName.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/utils/convertSdkGroupName.ts
@@ -18,15 +18,23 @@ export function convertSdkGroupNameToFileWithoutExtension(groupName: SdkGroupNam
     const fileNames: string[] = [];
     for (const [index, group] of cleanedGroupName.entries()) {
         if (typeof group === "string") {
-            fileNames.push(camelCase(group));
+            const camelCased = camelCase(group);
+            if (camelCased.length > 0) {
+                fileNames.push(camelCased);
+            }
         } else if (typeof group === "object") {
             switch (group.type) {
                 case "namespace": {
+                    const camelCased = camelCase(group.name);
                     if (index < cleanedGroupName.length - 1) {
-                        fileNames.push(camelCase(group.name));
+                        if (camelCased.length > 0) {
+                            fileNames.push(camelCased);
+                        }
                     } else {
                         // For the last namespace, make it a true namespace (ie. a directory with it's contents in the root package marker)
-                        fileNames.push(...[group.name, FERN_PACKAGE_MARKER_FILENAME_NO_EXTENSION]);
+                        if (group.name.trim().length > 0) {
+                            fileNames.push(...[group.name, FERN_PACKAGE_MARKER_FILENAME_NO_EXTENSION]);
+                        }
                     }
                     break;
                 }
@@ -38,6 +46,9 @@ export function convertSdkGroupNameToFileWithoutExtension(groupName: SdkGroupNam
         }
     }
 
+    if (fileNames.length === 0) {
+        return FERN_PACKAGE_MARKER_FILENAME_NO_EXTENSION;
+    }
     return fileNames.join("/");
 }
 

--- a/packages/cli/api-importers/v3-importer-commons/src/extensions/x-fern-sdk-group-name.ts
+++ b/packages/cli/api-importers/v3-importer-commons/src/extensions/x-fern-sdk-group-name.ts
@@ -26,8 +26,8 @@ export class SdkGroupNameExtension extends AbstractExtension<SdkGroupNameExtensi
         }
 
         const groups = Array.isArray(extensionValue)
-            ? extensionValue.filter((name): name is string => typeof name === "string")
-            : typeof extensionValue === "string"
+            ? extensionValue.filter((name): name is string => typeof name === "string" && name.trim().length > 0)
+            : typeof extensionValue === "string" && extensionValue.trim().length > 0
               ? [extensionValue]
               : [];
 


### PR DESCRIPTION
## Description
Linear ticket: Closes [FER-8049](https://linear.app/buildwithfern/issue/FER-8049/pipedream-empty-name-parts-resulting-in-exports)

Fixes a bug where empty or whitespace-only values in `x-fern-sdk-group-name` OpenAPI extension resulted in malformed file paths and underscore (`_`) exports in generated SDKs.

**Root cause:** When `x-fern-sdk-group-name` contains empty strings, whitespace-only strings, or underscore-only strings (since `camelCase("_")` returns `""`), the file path generation would produce invalid paths like `.yml`, `valid//group.yml`, or parameter names like `_`.

## Changes Made
- Filter out empty and whitespace-only strings in `x-fern-sdk-group-name.ts` at the input boundary
- Filter out empty strings after `camelCase()` transformation in `convertSdkGroupName.ts` and fallback to `__package__` when all names are filtered
- Add defensive filtering in Python FastAPI generator's `service_initializer.py` to prevent `_` parameter names
- Add test fixture `empty-sdk-group-name` covering edge cases: empty string, empty array element, mixed arrays, whitespace-only, and underscore-only group names

## Testing
- [x] Unit tests added (new `empty-sdk-group-name` test fixture with snapshots)
- [x] Lint checks pass (`pnpm run check`)

## Human Review Checklist
- [ ] Verify filtering logic doesn't accidentally filter legitimate group names
- [ ] Check if there are other similar join patterns in Python generator that need the same fix
- [ ] Confirm the OpenAPI IR snapshot showing empty strings in `groupName` arrays is expected (filtering happens downstream)

---
Link to Devin run: https://app.devin.ai/sessions/f0cacc6a3b1e4f73881cb9b06530fbc4
Requested by: sukeerthi@buildwithfern.com