### PR TITLE
fix(ruby): fix inferred auth base URL resolution and add absolute URL support

### DIFF
--- a/generators/ruby-v2/base/src/asIs/internal/http/raw_client.Template.rb
+++ b/generators/ruby-v2/base/src/asIs/internal/http/raw_client.Template.rb
@@ -5,6 +5,9 @@ module <%= gem_namespace %>
     module Http
       # @api private
       class RawClient
+        # @return [String] The base URL for requests
+        attr_reader :base_url
+
         # @param base_url [String] The base url for the request.
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
@@ -44,6 +47,13 @@ module <%= gem_namespace %>
         # @param request [<%= gem_namespace %>::Internal::Http::BaseRequest] The HTTP request.
         # @return [URI::Generic] The URL.
         def build_url(request)
+          # If the path is already an absolute URL, use it directly
+          if request.path.start_with?("http://", "https://")
+            url = request.path
+            url = "#{url}?#{encode_query(request.query)}" if request.query&.any?
+            return URI.parse(url)
+          end
+
           path = request.path.start_with?("/") ? request.path[1..] : request.path
           base = request.base_url || @base_url
           url = "#{base.chomp("/")}/#{path}"
@@ -103,4 +113,4 @@ module <%= gem_namespace %>
       end
     end
   end
-end        
+end                                

--- a/generators/ruby-v2/sdk/src/inferred-auth/InferredAuthProviderGenerator.ts
+++ b/generators/ruby-v2/sdk/src/inferred-auth/InferredAuthProviderGenerator.ts
@@ -196,11 +196,11 @@ export class InferredAuthProviderGenerator extends FileGenerator<RubyFile, SdkCu
                 writer.writeLine("}");
                 writer.newLine();
 
-                // Call the token endpoint with request_options containing base_url
+                // Call the token endpoint
+                // Note: The auth_client is already configured with the correct base URL,
+                // so we don't need to override it in request_options
                 const endpointMethodName = this.getEndpointMethodName();
-                writer.writeLine(
-                    `token_response = @auth_client.${endpointMethodName}(**request_params, request_options: { base_url: @options[:base_url] })`
-                );
+                writer.writeLine(`token_response = @auth_client.${endpointMethodName}(**request_params)`);
                 writer.newLine();
 
                 // Get the access token from the response

--- a/generators/ruby-v2/sdk/versions.yml
+++ b/generators/ruby-v2/sdk/versions.yml
@@ -1,5 +1,18 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.0.0-rc70
+  createdAt: "2025-12-17"
+  changelogEntry:
+    - type: fix
+      summary: |
+        Fix inferred auth base URL resolution and add absolute URL support:
+        - Auth raw client now properly falls back to default environment when base_url is not provided
+        - RawClient.build_url now handles absolute URLs (e.g., HATEOAS pagination links) directly
+        - Added attr_reader :base_url to RawClient for external access
+        - Removed unnecessary base_url override in InferredAuthProvider.refresh since auth_client
+          is already configured with the correct base URL
+  irVersion: 61
+
 - version: 1.0.0-rc69
   createdAt: "2025-12-16"
   changelogEntry:


### PR DESCRIPTION
## Description

Refs: https://buildwithfern.slack.com/archives/C09UDMNDC5N/p1765927916226099

Fixes issues with the Ruby v2 generator related to inferred authentication URL handling and absolute URL support, as reported in the Payroc SDK PR (payroc/papi-sdk-ruby/pull/96).

Requested by: @iamnamananand996 (naman.anand@buildwithfern.com)
Link to Devin run: https://app.devin.ai/sessions/cde646b520b7412ea3d9bf4174ff88a8

## Changes Made

- **RawClient base URL exposure**: Added `attr_reader :base_url` to expose the base URL for external access (e.g., custom pagers that need URL normalization)
- **Absolute URL handling**: Updated `build_url` method to detect and use absolute URLs directly (e.g., HATEOAS pagination links) instead of combining them with base_url
- **Inferred auth base URL resolution**: Fixed the auth_raw_client initialization to properly resolve the base URL:
  - For multi-URL environments: Uses the token endpoint's `baseUrl` from the IR if specified, otherwise falls back to the first base URL
  - For single-URL environments: Falls back to `DefaultEnvironment` when `base_url` is not provided
- **Removed unnecessary base_url override**: The `InferredAuthProvider.refresh` method no longer passes `base_url` in request_options since the auth_client is already configured with the correct base URL

## What This PR Does NOT Address

These issues from the Payroc SDK are intentionally not addressed as they are API-specific:
- `derive_identity_url` logic (converting `api.*.payroc.com` → `identity.*.payroc.com`) - should be handled through the Fern definition by declaring separate base URLs
- Internal hostname normalization (`http://events/...` → public hostname) - this is an API bug on Payroc's end

## Human Review Checklist

- [ ] Verify the token endpoint's `baseUrl` from IR is correctly used for multi-URL environments (e.g., if token endpoint is marked to use `identity` URL, it should use that instead of `api`)
- [ ] Verify fallback to first base URL works when token endpoint doesn't have a `baseUrl` specified
- [ ] Verify removing the `base_url` override in `InferredAuthProvider.refresh` doesn't break edge cases
- [ ] Consider whether seed tests should be added to validate these changes

## Testing

- [x] Lint checks pass (`pnpm run check`)
- [ ] Seed tests (not added - changes are based on analysis of manually-fixed Payroc SDK)