### PR TITLE
chore(cli): clear Next.js cache when running fern docs dev

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -2,7 +2,7 @@
 - version: 3.24.6
   changelogEntry:
     - summary: |
-        Clear app-preview cache when running `fern docs dev` to ensure a fresh start.
+        Clear Next.js cache when running `fern docs dev` to ensure a fresh start.
       type: chore
   createdAt: "2025-12-17"
   irVersion: 62

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.24.6
+  changelogEntry:
+    - summary: |
+        Clear app-preview cache when running `fern docs dev` to ensure a fresh start.
+      type: chore
+  createdAt: "2025-12-17"
+  irVersion: 62
+
 - version: 3.24.5
   changelogEntry:
     - summary: |

--- a/packages/cli/docs-preview/src/runAppPreviewServer.ts
+++ b/packages/cli/docs-preview/src/runAppPreviewServer.ts
@@ -1,6 +1,14 @@
 import { wrapWithHttps } from "@fern-api/docs-resolver";
 import { DocsV1Read, DocsV2Read, FernNavigation } from "@fern-api/fdr-sdk";
-import { AbsoluteFilePath, dirname, doesPathExist, listFiles, RelativeFilePath, resolve } from "@fern-api/fs-utils";
+import {
+    AbsoluteFilePath,
+    dirname,
+    doesPathExist,
+    join,
+    listFiles,
+    RelativeFilePath,
+    resolve
+} from "@fern-api/fs-utils";
 import { runExeca } from "@fern-api/logging-execa";
 import { Project } from "@fern-api/project-loader";
 import { TaskContext } from "@fern-api/task-context";
@@ -14,7 +22,7 @@ import Watcher from "watcher";
 import { WebSocket, WebSocketServer } from "ws";
 
 import { DebugLogger } from "./DebugLogger";
