### PR TITLE
fix(go): fall back to client-level environment for multi-URL resolution

### DIFF
--- a/generators/go-v2/sdk/src/endpoint/http/HttpEndpointGenerator.ts
+++ b/generators/go-v2/sdk/src/endpoint/http/HttpEndpointGenerator.ts
@@ -592,6 +592,16 @@ export class HttpEndpointGenerator extends AbstractEndpointGenerator {
                             on: this.getReceiverCodeBlock({ subpackage, rawClient }),
                             selector: go.codeblock("baseURL")
                         }),
+                        this.context.callResolveEnvironmentBaseURL([
+                            go.selector({
+                                on: go.selector({
+                                    on: this.getReceiverCodeBlock({ subpackage, rawClient }),
+                                    selector: go.codeblock("options")
+                                }),
+                                selector: go.codeblock("Environment")
+                            }),
+                            go.TypeInstantiation.string(baseUrlName)
+                        ]),
                         this.context.getDefaultBaseUrlTypeInstantiation(endpoint)
                     ])
                 );

--- a/generators/go/internal/generator/sdk.go
+++ b/generators/go/internal/generator/sdk.go
@@ -1259,22 +1259,23 @@ func (f *fileWriter) WriteClient(
 		}
 		f.P(") ", endpoint.ReturnValues, " {")
 		f.P("options := ", endpoint.OptionConstructor)
-			if endpoint.BaseURLName != "" {
-				f.P("baseURL := internal.ResolveBaseURL(")
-				f.P("options.BaseURL,")
-				f.P(fmt.Sprintf("internal.ResolveEnvironmentBaseURL(options.Environment, %q),", endpoint.BaseURLName))
-				f.P(receiver, ".baseURL,")
-				f.P(fmt.Sprintf("%q,", endpoint.BaseURL))
-				f.P(")")
-			} else {
-				f.P("baseURL := internal.ResolveBaseURL(")
-				f.P("options.BaseURL,")
-				f.P(receiver, ".baseURL,")
-				f.P(fmt.Sprintf("%q,", endpoint.BaseURL))
-				f.P(")")
-			}
-			baseURLVariable := "baseURL"
-			if len(endpoint.PathSuffix) > 0 {
+		if endpoint.BaseURLName != "" {
+			f.P("baseURL := internal.ResolveBaseURL(")
+			f.P("options.BaseURL,")
+			f.P(fmt.Sprintf("internal.ResolveEnvironmentBaseURL(options.Environment, %q),", endpoint.BaseURLName))
+			f.P(receiver, ".baseURL,")
+			f.P(fmt.Sprintf("internal.ResolveEnvironmentBaseURL(%s.options.Environment, %q),", receiver, endpoint.BaseURLName))
+			f.P(fmt.Sprintf("%q,", endpoint.BaseURL))
+			f.P(")")
+		} else {
+			f.P("baseURL := internal.ResolveBaseURL(")
+			f.P("options.BaseURL,")
+			f.P(receiver, ".baseURL,")
+			f.P(fmt.Sprintf("%q,", endpoint.BaseURL))
+			f.P(")")
+		}
+		baseURLVariable := "baseURL"
+		if len(endpoint.PathSuffix) > 0 {
 			baseURLVariable = `baseURL + ` + fmt.Sprintf(`"/%s"`, endpoint.PathSuffix)
 		}
 		if len(endpoint.PathParameterNames) > 0 {
@@ -3210,10 +3211,10 @@ func (f *fileWriter) WriteRequestType(
 	f.WriteSetterMethods(typeName, propertyNames, propertyTypes, propertySafeNames)
 
 	var (
-		referenceType            string
-		referenceIsPointer       bool
-		referenceFieldIsPointer  bool
-		referenceLiteral         string
+		referenceType           string
+		referenceIsPointer      bool
+		referenceFieldIsPointer bool
+		referenceLiteral        string
 	)
 	if reference := endpoint.RequestBody.Reference; reference != nil {
 		fullType := typeReferenceToGoType(reference.RequestBodyType, f.types, f.scope, f.baseImportPath, importPath, false)

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.21.3
+  changelogEntry:
+    - summary: |
+        Fix multi-URL environment resolution to fall back to client-level environment when
+        per-request environment is not specified. This ensures endpoints correctly resolve
+        their base URL when the environment is set at client construction time.
+      type: fix
+  createdAt: "2025-12-17"
+  irVersion: 60
+
 - version: 1.21.2
   changelogEntry:
     - summary: |

--- a/seed/go-sdk/multi-url-environment/ec2/raw_client.go
+++ b/seed/go-sdk/multi-url-environment/ec2/raw_client.go
@@ -43,6 +43,10 @@ func (r *RawClient) BootInstance(
 			"Ec2",
 		),
 		r.baseURL,
+		internal.ResolveEnvironmentBaseURL(
+			r.options.Environment,
+			"Ec2",
+		),
 		"https://ec2.aws.com",
 	)
 	endpointURL := baseURL + "/ec2/boot"

--- a/seed/go-sdk/multi-url-environment/internal/retrier.go
+++ b/seed/go-sdk/multi-url-environment/internal/retrier.go
@@ -98,6 +98,15 @@ func (r *Retrier) run(
 		return nil, err
 	}
 
+	// Reset the request body for retries since the body may have already been read.
+	if retryAttempt > 0 && request.GetBody != nil {
+		requestBody, err := request.GetBody()
+		if err != nil {
+			return nil, err
+		}
+		request.Body = requestBody
+	}
+
 	response, err := fn(request)
 	if err != nil {
 		return nil, err

--- a/seed/go-sdk/multi-url-environment/s3/raw_client.go
+++ b/seed/go-sdk/multi-url-environment/s3/raw_client.go
@@ -43,6 +43,10 @@ func (r *RawClient) GetPresignedUrl(
 			"S3",
 		),
 		r.baseURL,
+		internal.ResolveEnvironmentBaseURL(
+			r.options.Environment,
+			"S3",
+		),
 		"https://s3.aws.com",
 	)
 	endpointURL := baseURL + "/s3/presigned-url"


### PR DESCRIPTION
When per-request environment is not specified, the SDK now falls back to the client-level environment for resolving base URLs in multi-URL environments. This fixes an issue where endpoints would incorrectly use the default URL instead of the environment set at client construction time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)