### PR TITLE
fix(go): dedupe wire test functions to avoid duplicate declarations

### DIFF
--- a/generators/go-v2/sdk/src/wire-tests/WireTestGenerator.ts
+++ b/generators/go-v2/sdk/src/wire-tests/WireTestGenerator.ts
@@ -136,7 +136,8 @@ export class WireTestGenerator {
                 testFunctionNameCounts.set(baseTestFunctionName, count + 1);
 
                 // First occurrence uses the base name, subsequent occurrences get a numeric suffix
-                const uniqueTestFunctionName = count === 0 ? baseTestFunctionName : `${baseTestFunctionName}${count + 1}`;
+                const uniqueTestFunctionName =
+                    count === 0 ? baseTestFunctionName : `${baseTestFunctionName}${count + 1}`;
 
                 const [endpointTestCaseCodeBlock, endpointImports] = this.generateEndpointTestMethod(
                     endpoint,
@@ -322,10 +323,9 @@ export class WireTestGenerator {
     private generateEndpointTestMethod(
         endpoint: HttpEndpoint,
         snippet: string,
-        testFunctionNameOverride?: string
+        testFunctionName: string
     ): [go.CodeBlock, Map<string, string>] {
         const imports = this.parseImportsFromSnippet(snippet);
-        const testFunctionName = testFunctionNameOverride ?? this.parseTestFunctionNameFromSnippet(snippet);
 
         const testMethod = go.codeblock((writer) => {
             writer.writeNode(

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,4 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.21.5
+  changelogEntry:
+    - summary: |
+        Fix duplicate test function generation in wire tests. When multiple endpoints map to the
+        same test function name, only the first one is now generated to avoid Go compilation errors.
+      type: fix
+  createdAt: "2025-12-18"
+  irVersion: 60
+
 - version: 1.21.4
   changelogEntry:
     - summary: |

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -3,7 +3,8 @@
   changelogEntry:
     - summary: |
         Fix duplicate test function generation in wire tests. When multiple endpoints map to the
-        same test function name, only the first one is now generated to avoid Go compilation errors.
+        same test function name, subsequent occurrences now get numeric suffixes (e.g., Test2, Test3)
+        to avoid Go compilation errors while preserving all test coverage.
       type: fix
   createdAt: "2025-12-18"
   irVersion: 60


### PR DESCRIPTION
## Description
Refs https://github.com/cohere-ai/cohere-go/actions/runs/20343502658/job/58450036956?pr=142

Fixes a Go compilation error in generated SDKs where multiple endpoints can map to the same test function name, causing duplicate function declarations.

## Changes Made
- Added deduplication logic in `WireTestGenerator.ts` to track test function name counts and generate unique names with numeric suffixes for duplicates
  - First occurrence: `TestChatStreamWithWireMock`
  - Second occurrence: `TestChatStreamWithWireMock2`
  - Third occurrence: `TestChatStreamWithWireMock3`
- Modified `generateEndpointTestMethod` to accept an optional `testFunctionNameOverride` parameter
- Added version 1.21.5 changelog entry

## Context
The cohere-go SDK CI was failing because the wire test generator was creating duplicate `TestChatStreamWithWireMock`, `TestGenerateStreamWithWireMock`, and `TestV2ChatStreamWithWireMock` functions. This happens when multiple endpoints (potentially streaming variants) resolve to the same test function name via `getTestMethodName()`.

## Human Review Checklist
- [ ] **Important**: The `versions.yml` changelog entry says "only the first one is now generated" but the implementation now adds numeric suffixes to keep all tests - this should be updated to match
- [ ] Verify endpoint ordering is deterministic (the counter approach relies on consistent iteration order)
- [ ] Consider if the numeric suffix naming convention (Test, Test2, Test3) is appropriate

## Testing
- [x] Code compiles successfully
- [x] Biome lint passes
- [ ] Unit tests added/updated (none added - this is a defensive fix)

---
Link to Devin run: https://app.devin.ai/sessions/7b1d83848cf7410eaacea270a8b87d05
Requested by: thomas@buildwithfern.com (@tjb9dc)