### PR TITLE
feat(typescript): Add support for overriding SDK variables at request level

### DIFF
--- a/generators/typescript/sdk/client-class-generator/src/endpoints/GeneratedFileDownloadEndpointImplementation.ts
+++ b/generators/typescript/sdk/client-class-generator/src/endpoints/GeneratedFileDownloadEndpointImplementation.ts
@@ -13,7 +13,8 @@ import {
     getAbortSignalExpression,
     getMaxRetriesExpression,
     getRequestOptionsParameter,
-    getTimeoutExpression
+    getTimeoutExpression,
+    REQUEST_OPTIONS_PARAMETER_NAME
 } from "./utils/requestOptionsParameter";
 
 export declare namespace GeneratedFileDownloadEndpointImplementation {
@@ -191,7 +192,8 @@ export class GeneratedFileDownloadEndpointImplementation implements GeneratedEnd
             getReferenceToPathParameterVariableFromRequest: (pathParameter) => {
                 return this.request.getReferenceToPathParameter(pathParameter.name.originalName, context);
             },
-            parameterNaming: this.parameterNaming
+            parameterNaming: this.parameterNaming,
+            requestOptionsReference: ts.factory.createIdentifier(REQUEST_OPTIONS_PARAMETER_NAME)
         });
 
         if (url != null) {

--- a/generators/typescript/sdk/client-class-generator/src/endpoints/GeneratedStreamingEndpointImplementation.ts
+++ b/generators/typescript/sdk/client-class-generator/src/endpoints/GeneratedStreamingEndpointImplementation.ts
@@ -12,7 +12,8 @@ import {
     getAbortSignalExpression,
     getMaxRetriesExpression,
     getRequestOptionsParameter,
-    getTimeoutExpression
+    getTimeoutExpression,
+    REQUEST_OPTIONS_PARAMETER_NAME
 } from "./utils/requestOptionsParameter";
 
 export declare namespace GeneratedStreamingEndpointImplementation {
@@ -230,7 +231,8 @@ export class GeneratedStreamingEndpointImplementation implements GeneratedEndpoi
             getReferenceToPathParameterVariableFromRequest: (pathParameter) => {
                 return this.request.getReferenceToPathParameter(pathParameter.name.originalName, context);
             },
-            parameterNaming: this.parameterNaming
+            parameterNaming: this.parameterNaming,
+            requestOptionsReference: ts.factory.createIdentifier(REQUEST_OPTIONS_PARAMETER_NAME)
         });
         if (url != null) {
             return context.coreUtilities.urlUtils.join._invoke([baseUrl, url]);

--- a/generators/typescript/sdk/client-class-generator/src/endpoints/default/GeneratedDefaultEndpointImplementation.ts
+++ b/generators/typescript/sdk/client-class-generator/src/endpoints/default/GeneratedDefaultEndpointImplementation.ts
@@ -726,7 +726,8 @@ export class GeneratedDefaultEndpointImplementation implements GeneratedEndpoint
             getReferenceToPathParameterVariableFromRequest: (pathParameter) => {
                 return this.request.getReferenceToPathParameter(pathParameter.name.originalName, context);
             },
-            parameterNaming: this.parameterNaming
+            parameterNaming: this.parameterNaming,
+            requestOptionsReference: ts.factory.createIdentifier(REQUEST_OPTIONS_PARAMETER_NAME)
         });
         if (url != null) {
             return context.coreUtilities.urlUtils.join._invoke([baseUrl, url]);

--- a/generators/typescript/sdk/client-class-generator/src/endpoints/utils/buildUrl.ts
+++ b/generators/typescript/sdk/client-class-generator/src/endpoints/utils/buildUrl.ts
@@ -17,7 +17,8 @@ export function buildUrl({
     omitUndefined,
     parameterNaming,
     getReferenceToPathParameterVariableFromRequest,
-    forceInlinePathParameters = false
+    forceInlinePathParameters = false,
+    requestOptionsReference
 }: {
     endpoint: {
         sdkRequest: SdkRequest | undefined;
@@ -33,6 +34,7 @@ export function buildUrl({
     omitUndefined: boolean;
     getReferenceToPathParameterVariableFromRequest: GetReferenceToPathParameterVariableFromRequest;
     forceInlinePathParameters?: boolean;
+    requestOptionsReference?: ts.Expression;
 }): ts.Expression | undefined {
     if (endpoint.allPathParameters.length === 0) {
         if (endpoint.fullPath.head.length === 0) {
@@ -57,7 +59,8 @@ export function buildUrl({
                 parameterNaming,
                 shouldInlinePathParameters:
                     forceInlinePathParameters || context.requestWrapper.shouldInlinePathParameters(endpoint.sdkRequest),
-                getReferenceToPathParameterVariableFromRequest
+                getReferenceToPathParameterVariableFromRequest,
+                requestOptionsReference
             });
 
             if (includeSerdeLayer && pathParameter.valueType.type === "named") {
@@ -91,7 +94,8 @@ function getReferenceToPathParameter({
     retainOriginalCasing,
     shouldInlinePathParameters,
     parameterNaming,
-    getReferenceToPathParameterVariableFromRequest
+    getReferenceToPathParameterVariableFromRequest,
+    requestOptionsReference
 }: {
     pathParameter: PathParameter;
     generatedClientClass: GeneratedSdkClientClassImpl;
@@ -99,8 +103,15 @@ function getReferenceToPathParameter({
     shouldInlinePathParameters: boolean;
     parameterNaming: "originalName" | "wireValue" | "camelCase" | "snakeCase" | "default";
     getReferenceToPathParameterVariableFromRequest: GetReferenceToPathParameterVariableFromRequest;
+    requestOptionsReference?: ts.Expression;
 }): ts.Expression {
     if (pathParameter.variable != null) {
+        if (requestOptionsReference != null) {
+            return generatedClientClass.getReferenceToVariableWithRequestOptions(
+                pathParameter.variable,
+                requestOptionsReference
+            );
+        }
         return generatedClientClass.getReferenceToVariable(pathParameter.variable);
     }
     switch (pathParameter.location) {

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.43.0
+  changelogEntry:
+    - summary: |
+        Add support for overriding SDK variables at the request level.
+        Variables defined via `x-fern-sdk-variables` can now be optionally overridden per-request
+        by passing them in the endpoint-specific RequestOptions interface.
+        The request-level value takes precedence over the client-level value when provided.
+      type: feat
+  createdAt: "2025-12-17"
+  irVersion: 62
+
 - version: 3.42.5
   changelogEntry:
     - summary: |

--- a/seed/ts-sdk/variables/reference.md
+++ b/seed/ts-sdk/variables/reference.md
@@ -29,7 +29,7 @@ await client.service.post();
 <dl>
 <dd>
 
-**requestOptions:** `ServiceClient.RequestOptions` 
+**requestOptions:** `ServiceClient.PostRequestOptions` 
     
 </dd>
 </dl>

--- a/seed/ts-sdk/variables/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/variables/src/api/resources/service/client/Client.ts
@@ -11,6 +11,10 @@ export declare namespace ServiceClient {
     export type Options = BaseClientOptions;
 
     export interface RequestOptions extends BaseRequestOptions {}
+
+    export interface PostRequestOptions extends RequestOptions {
+        rootVariable?: string;
+    }
 }
 
 export class ServiceClient {
@@ -26,17 +30,17 @@ export class ServiceClient {
      * @example
      *     await client.service.post()
      */
-    public post(requestOptions?: ServiceClient.RequestOptions): core.HttpResponsePromise<void> {
+    public post(requestOptions?: ServiceClient.PostRequestOptions): core.HttpResponsePromise<void> {
         return core.HttpResponsePromise.fromPromise(this.__post(requestOptions));
     }
 
-    private async __post(requestOptions?: ServiceClient.RequestOptions): Promise<core.WithRawResponse<void>> {
+    private async __post(requestOptions?: ServiceClient.PostRequestOptions): Promise<core.WithRawResponse<void>> {
         const _headers: core.Fetcher.Args["headers"] = mergeHeaders(this._options?.headers, requestOptions?.headers);
         const _response = await core.fetcher({
             url: core.url.join(
                 (await core.Supplier.get(this._options.baseUrl)) ??
                     (await core.Supplier.get(this._options.environment)),
-                `/${core.url.encodePathParam(this._options.rootVariable)}`,
+                `/${core.url.encodePathParam(requestOptions?.rootVariable ?? this._options.rootVariable)}`,
             ),
             method: "POST",
             headers: _headers,


### PR DESCRIPTION
## Description

Refs: Request from @tjb9dc via Slack

Variables defined via `x-fern-sdk-variables` can now be optionally overridden per-request by passing them in endpoint-specific RequestOptions interfaces. The request-level value takes precedence over the client-level value when provided.

**Link to Devin run:** https://app.devin.ai/sessions/623bc646df7d471cb27f1509f0c3b1f8
**Requested by:** thomas@buildwithfern.com (@tjb9dc)

## Changes Made

- Added `getVariablesForEndpoint()` method to identify which variables are used by each endpoint (via path parameters)
- Added `getReferenceToVariableWithRequestOptions()` method that generates fallback logic: `requestOptions?.variable ?? clientOptions.variable`
- Added endpoint-specific RequestOptions interface generation (e.g., `PostRequestOptions`) that extends base `RequestOptions` with optional variable properties
- Updated `buildUrl.ts` to accept `requestOptionsReference` parameter and use it when resolving variables
- Updated all HTTP endpoint implementations to pass request options reference when building URLs

**Example generated output:**
```typescript
export interface PostRequestOptions extends RequestOptions {
    rootVariable?: string;
}

// URL building now uses:
`/${core.url.encodePathParam(requestOptions?.rootVariable ?? this._options.rootVariable)}`
```

- [x] Updated versions.yml with changelog entry (v3.43.0)

## Testing

- [x] Seed tests pass for `variables` fixture
- [x] Lint checks pass (`pnpm run check`)
- [x] Verified generated output shows correct endpoint-specific RequestOptions interfaces

## Human Review Checklist

- [ ] Verify endpoint-specific RequestOptions naming (e.g., `PostRequestOptions`) doesn't conflict with existing types in user codebases
- [ ] Confirm the fallback pattern is correct for all variable use cases
- [ ] Note: WebSocket implementation was intentionally not updated as it uses a different pattern (no request options)