### PR TITLE
feat(cli): add user email to PostHog events when not using access token

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.25.0
+  changelogEntry:
+    - summary: |
+        Add user email to CLI PostHog events when not using an access token. This enables better user analytics by capturing the primary email address from Auth0 for logged-in users.
+      type: feat
+  createdAt: "2025-12-17"
+  irVersion: 62
+
 - version: 3.24.5
   changelogEntry:
     - summary: |

--- a/packages/cli/posthog-manager/package.json
+++ b/packages/cli/posthog-manager/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "@fern-api/auth": "workspace:*",
+    "@fern-api/core": "workspace:*",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/task-context": "workspace:*",
     "posthog-node": "^4.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6625,6 +6625,9 @@ importers:
       '@fern-api/auth':
         specifier: workspace:*
         version: link:../auth
+      '@fern-api/core':
+        specifier: workspace:*
+        version: link:../../core
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../commons/fs-utils


### PR DESCRIPTION
## Description

Refs: Slack request from Danny

Adds the user's primary email address to CLI PostHog events when the user is logged in with a user token (not an access token). This enables better user analytics by capturing email addresses from Auth0 for logged-in users.

**Link to Devin run**: https://app.devin.ai/sessions/5f21cef38f3d497289e64a4200c38c16
**Requested by**: danny@buildwithfern.com (@dannysheridan)

## Changes Made

- Modified `UserPosthogManager` to store the user token and lazily fetch the user's email from Venus service
- Added `userEmail` property to PostHog events when available (fetched from Auth0 via Venus)
- Added `usingAccessToken: false` to events from `UserPosthogManager` (complements `AccessTokenPosthogManager` which sets `usingAccessToken: true`)
- Added `@fern-api/core` dependency to `posthog-manager` package for Venus service access
- Bumped CLI version to 3.25.0

## Human Review Checklist

- [ ] Verify the caching logic in `getUserEmail()` is correct (uses `null` to indicate "already tried", `undefined` for "not yet fetched")
- [ ] Confirm it's acceptable to make a Venus API call during PostHog event sending (cached after first call)
- [ ] Note: Errors are silently caught since email is optional for analytics

## Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed (lint checks pass)