### PR TITLE
feat(go): add X-Test-Id header to wire tests for scoping assertions

### DIFF
--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
-- version: 1.21.6
+- version: 1.22.0
   changelogEntry:
     - summary: |
         Add X-Test-Id header to wire tests for scoping assertions to specific tests. This allows

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.21.6
+  changelogEntry:
+    - summary: |
+        Add X-Test-Id header to wire tests for scoping assertions to specific tests. This allows
+        tests to run concurrently without interfering with each other by filtering WireMock
+        request verification by the test ID header.
+      type: feat
+  createdAt: "2025-12-18"
+  irVersion: 60
+
 - version: 1.21.5
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs: Slack thread from thomas@buildwithfern.com

Adds the `X-Test-Id` header to Go v2 wire tests, matching the pattern already implemented in Python, PHP, and Ruby generators. This allows wire tests to run concurrently without interfering with each other by filtering WireMock request verification by a unique test ID.

## Changes Made

- Added `buildDeterministicTestId` function to generate unique test IDs from service path and endpoint name
- Added `parseClientConstructorParts` method to parse client constructor into structured components (prefix and args)
- Refactored `constructWiremockTestClient` to use go-ast writer API for injecting `X-Test-Id` header via `option.WithHTTPHeader`
- Updated `writeVerifyRequestCount` to accept testId parameter and filter WireMock requests by the `X-Test-Id` header
- Updated `callClientMethodAndAssert` to pass testId to `VerifyRequestCount`
- Removed `ResetWireMockRequests` function (no longer needed since test isolation is achieved via header filtering)
- Updated versions.yml with version 1.22.0 (minor version bump for new feature)

## Updates Since Last Revision

- Refactored from string manipulation to use go-ast writer API for cleaner code generation
- Removed unused `exampleIndex` parameter from `buildDeterministicTestId` (test ID format is now `service.path.endpoint_name`)
- Resolved merge conflicts with main branch

## Testing

- [x] Lint checks pass
- [x] All CI checks pass (103 passing)
- [x] Relies on existing seed tests for validation (including `imdb:with-wiremock-tests`)

## Human Review Checklist

- [ ] Verify `parseClientConstructorParts` correctly handles edge cases (nested parens/braces in arguments, multi-line constructors)
- [ ] Verify the JSON structure for WireMock's `/requests/find` endpoint is correctly formed with the X-Test-Id header filter
- [ ] Confirm test ID format (`service.path.endpoint_name`) is appropriate for test isolation
- [ ] Verify writer API indentation produces valid Go code in generated tests

---

Link to Devin run: https://app.devin.ai/sessions/2b43142a7dda4b5cb04414a7a7ce74d0
Requested by: thomas@buildwithfern.com (@tjb9dc)