### PR TITLE
feat(internal): add sdkVersion as top-level field in metadata.json

### DIFF
--- a/generators/csharp/base/src/cli/AbstractCsharpGeneratorCli.ts
+++ b/generators/csharp/base/src/cli/AbstractCsharpGeneratorCli.ts
@@ -24,7 +24,11 @@ export abstract class AbstractCsharpGeneratorCli extends AbstractGeneratorCli<
     }
 
     protected async generateMetadata(context: GeneratorContext): Promise<void> {
-        const content = JSON.stringify(context.ir.generationMetadata, null, 2);
+        const metadata = {
+            ...context.ir.generationMetadata,
+            sdkVersion: context.version
+        };
+        const content = JSON.stringify(metadata, null, 2);
         context.project.addRawFiles(
             new File(this.GENERATION_METADATA_FILENAME, this.GENERATION_METADATA_FILEPATH, content)
         );

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.12.1
+  changelogEntry:
+    - summary: |
+        Add sdkVersion as a top-level field in the generated metadata.json file.
+      type: feat
+  createdAt: "2025-12-18"
+  irVersion: 62
+
 - version: 2.12.0
   changelogEntry:
     - summary: |

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -3,7 +3,7 @@
   changelogEntry:
     - summary: |
         Add sdkVersion as a top-level field in the generated metadata.json file.
-      type: feat
+      type: chore
   createdAt: "2025-12-18"
   irVersion: 62
 

--- a/generators/go-v2/base/src/cli/AbstractGoGeneratorCli.ts
+++ b/generators/go-v2/base/src/cli/AbstractGoGeneratorCli.ts
@@ -22,7 +22,11 @@ export abstract class AbstractGoGeneratorCli<
     }
 
     protected async generateMetadata(context: GoGeneratorContext): Promise<void> {
-        const content = JSON.stringify(context.ir.generationMetadata, null, 2);
+        const metadata = {
+            ...context.ir.generationMetadata,
+            sdkVersion: context.version
+        };
+        const content = JSON.stringify(metadata, null, 2);
         context.project.addRawFiles(
             new File(this.GENERATION_METADATA_FILENAME, this.GENERATION_METADATA_FILEPATH, content)
         );

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -3,7 +3,7 @@
   changelogEntry:
     - summary: |
         Add sdkVersion as a top-level field in the generated metadata.json file.
-      type: feat
+      type: chore
   createdAt: "2025-12-18"
   irVersion: 60
 

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.21.4
+  changelogEntry:
+    - summary: |
+        Add sdkVersion as a top-level field in the generated metadata.json file.
+      type: feat
+  createdAt: "2025-12-18"
+  irVersion: 60
+
 - version: 1.21.3
   changelogEntry:
     - summary: |

--- a/generators/java-v2/base/src/cli/AbstractJavaGeneratorCli.ts
+++ b/generators/java-v2/base/src/cli/AbstractJavaGeneratorCli.ts
@@ -23,7 +23,11 @@ export abstract class AbstractJavaGeneratorCli<
     }
 
     protected async generateMetadata(context: JavaGeneratorContext): Promise<void> {
-        const content = JSON.stringify(context.ir.generationMetadata, null, 2);
+        const metadata = {
+            ...context.ir.generationMetadata,
+            sdkVersion: context.version
+        };
+        const content = JSON.stringify(metadata, null, 2);
         context.project.addRawFiles(
             new File(this.GENERATION_METADATA_FILENAME, this.GENERATION_METADATA_FILEPATH, content)
         );

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,3 +1,11 @@
+- version: 3.27.1
+  changelogEntry:
+    - summary: |
+        Add sdkVersion as a top-level field in the generated metadata.json file.
+      type: feat
+  createdAt: "2025-12-18"
+  irVersion: 61
+
 - version: 3.27.0
   changelogEntry:
     - summary: |

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -2,7 +2,7 @@
   changelogEntry:
     - summary: |
         Add sdkVersion as a top-level field in the generated metadata.json file.
-      type: feat
+      type: chore
   createdAt: "2025-12-18"
   irVersion: 61
 

--- a/generators/php/base/src/cli/AbstractPhpGeneratorCli.ts
+++ b/generators/php/base/src/cli/AbstractPhpGeneratorCli.ts
@@ -24,7 +24,11 @@ export abstract class AbstractPhpGeneratorCli<
     }
 
     protected async generateMetadata(context: PhpGeneratorContext): Promise<void> {
-        const content = JSON.stringify(context.ir.generationMetadata, null, 2);
+        const metadata = {
+            ...context.ir.generationMetadata,
+            sdkVersion: context.version
+        };
+        const content = JSON.stringify(metadata, null, 2);
         context.project.addRawFiles(
             new File(this.GENERATION_METADATA_FILENAME, this.GENERATION_METADATA_FILEPATH, content)
         );

--- a/generators/php/sdk/versions.yml
+++ b/generators/php/sdk/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.25.2
+  changelogEntry:
+    - summary: |
+        Add sdkVersion as a top-level field in the generated metadata.json file.
+      type: feat
+  createdAt: "2025-12-18"
+  irVersion: 62
+
 - version: 1.25.1
   changelogEntry:
     - summary: |

--- a/generators/php/sdk/versions.yml
+++ b/generators/php/sdk/versions.yml
@@ -4,7 +4,7 @@
   changelogEntry:
     - summary: |
         Add sdkVersion as a top-level field in the generated metadata.json file.
-      type: feat
+      type: chore
   createdAt: "2025-12-18"
   irVersion: 62
 

--- a/generators/python-v2/base/src/cli/AbstractPythonGeneratorCli.ts
+++ b/generators/python-v2/base/src/cli/AbstractPythonGeneratorCli.ts
@@ -22,7 +22,11 @@ export abstract class AbstractPythonGeneratorCli<
     }
 
     protected async generateMetadata(context: PythonGeneratorContext): Promise<void> {
-        const content = JSON.stringify(context.ir.generationMetadata, null, 2);
+        const metadata = {
+            ...context.ir.generationMetadata,
+            sdkVersion: context.version
+        };
+        const content = JSON.stringify(metadata, null, 2);
         context.project.addRawFiles(
             new File(this.GENERATION_METADATA_FILENAME, this.GENERATION_METADATA_FILEPATH, content)
         );

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -4,7 +4,7 @@
   changelogEntry:
     - summary: |
         Add sdkVersion as a top-level field in the generated metadata.json file.
-      type: feat
+      type: chore
   createdAt: "2025-12-18"
   irVersion: 61
 

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 4.46.5
+  changelogEntry:
+    - summary: |
+        Add sdkVersion as a top-level field in the generated metadata.json file.
+      type: feat
+  createdAt: "2025-12-18"
+  irVersion: 61
+
 - version: 4.46.4-rc1
   changelogEntry:
     - summary: |

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
-- version: 4.46.5
+- version: 4.46.4-rc2
   changelogEntry:
     - summary: |
         Add sdkVersion as a top-level field in the generated metadata.json file.

--- a/generators/ruby-v2/base/src/cli/AbstractRubyGeneratorCli.ts
+++ b/generators/ruby-v2/base/src/cli/AbstractRubyGeneratorCli.ts
@@ -22,7 +22,11 @@ export abstract class AbstractRubyGeneratorCli<
     }
 
     protected async generateMetadata(context: RubyGeneratorContext): Promise<void> {
-        const content = JSON.stringify(context.ir.generationMetadata, null, 2);
+        const metadata = {
+            ...context.ir.generationMetadata,
+            sdkVersion: context.version
+        };
+        const content = JSON.stringify(metadata, null, 2);
         context.project.addRawFiles(
             new File(this.GENERATION_METADATA_FILENAME, this.GENERATION_METADATA_FILEPATH, content)
         );

--- a/generators/ruby-v2/sdk/versions.yml
+++ b/generators/ruby-v2/sdk/versions.yml
@@ -4,7 +4,7 @@
   changelogEntry:
     - summary: |
         Add sdkVersion as a top-level field in the generated metadata.json file.
-      type: feat
+      type: chore
   createdAt: "2025-12-18"
   irVersion: 61
 

--- a/generators/ruby-v2/sdk/versions.yml
+++ b/generators/ruby-v2/sdk/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.0.0-rc72
+  changelogEntry:
+    - summary: |
+        Add sdkVersion as a top-level field in the generated metadata.json file.
+      type: feat
+  createdAt: "2025-12-18"
+  irVersion: 61
+
 - version: 1.0.0-rc71
   createdAt: "2025-12-17"
   changelogEntry:

--- a/generators/rust/base/src/cli/AbstractRustGeneratorCli.ts
+++ b/generators/rust/base/src/cli/AbstractRustGeneratorCli.ts
@@ -47,7 +47,11 @@ export abstract class AbstractRustGeneratorCli<
     }
 
     protected async generateMetadata(context: RustGeneratorContext): Promise<void> {
-        const content = JSON.stringify(context.ir.generationMetadata, null, 2);
+        const metadata = {
+            ...context.ir.generationMetadata,
+            sdkVersion: context.version
+        };
+        const content = JSON.stringify(metadata, null, 2);
         context.project.addRawFiles(
             new File(this.GENERATION_METADATA_FILENAME, this.GENERATION_METADATA_FILEPATH, content)
         );

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -4,7 +4,7 @@
   changelogEntry:
     - summary: |
         Add sdkVersion as a top-level field in the generated metadata.json file.
-      type: feat
+      type: chore
   createdAt: "2025-12-18"
   irVersion: 61
 

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.13.5
+  changelogEntry:
+    - summary: |
+        Add sdkVersion as a top-level field in the generated metadata.json file.
+      type: feat
+  createdAt: "2025-12-18"
+  irVersion: 61
+
 - version: 0.13.4
   createdAt: "2025-12-02"
   changelogEntry:

--- a/generators/swift/base/src/cli/AbstractSwiftGeneratorCli.ts
+++ b/generators/swift/base/src/cli/AbstractSwiftGeneratorCli.ts
@@ -18,7 +18,11 @@ export abstract class AbstractSwiftGeneratorCli<
     }
 
     protected async generateMetadata(context: SwiftGeneratorContext): Promise<void> {
-        const content = JSON.stringify(context.ir.generationMetadata, null, 2);
+        const metadata = {
+            ...context.ir.generationMetadata,
+            sdkVersion: context.version
+        };
+        const content = JSON.stringify(metadata, null, 2);
         context.project.addRawFiles(
             new File(this.GENERATION_METADATA_FILENAME, this.GENERATION_METADATA_FILEPATH, content)
         );

--- a/generators/swift/sdk/versions.yml
+++ b/generators/swift/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 0.25.4
+  changelogEntry:
+    - summary: |
+        Add sdkVersion as a top-level field in the generated metadata.json file.
+      type: feat
+  createdAt: "2025-12-18"
+  irVersion: 61
+
 - version: 0.25.3
   changelogEntry:
     - summary: |

--- a/generators/swift/sdk/versions.yml
+++ b/generators/swift/sdk/versions.yml
@@ -3,7 +3,7 @@
   changelogEntry:
     - summary: |
         Add sdkVersion as a top-level field in the generated metadata.json file.
-      type: feat
+      type: chore
   createdAt: "2025-12-18"
   irVersion: 61
 

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.42.7
+  changelogEntry:
+    - summary: |
+        Add sdkVersion as a top-level field in the generated metadata.json file.
+      type: feat
+  createdAt: "2025-12-18"
+  irVersion: 62
+
 - version: 3.42.6
   changelogEntry:
     - summary: Fix wire test generation for OAuth endpoints with reference request bodies.

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -3,7 +3,7 @@
   changelogEntry:
     - summary: |
         Add sdkVersion as a top-level field in the generated metadata.json file.
-      type: feat
+      type: chore
   createdAt: "2025-12-18"
   irVersion: 62
 

--- a/generators/typescript/utils/abstract-generator-cli/src/AbstractGeneratorCli.ts
+++ b/generators/typescript/utils/abstract-generator-cli/src/AbstractGeneratorCli.ts
@@ -140,7 +140,8 @@ export abstract class AbstractGeneratorCli<CustomConfig> {
                 if (ir.generationMetadata) {
                     await writeGenerationMetadata({
                         generationMetadata: ir.generationMetadata,
-                        pathToProject
+                        pathToProject,
+                        sdkVersion: version
                     });
                 }
             });

