### PR TITLE
feat(ruby): make base_url parameter optional in main client.rb

### DIFF
--- a/generators/ruby-v2/sdk/src/root-client/RootClientGenerator.ts
+++ b/generators/ruby-v2/sdk/src/root-client/RootClientGenerator.ts
@@ -58,7 +58,7 @@ export class RootClientGenerator extends FileGenerator<RubyFile, SdkCustomConfig
         const baseUrlParameter = ruby.parameters.keyword({
             name: "base_url",
             type: ruby.Type.nilable(ruby.Type.string()),
-            initializer: undefined,
+            initializer: ruby.nilValue(),
             docs: "Override the default base URL for the API, e.g., `https://api.example.com`"
         });
         parameters.push(baseUrlParameter);

--- a/generators/ruby-v2/sdk/versions.yml
+++ b/generators/ruby-v2/sdk/versions.yml
@@ -1,5 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.0.0-rc71
+  createdAt: "2025-12-17"
+  changelogEntry:
+    - type: feat
+      summary: |
+        Make the base_url parameter optional in the main client.rb. The parameter now has a default
+        value of nil, allowing users to instantiate the client without explicitly providing a base_url
+        when using environment-based configuration.
+  irVersion: 61
+
 - version: 1.0.0-rc70
   createdAt: "2025-12-17"
   changelogEntry:


### PR DESCRIPTION
## Description

Refs: Slack request from @aditya-arolkar-swe

Makes the `base_url` parameter optional in the Ruby SDK's main client.rb by adding a default value of `nil`.

Link to Devin run: https://app.devin.ai/sessions/d5a383b65b71460f91cbd52ae6f3d79b
Requested by: adi@buildwithfern.com (@aditya-arolkar-swe)

## Changes Made

- Updated `RootClientGenerator.ts` to set `initializer: ruby.nilValue()` instead of `initializer: undefined` for the `base_url` parameter
- Bumped version from `1.0.0-rc70` to `1.0.0-rc71` in `versions.yml`

## Testing

- [x] Lint checks pass (`pnpm run check`)
- [ ] Seed tests should be run to verify generated Ruby code

## Human Review Checklist

- [ ] Verify the generated Ruby client code now shows `base_url: nil` as the default parameter value
- [ ] Confirm this change aligns with the expected behavior for environment-based configuration