### PR TITLE
fix(internal): Enable using --local flag with go-sdk generator in seed cli

### DIFF
--- a/generators/go/.gitignore
+++ b/generators/go/.gitignore
@@ -1,2 +1,7 @@
 *.swp
 .env
+
+# Go binaries created during local builds
+fern-go-sdk
+fern-go-model
+fern-go-fiber

--- a/generators/go/internal/generator/v2/generator.go
+++ b/generators/go/internal/generator/v2/generator.go
@@ -13,8 +13,18 @@ import (
 )
 
 // v2BinPath is the path to the go-v2 binary included in the SDK
-// generator docker image.
-const v2BinPath = "/bin/go-v2"
+// generator docker image. Can be overridden with GO_V2_PATH environment variable.
+const defaultV2BinPath = "/bin/go-v2"
+
+// getV2BinPath returns the path to the go-v2 binary, checking for environment variable override
+func getV2BinPath() string {
+	if envPath := os.Getenv("GO_V2_PATH"); envPath != "" {
+		fmt.Printf("DEBUG: Using GO_V2_PATH environment variable: %s\n", envPath)
+		return envPath
+	}
+	fmt.Printf("DEBUG: GO_V2_PATH not set, using default: %s\n", defaultV2BinPath)
+	return defaultV2BinPath
+}
 
 // Generator represents a shim used to go-v2 SDK generator.
 type Generator struct {
@@ -34,6 +44,7 @@ func (g *Generator) Run() error {
 		return errors.New("internal error; failed to resolve configuration file path")
 	}
 
+	v2BinPath := getV2BinPath()
 	if _, err := os.Stat(v2BinPath); os.IsNotExist(err) {
 		return fmt.Errorf("go-v2 binary not found at %s", v2BinPath)
 	}

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,8 +1,8 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
-- version: 1.22.0
+- version: 1.21.6
   changelogEntry:
     - summary: Add GO_V2_PATH environment variable support for configurable v2 binary path during local development and testing
-      type: feat
+      type: chore
   createdAt: "2025-12-18"
   irVersion: 60
 

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,4 +1,11 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.22.0
+  changelogEntry:
+    - summary: Add GO_V2_PATH environment variable support for configurable v2 binary path during local development and testing
+      type: feat
+  createdAt: "2025-12-18"
+  irVersion: 60
+
 - version: 1.21.5
   changelogEntry:
     - summary: |

--- a/seed/go-sdk/seed.yml
+++ b/seed/go-sdk/seed.yml
@@ -31,6 +31,17 @@ test:
   podman:
     image: fernapi/fern-go-sdk:latest
     command: pnpm turbo run dist:cli --filter @fern-api/go-sdk && podman build -f ./generators/go/sdk/Dockerfile -t fernapi/fern-go-sdk:latest .
+  local:
+    workingDirectory: generators/go
+    buildCommand:
+      # Build TypeScript v2 CLI first
+      - pnpm turbo run dist:cli --filter @fern-api/go-sdk
+      # Build Go v1 CLI
+      - go build -ldflags "-s -w" -trimpath -buildvcs=false -o fern-go-sdk ./cmd/fern-go-sdk
+    runCommand: ./fern-go-sdk {CONFIG_PATH}
+    env:
+      # Set path to the go-v2 CLI built from TypeScript (absolute path)
+      GO_V2_PATH: "/Users/jsklan/git/fern-2/generators/go-v2/sdk/dist/cli.cjs"
 language: go
 generatorType: SDK
 defaultOutputMode: github


### PR DESCRIPTION
## Description
This PR enables using the `--local` flag with the go-sdk generator in the seed CLI by making the v2 binary path configurable via environment variable.

Previously, when running seed tests locally with `pnpm seed test --generator go-sdk --fixture <fixture> --local`, the go-v1 generator would fail because it was hardcoded to look for the go-v2 binary at `/bin/go-v2` (the Docker container path). This prevented local development and debugging of the go-sdk generator.

## Changes Made
- **Environment Variable Support**: Added `GO_V2_PATH` environment variable to override the default v2 binary path in the go-v1 generator
- **Seed Configuration**: Updated `seed/go-sdk/seed.yml` to include local build and run commands with proper environment setup
- **Binary Path Resolution**: Modified `generators/go/internal/generator/v2/generator.go` to check for the environment variable before falling back to the default Docker path
- **Gitignore Updates**: Added Go binary files to `.gitignore` to prevent accidental commits of build artifacts
- **Version Bump**: Incremented version to 1.21.6 with appropriate changelog entry

## Testing
- [x] Manual testing completed with local seed runs
- [x] Verified go-v1 generator can successfully invoke go-v2 CLI during local development
- [x] Confirmed existing Docker-based functionality remains unchanged