### PR TITLE
chore(internal): Update ruby v2 seed.yml to fix seed run commands

### DIFF
--- a/seed/ruby-sdk-v2/seed.yml
+++ b/seed/ruby-sdk-v2/seed.yml
@@ -4,6 +4,7 @@ language: ruby
 generatorType: SDK
 defaultOutputMode: github
 image: fernapi/fern-ruby-sdk-v2
+imageAliases: [fernapi/fern-ruby-sdk]
 changelogLocation: ../../generators/ruby-v2/sdk/versions.yml
 
 buildScripts:


### PR DESCRIPTION
## Description
Adds `imageAliases` to the ruby-sdk-v2 seed configuration so that `seed run --generator ruby-sdk-v2` can work with custom projects that have `fernapi/fern-ruby-sdk` configured in their generators.yml.

## Changes Made
- **seed/ruby-sdk-v2/seed.yml**: Added `imageAliases: [fernapi/fern-ruby-sdk]` to allow ruby-sdk-v2 to match generator configurations using the ruby-sdk image name

## Testing
- [x] Verified `pnpm seed run --generator ruby-sdk-v2 --path <custom-project>` now works on projects with ruby-sdk configured