-import { downloadBundle, getPathToBundleFolder, getPathToPreviewFolder } from "./downloadLocalDocsBundle";
+import { downloadBundle, getPathToBundleFolder } from "./downloadLocalDocsBundle";
 import { getPreviewDocsDefinition } from "./previewDocs";
 
 const EMPTY_DOCS_DEFINITION: DocsV1Read.DocsDefinition = {
@@ -373,11 +381,11 @@ export async function runAppPreviewServer({
     bundlePath?: string;
     backendPort: number;
 }): Promise<void> {
-    // Clear any previous app-preview cache to ensure a fresh start
-    const appPreviewPath = getPathToPreviewFolder({ app: true });
-    if (await doesPathExist(appPreviewPath)) {
-        context.logger.debug(`Clearing previous app-preview cache at: ${appPreviewPath}`);
-        await rm(appPreviewPath, { recursive: true });
+    // Clear the Next.js cache to ensure a fresh start (preserves the downloaded bundle)
+    const nextCachePath = join(getPathToBundleFolder({ app: true }), RelativeFilePath.of("cache"));
+    if (await doesPathExist(nextCachePath)) {
+        context.logger.debug(`Clearing Next.js cache at: ${nextCachePath}`);
+        await rm(nextCachePath, { recursive: true, force: true });
     }
 
     if (bundlePath != null) {

--- a/packages/cli/docs-preview/src/runAppPreviewServer.ts
+++ b/packages/cli/docs-preview/src/runAppPreviewServer.ts
@@ -7,14 +7,14 @@ import { TaskContext } from "@fern-api/task-context";
 import chalk from "chalk";
 import cors from "cors";
 import express from "express";
-import { readFile } from "fs/promises";
+import { readFile, rm } from "fs/promises";
 import http from "http";
 import path from "path";
 import Watcher from "watcher";
 import { WebSocket, WebSocketServer } from "ws";
 
 import { DebugLogger } from "./DebugLogger";
-import { downloadBundle, getPathToBundleFolder } from "./downloadLocalDocsBundle";
+import { downloadBundle, getPathToBundleFolder, getPathToPreviewFolder } from "./downloadLocalDocsBundle";
 import { getPreviewDocsDefinition } from "./previewDocs";
 
 const EMPTY_DOCS_DEFINITION: DocsV1Read.DocsDefinition = {
@@ -373,6 +373,13 @@ export async function runAppPreviewServer({
     bundlePath?: string;
     backendPort: number;
 }): Promise<void> {
+    // Clear any previous app-preview cache to ensure a fresh start
+    const appPreviewPath = getPathToPreviewFolder({ app: true });
+    if (await doesPathExist(appPreviewPath)) {
+        context.logger.debug(`Clearing previous app-preview cache at: ${appPreviewPath}`);
+        await rm(appPreviewPath, { recursive: true });
+    }
+
     if (bundlePath != null) {
         context.logger.info(`Using bundle from path: ${bundlePath}`);
     } else {

--- a/packages/cli/docs-preview/src/runAppPreviewServer.ts
+++ b/packages/cli/docs-preview/src/runAppPreviewServer.ts
@@ -22,7 +22,7 @@ import Watcher from "watcher";
 import { WebSocket, WebSocketServer } from "ws";
 
 import { DebugLogger } from "./DebugLogger";
-import { downloadBundle, getPathToBundleFolder } from "./downloadLocalDocsBundle";
+import { downloadBundle, getPathToBundleFolder, getPathToEtagFile } from "./downloadLocalDocsBundle";
 import { getPreviewDocsDefinition } from "./previewDocs";
 
 const EMPTY_DOCS_DEFINITION: DocsV1Read.DocsDefinition = {
@@ -386,6 +386,13 @@ export async function runAppPreviewServer({
     if (await doesPathExist(nextCachePath)) {
         context.logger.debug(`Clearing Next.js cache at: ${nextCachePath}`);
         await rm(nextCachePath, { recursive: true, force: true });
+    }
+
+    // Clear the ETag cache to force re-download of the bundle
+    const etagPath = getPathToEtagFile({ app: true });
+    if (await doesPathExist(etagPath)) {
+        context.logger.debug(`Clearing ETag cache at: ${etagPath}`);
+        await rm(etagPath, { force: true });
     }
 
     if (bundlePath != null) {

--- a/packages/cli/docs-preview/src/runAppPreviewServer.ts
+++ b/packages/cli/docs-preview/src/runAppPreviewServer.ts
@@ -22,7 +22,7 @@ import Watcher from "watcher";
 import { WebSocket, WebSocketServer } from "ws";
 
 import { DebugLogger } from "./DebugLogger";
-import { downloadBundle, getPathToBundleFolder, getPathToEtagFile } from "./downloadLocalDocsBundle";
+import { downloadBundle, getPathToBundleFolder } from "./downloadLocalDocsBundle";
 import { getPreviewDocsDefinition } from "./previewDocs";
 
 const EMPTY_DOCS_DEFINITION: DocsV1Read.DocsDefinition = {
@@ -386,13 +386,6 @@ export async function runAppPreviewServer({
     if (await doesPathExist(nextCachePath)) {
         context.logger.debug(`Clearing Next.js cache at: ${nextCachePath}`);
         await rm(nextCachePath, { recursive: true, force: true });
-    }
-
-    // Clear the ETag cache to force re-download of the bundle
-    const etagPath = getPathToEtagFile({ app: true });
-    if (await doesPathExist(etagPath)) {
-        context.logger.debug(`Clearing ETag cache at: ${etagPath}`);
-        await rm(etagPath, { force: true });
     }
 
     if (bundlePath != null) {


### PR DESCRIPTION
## Description

Refs: Slack request from Sandeep

Clears the Next.js cache directory (`~/.fern/app-preview/.next/cache/`) at the start of `fern docs dev` to ensure a fresh start each time, while preserving the downloaded bundle.

**Link to Devin run:** https://app.devin.ai/sessions/968bf08808624d43bb6733400a17eb0f
**Requested by:** Sandeep Dinesh (sandeep@buildwithfern.com) / @thesandlord

## Changes Made

- Added cache clearing logic at the start of `runAppPreviewServer()` that removes the Next.js cache folder (`~/.fern/app-preview/.next/cache/`)
- Added `join` import from `@fern-api/fs-utils` and `rm` import from `fs/promises`
- Added changelog entry for version 3.24.6

## Updates Since Last Revision

- Reverted ETag cache clearing per user request - now only clears the Next.js runtime cache
- The downloaded bundle and ETag caching remain intact, avoiding unnecessary re-downloads

## Human Review Checklist

- [ ] **Verify cache path**: Confirm `~/.fern/app-preview/.next/cache/` is the correct Next.js cache location to clear
- [ ] **Verify bundle preservation**: The downloaded bundle at `~/.fern/app-preview/.next/standalone/` should remain intact

## Testing

- [ ] Unit tests added/updated
- [x] Lint checks pass (`pnpm run check`)
- [ ] Manual testing completed