--- a/generators/typescript/utils/abstract-generator-cli/src/writeGenerationMetadata.ts
+++ b/generators/typescript/utils/abstract-generator-cli/src/writeGenerationMetadata.ts
@@ -8,12 +8,18 @@ const GENERATION_METADATA_FILEPATH = ".fern";
 
 export async function writeGenerationMetadata({
     generationMetadata,
-    pathToProject
+    pathToProject,
+    sdkVersion
 }: {
     generationMetadata: FernIr.GenerationMetadata;
     pathToProject: AbsoluteFilePath;
+    sdkVersion: string | undefined;
 }): Promise<void> {
-    const content = JSON.stringify(generationMetadata, null, 2);
+    const metadata = {
+        ...generationMetadata,
+        sdkVersion
+    };
+    const content = JSON.stringify(metadata, null, 2);
     const generationMetadataDir = path.join(pathToProject, GENERATION_METADATA_FILEPATH);
     await mkdir(generationMetadataDir, { recursive: true });
     await writeFile(`${generationMetadataDir}/${GENERATION_METADATA_FILENAME}`, content);


### PR DESCRIPTION
## Description

Refs: Slack request from @tjb9dc

Adds `sdkVersion` as a top-level field in the `.fern/metadata.json` file that gets written by all SDK generators.

**Link to Devin run:** https://app.devin.ai/sessions/fe270d6a944842b6b6faeacabe162cff
**Requested by:** thomas@buildwithfern.com (@tjb9dc)

## Changes Made

- Updated `generateMetadata` method in all generator base classes (Go, Python, Java, C#, Swift, Ruby, PHP, Rust) to include `sdkVersion` from `context.version`
- Updated TypeScript generator's `writeGenerationMetadata` function to accept and include `sdkVersion` parameter
- Added `versions.yml` entries for all modified generators with new version numbers:
  - Go SDK: 1.21.4
  - Python SDK: 4.46.5
  - TypeScript SDK: 3.42.7
  - Java SDK: 3.27.1
  - C# SDK: 2.12.1
  - Swift SDK: 0.25.4
  - Ruby SDK: 1.0.0-rc72
  - PHP SDK: 1.25.2
  - Rust SDK: 0.13.5
- The `sdkVersion` value comes from the output mode configuration (github.version or publish.version), and will be `undefined` for downloadFiles mode

## Human Review Checklist

- [ ] Verify behavior is acceptable when `sdkVersion` is `undefined` (occurs in downloadFiles mode)
- [ ] Confirm downstream consumers of metadata.json can handle the new field
- [ ] Note: TypeScript MCP generator was not modified (it doesn't currently support metadata generation)

## Testing

- [x] Lint checks pass (`pnpm run check`)
- [ ] Manual testing completed
- [ ] Seed tests will validate generated output in CI

## Notes

- Initial CI failures for go-fiber, java-model, and python-sdk were network timeout issues (not related to code changes)
- go-fiber and java-model generators don't write metadata.json to seed output, so they are unaffected by this change