### PR TITLE
feat(python): optimize union factory and visit methods to avoid .dict() serialization

### DIFF
--- a/generators/python/core_utilities/shared/pydantic_utilities.py
+++ b/generators/python/core_utilities/shared/pydantic_utilities.py
@@ -312,6 +312,12 @@ def copy_and_update_model(
         fields_set.discard(field_name)
 
     if IS_PYDANTIC_V2:
-        return pydantic.BaseModel.model_construct.__func__(target_cls, fields_set, **values)  # type: ignore[attr-defined, return-value]
+        return cast(
+            Model,
+            pydantic.BaseModel.model_construct.__func__(target_cls, fields_set, **values),  # type: ignore[attr-defined]
+        )
     else:
-        return pydantic.BaseModel.construct.__func__(target_cls, fields_set, **values)  # type: ignore[attr-defined, return-value]
+        return cast(
+            Model,
+            pydantic.BaseModel.construct.__func__(target_cls, fields_set, **values),  # type: ignore[attr-defined]
+        )

--- a/generators/python/core_utilities/shared/with_pydantic_aliases/pydantic_utilities.py
+++ b/generators/python/core_utilities/shared/with_pydantic_aliases/pydantic_utilities.py
@@ -1,7 +1,7 @@
 # nopycln: file
 import datetime as dt
 from collections import defaultdict
-from typing import Any, Callable, Dict, List, Mapping, Tuple, Type, TypeVar, Union, cast
+from typing import Any, Callable, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
 import pydantic
 
@@ -226,3 +226,62 @@ def _get_field_default(field: PydanticField) -> Any:
             return None
         return value
     return value
+
+
+def copy_and_update_model(
+    source: pydantic.BaseModel,
+    target_cls: Type[Model],
+    *,
+    update: Optional[Dict[str, Any]] = None,
+    exclude: Optional[Set[str]] = None,
+) -> Model:
+    """
+    Efficiently copy fields from a source model to a new instance of target_cls
+    without deep serialization (avoiding .dict() overhead).
+
+    This is useful for union type conversions where we need to:
+    - Add fields (e.g., discriminant field in factory methods)
+    - Remove fields (e.g., discriminant field in visit methods)
+
+    Args:
+        source: The source Pydantic model instance
+        target_cls: The target model class to create
+        update: Optional dict of field values to add/override
+        exclude: Optional set of field names to exclude from copying
+
+    Returns:
+        A new instance of target_cls with copied fields
+    """
+    update = update or {}
+    exclude = exclude or set()
+
+    if IS_PYDANTIC_V2:
+        fields_set = source.__pydantic_fields_set__.copy()  # type: ignore[attr-defined]
+        extras = getattr(source, "__pydantic_extra__", None) or {}
+    else:
+        fields_set = source.__fields_set__.copy()
+        extras = {}
+        for key in source.__dict__:
+            if key not in source.__fields__:
+                extras[key] = source.__dict__[key]
+
+    values: Dict[str, Any] = {}
+    for field_name in source.__dict__:
+        if field_name not in exclude:
+            values[field_name] = source.__dict__[field_name]
+
+    for key in extras:
+        if key not in exclude:
+            values[key] = extras[key]
+
+    for key, value in update.items():
+        values[key] = value
+        fields_set.add(key)
+
+    for field_name in exclude:
+        fields_set.discard(field_name)
+
+    if IS_PYDANTIC_V2:
+        return pydantic.BaseModel.model_construct.__func__(target_cls, fields_set, **values)  # type: ignore[attr-defined, return-value]
+    else:
+        return pydantic.BaseModel.construct.__func__(target_cls, fields_set, **values)  # type: ignore[attr-defined, return-value]

--- a/generators/python/core_utilities/shared/with_pydantic_aliases/pydantic_utilities.py
+++ b/generators/python/core_utilities/shared/with_pydantic_aliases/pydantic_utilities.py
@@ -282,6 +282,12 @@ def copy_and_update_model(
         fields_set.discard(field_name)
 
     if IS_PYDANTIC_V2:
-        return pydantic.BaseModel.model_construct.__func__(target_cls, fields_set, **values)  # type: ignore[attr-defined, return-value]
+        return cast(
+            Model,
+            pydantic.BaseModel.model_construct.__func__(target_cls, fields_set, **values),  # type: ignore[attr-defined]
+        )
     else:
-        return pydantic.BaseModel.construct.__func__(target_cls, fields_set, **values)  # type: ignore[attr-defined, return-value]
+        return cast(
+            Model,
+            pydantic.BaseModel.construct.__func__(target_cls, fields_set, **values),  # type: ignore[attr-defined]
+        )

--- a/generators/python/core_utilities/shared/with_pydantic_v1_on_v2/pydantic_utilities.py
+++ b/generators/python/core_utilities/shared/with_pydantic_v1_on_v2/pydantic_utilities.py
@@ -219,4 +219,7 @@ def copy_and_update_model(
     for field_name in exclude:
         fields_set.discard(field_name)
 
-    return pydantic.v1.BaseModel.construct.__func__(target_cls, fields_set, **values)  # type: ignore[attr-defined, return-value]
+    return cast(
+        Model,
+        pydantic.v1.BaseModel.construct.__func__(target_cls, fields_set, **values),  # type: ignore[attr-defined]
+    )

--- a/generators/python/core_utilities/shared/with_pydantic_v1_on_v2/pydantic_utilities.py
+++ b/generators/python/core_utilities/shared/with_pydantic_v1_on_v2/pydantic_utilities.py
@@ -168,3 +168,55 @@ def _get_field_default(field: PydanticField) -> Any:
     except:
         value = field.default
     return value
+
+
+def copy_and_update_model(
+    source: pydantic.v1.BaseModel,
+    target_cls: Type[Model],
+    *,
+    update: Optional[Dict[str, Any]] = None,
+    exclude: Optional[Set[str]] = None,
+) -> Model:
+    """
+    Efficiently copy fields from a source model to a new instance of target_cls
+    without deep serialization (avoiding .dict() overhead).
+
+    This is useful for union type conversions where we need to:
+    - Add fields (e.g., discriminant field in factory methods)
+    - Remove fields (e.g., discriminant field in visit methods)
+
+    Args:
+        source: The source Pydantic model instance
+        target_cls: The target model class to create
+        update: Optional dict of field values to add/override
+        exclude: Optional set of field names to exclude from copying
+
+    Returns:
+        A new instance of target_cls with copied fields
+    """
+    update = update or {}
+    exclude = exclude or set()
+
+    fields_set = source.__fields_set__.copy()
+    extras = {}
+    for key in source.__dict__:
+        if key not in source.__fields__:
+            extras[key] = source.__dict__[key]
+
+    values: Dict[str, Any] = {}
+    for field_name in source.__dict__:
+        if field_name not in exclude:
+            values[field_name] = source.__dict__[field_name]
+
+    for key in extras:
+        if key not in exclude:
+            values[key] = extras[key]
+
+    for key, value in update.items():
+        values[key] = value
+        fields_set.add(key)
+
+    for field_name in exclude:
+        fields_set.discard(field_name)
+
+    return pydantic.v1.BaseModel.construct.__func__(target_cls, fields_set, **values)  # type: ignore[attr-defined, return-value]

--- a/generators/python/core_utilities/shared/with_pydantic_v1_on_v2/with_aliases/pydantic_utilities.py
+++ b/generators/python/core_utilities/shared/with_pydantic_v1_on_v2/with_aliases/pydantic_utilities.py
@@ -1,7 +1,7 @@
 # nopycln: file
 import datetime as dt
 from collections import defaultdict
-from typing import Any, Callable, Dict, List, Mapping, Tuple, Type, TypeVar, Union, cast
+from typing import Any, Callable, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
 import pydantic
 from .datetime_utils import serialize_datetime
@@ -158,3 +158,55 @@ def _get_field_default(field: PydanticField) -> Any:
     except:
         value = field.default
     return value
+
+
+def copy_and_update_model(
+    source: pydantic.v1.BaseModel,
+    target_cls: Type[Model],
+    *,
+    update: Optional[Dict[str, Any]] = None,
+    exclude: Optional[Set[str]] = None,
+) -> Model:
+    """
+    Efficiently copy fields from a source model to a new instance of target_cls
+    without deep serialization (avoiding .dict() overhead).
+
+    This is useful for union type conversions where we need to:
+    - Add fields (e.g., discriminant field in factory methods)
+    - Remove fields (e.g., discriminant field in visit methods)
+
+    Args:
+        source: The source Pydantic model instance
+        target_cls: The target model class to create
+        update: Optional dict of field values to add/override
+        exclude: Optional set of field names to exclude from copying
+
+    Returns:
+        A new instance of target_cls with copied fields
+    """
+    update = update or {}
+    exclude = exclude or set()
+
+    fields_set = source.__fields_set__.copy()
+    extras = {}
+    for key in source.__dict__:
+        if key not in source.__fields__:
+            extras[key] = source.__dict__[key]
+
+    values: Dict[str, Any] = {}
+    for field_name in source.__dict__:
+        if field_name not in exclude:
+            values[field_name] = source.__dict__[field_name]
+
+    for key in extras:
+        if key not in exclude:
+            values[key] = extras[key]
+
+    for key, value in update.items():
+        values[key] = value
+        fields_set.add(key)
+
+    for field_name in exclude:
+        fields_set.discard(field_name)
+
+    return pydantic.v1.BaseModel.construct.__func__(target_cls, fields_set, **values)  # type: ignore[attr-defined, return-value]

--- a/generators/python/core_utilities/shared/with_pydantic_v1_on_v2/with_aliases/pydantic_utilities.py
+++ b/generators/python/core_utilities/shared/with_pydantic_v1_on_v2/with_aliases/pydantic_utilities.py
@@ -209,4 +209,7 @@ def copy_and_update_model(
     for field_name in exclude:
         fields_set.discard(field_name)
 
-    return pydantic.v1.BaseModel.construct.__func__(target_cls, fields_set, **values)  # type: ignore[attr-defined, return-value]
+    return cast(
+        Model,
+        pydantic.v1.BaseModel.construct.__func__(target_cls, fields_set, **values),  # type: ignore[attr-defined]
+    )

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 4.47.0
+  changelogEntry:
+    - summary: |
+        Optimize discriminated union `factory` and `visit` methods to avoid expensive `.dict()` 
+        serialization/deserialization. The new implementation uses shallow field copying via 
+        `copy_and_update_model`, significantly reducing runtime overhead and memory usage for 
+        deep, tree-like API shapes.
+      type: feat
+  createdAt: "2025-12-18"
+  irVersion: 61
+
 - version: 4.46.4-rc2
   changelogEntry:
     - summary: |

--- a/generators/python/src/fern_python/generators/core_utilities/core_utilities.py
+++ b/generators/python/src/fern_python/generators/core_utilities/core_utilities.py
@@ -80,6 +80,7 @@ class CoreUtilities:
                 "universal_field_validator",
                 "update_forward_refs",
                 "UniversalRootModel",
+                "copy_and_update_model",
             }
             | (set() if is_v1_on_v2 else {"IS_PYDANTIC_V2"}),
         )
@@ -286,3 +287,12 @@ class CoreUtilities:
             return Pydantic(self._pydantic_compatibility).RootModel()
         else:  # V1 or V1_ON_V2
             return Pydantic(self._pydantic_compatibility).BaseModel()
+
+    def get_copy_and_update_model(self) -> AST.Reference:
+        return AST.Reference(
+            qualified_name_excluding_import=(),
+            import_=AST.ReferenceImport(
+                module=AST.Module.local(*self._module_path, "pydantic_utilities"),
+                named_import="copy_and_update_model",
+            ),
+        )

--- a/seed/python-sdk/unions/no-custom-config/.fern/metadata.json
+++ b/seed/python-sdk/unions/no-custom-config/.fern/metadata.json
@@ -1,5 +1,6 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-python-sdk",
-  "generatorVersion": "latest"
+  "generatorVersion": "latest",
+  "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/unions/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/unions/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -258,3 +258,62 @@ def _get_field_default(field: PydanticField) -> Any:
             return None
         return value
     return value
+
+
+def copy_and_update_model(
+    source: pydantic.BaseModel,
+    target_cls: Type[Model],
+    *,
+    update: Optional[Dict[str, Any]] = None,
+    exclude: Optional[Set[str]] = None,
+) -> Model:
+    """
+    Efficiently copy fields from a source model to a new instance of target_cls
+    without deep serialization (avoiding .dict() overhead).
+
+    This is useful for union type conversions where we need to:
+    - Add fields (e.g., discriminant field in factory methods)
+    - Remove fields (e.g., discriminant field in visit methods)
+
+    Args:
+        source: The source Pydantic model instance
+        target_cls: The target model class to create
+        update: Optional dict of field values to add/override
+        exclude: Optional set of field names to exclude from copying
+
+    Returns:
+        A new instance of target_cls with copied fields
+    """
+    update = update or {}
+    exclude = exclude or set()
+
+    if IS_PYDANTIC_V2:
+        fields_set = source.__pydantic_fields_set__.copy()  # type: ignore[attr-defined]
+        extras = getattr(source, "__pydantic_extra__", None) or {}
+    else:
+        fields_set = source.__fields_set__.copy()
+        extras = {}
+        for key in source.__dict__:
+            if key not in source.__fields__:
+                extras[key] = source.__dict__[key]
+
+    values: Dict[str, Any] = {}
+    for field_name in source.__dict__:
+        if field_name not in exclude:
+            values[field_name] = source.__dict__[field_name]
+
+    for key in extras:
+        if key not in exclude:
+            values[key] = extras[key]
+
+    for key, value in update.items():
+        values[key] = value
+        fields_set.add(key)
+
+    for field_name in exclude:
+        fields_set.discard(field_name)
+
+    if IS_PYDANTIC_V2:
+        return pydantic.BaseModel.model_construct.__func__(target_cls, fields_set, **values)  # type: ignore[attr-defined, return-value]
+    else:
+        return pydantic.BaseModel.construct.__func__(target_cls, fields_set, **values)  # type: ignore[attr-defined, return-value]

--- a/seed/python-sdk/unions/union-naming-v1/.fern/metadata.json
+++ b/seed/python-sdk/unions/union-naming-v1/.fern/metadata.json
@@ -7,5 +7,6 @@
       "union_naming": "v1"
     },
     "use_inheritance_for_extended_models": false
-  }
+  },
+  "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/unions/union-naming-v1/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/unions/union-naming-v1/src/seed/core/pydantic_utilities.py
@@ -258,3 +258,62 @@ def _get_field_default(field: PydanticField) -> Any:
             return None
         return value
     return value
+
+
+def copy_and_update_model(
+    source: pydantic.BaseModel,
+    target_cls: Type[Model],
+    *,
+    update: Optional[Dict[str, Any]] = None,
+    exclude: Optional[Set[str]] = None,
+) -> Model:
+    """
+    Efficiently copy fields from a source model to a new instance of target_cls
+    without deep serialization (avoiding .dict() overhead).
+
+    This is useful for union type conversions where we need to:
+    - Add fields (e.g., discriminant field in factory methods)
+    - Remove fields (e.g., discriminant field in visit methods)
+
+    Args:
+        source: The source Pydantic model instance
+        target_cls: The target model class to create
+        update: Optional dict of field values to add/override
+        exclude: Optional set of field names to exclude from copying
+
+    Returns:
+        A new instance of target_cls with copied fields
+    """
+    update = update or {}
+    exclude = exclude or set()
+
+    if IS_PYDANTIC_V2:
+        fields_set = source.__pydantic_fields_set__.copy()  # type: ignore[attr-defined]
+        extras = getattr(source, "__pydantic_extra__", None) or {}
+    else:
+        fields_set = source.__fields_set__.copy()
+        extras = {}
+        for key in source.__dict__:
+            if key not in source.__fields__:
+                extras[key] = source.__dict__[key]
+
+    values: Dict[str, Any] = {}
+    for field_name in source.__dict__:
+        if field_name not in exclude:
+            values[field_name] = source.__dict__[field_name]
+
+    for key in extras:
+        if key not in exclude:
+            values[key] = extras[key]
+
+    for key, value in update.items():
+        values[key] = value
+        fields_set.add(key)
+
+    for field_name in exclude:
+        fields_set.discard(field_name)
+
+    if IS_PYDANTIC_V2:
+        return pydantic.BaseModel.model_construct.__func__(target_cls, fields_set, **values)  # type: ignore[attr-defined, return-value]
+    else:
+        return pydantic.BaseModel.construct.__func__(target_cls, fields_set, **values)  # type: ignore[attr-defined, return-value]

--- a/seed/python-sdk/unions/union-utils/.fern/metadata.json
+++ b/seed/python-sdk/unions/union-utils/.fern/metadata.json
@@ -7,5 +7,6 @@
       "include_union_utils": true
     },
     "use_inheritance_for_extended_models": false
-  }
+  },
+  "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/unions/union-utils/src/seed/bigunion/types/big_union.py
+++ b/seed/python-sdk/unions/union-utils/src/seed/bigunion/types/big_union.py
@@ -6,7 +6,7 @@ import typing
 
 import pydantic
 import typing_extensions
-from ...core.pydantic_utilities import IS_PYDANTIC_V2, UniversalRootModel, update_forward_refs
+from ...core.pydantic_utilities import IS_PYDANTIC_V2, UniversalRootModel, copy_and_update_model, update_forward_refs
 from .active_diamond import ActiveDiamond as bigunion_types_active_diamond_ActiveDiamond
 from .attractive_script import AttractiveScript as bigunion_types_attractive_script_AttractiveScript
 from .circular_card import CircularCard as bigunion_types_circular_card_CircularCard
@@ -43,191 +43,253 @@ T_Result = typing.TypeVar("T_Result")
 class _Factory:
     def normal_sweet(self, value: bigunion_types_normal_sweet_NormalSweet) -> BigUnion:
         if IS_PYDANTIC_V2:
-            return BigUnion(root=_BigUnion.NormalSweet(**value.dict(exclude_unset=True), type="normalSweet"))  # type: ignore
+            return BigUnion(root=copy_and_update_model(value, _BigUnion.NormalSweet, update={"type": "normalSweet"}))  # type: ignore
         else:
-            return BigUnion(__root__=_BigUnion.NormalSweet(**value.dict(exclude_unset=True), type="normalSweet"))  # type: ignore
+            return BigUnion(
+                __root__=copy_and_update_model(value, _BigUnion.NormalSweet, update={"type": "normalSweet"})
+            )  # type: ignore
 
     def thankful_factor(self, value: bigunion_types_thankful_factor_ThankfulFactor) -> BigUnion:
         if IS_PYDANTIC_V2:
-            return BigUnion(root=_BigUnion.ThankfulFactor(**value.dict(exclude_unset=True), type="thankfulFactor"))  # type: ignore
+            return BigUnion(
+                root=copy_and_update_model(value, _BigUnion.ThankfulFactor, update={"type": "thankfulFactor"})
+            )  # type: ignore
         else:
-            return BigUnion(__root__=_BigUnion.ThankfulFactor(**value.dict(exclude_unset=True), type="thankfulFactor"))  # type: ignore
+            return BigUnion(
+                __root__=copy_and_update_model(value, _BigUnion.ThankfulFactor, update={"type": "thankfulFactor"})
+            )  # type: ignore
 
     def jumbo_end(self, value: bigunion_types_jumbo_end_JumboEnd) -> BigUnion:
         if IS_PYDANTIC_V2:
-            return BigUnion(root=_BigUnion.JumboEnd(**value.dict(exclude_unset=True), type="jumboEnd"))  # type: ignore
+            return BigUnion(root=copy_and_update_model(value, _BigUnion.JumboEnd, update={"type": "jumboEnd"}))  # type: ignore
         else:
-            return BigUnion(__root__=_BigUnion.JumboEnd(**value.dict(exclude_unset=True), type="jumboEnd"))  # type: ignore
+            return BigUnion(__root__=copy_and_update_model(value, _BigUnion.JumboEnd, update={"type": "jumboEnd"}))  # type: ignore
 
     def hasty_pain(self, value: bigunion_types_hasty_pain_HastyPain) -> BigUnion:
         if IS_PYDANTIC_V2:
-            return BigUnion(root=_BigUnion.HastyPain(**value.dict(exclude_unset=True), type="hastyPain"))  # type: ignore
+            return BigUnion(root=copy_and_update_model(value, _BigUnion.HastyPain, update={"type": "hastyPain"}))  # type: ignore
         else:
-            return BigUnion(__root__=_BigUnion.HastyPain(**value.dict(exclude_unset=True), type="hastyPain"))  # type: ignore
+            return BigUnion(__root__=copy_and_update_model(value, _BigUnion.HastyPain, update={"type": "hastyPain"}))  # type: ignore
 
     def misty_snow(self, value: bigunion_types_misty_snow_MistySnow) -> BigUnion:
         if IS_PYDANTIC_V2:
-            return BigUnion(root=_BigUnion.MistySnow(**value.dict(exclude_unset=True), type="mistySnow"))  # type: ignore
+            return BigUnion(root=copy_and_update_model(value, _BigUnion.MistySnow, update={"type": "mistySnow"}))  # type: ignore
         else:
-            return BigUnion(__root__=_BigUnion.MistySnow(**value.dict(exclude_unset=True), type="mistySnow"))  # type: ignore
+            return BigUnion(__root__=copy_and_update_model(value, _BigUnion.MistySnow, update={"type": "mistySnow"}))  # type: ignore
 
     def distinct_failure(self, value: bigunion_types_distinct_failure_DistinctFailure) -> BigUnion:
         if IS_PYDANTIC_V2:
-            return BigUnion(root=_BigUnion.DistinctFailure(**value.dict(exclude_unset=True), type="distinctFailure"))  # type: ignore
+            return BigUnion(
+                root=copy_and_update_model(value, _BigUnion.DistinctFailure, update={"type": "distinctFailure"})
+            )  # type: ignore
         else:
             return BigUnion(
-                __root__=_BigUnion.DistinctFailure(**value.dict(exclude_unset=True), type="distinctFailure")
+                __root__=copy_and_update_model(value, _BigUnion.DistinctFailure, update={"type": "distinctFailure"})
             )  # type: ignore
 
     def practical_principle(self, value: bigunion_types_practical_principle_PracticalPrinciple) -> BigUnion:
         if IS_PYDANTIC_V2:
             return BigUnion(
-                root=_BigUnion.PracticalPrinciple(**value.dict(exclude_unset=True), type="practicalPrinciple")
+                root=copy_and_update_model(value, _BigUnion.PracticalPrinciple, update={"type": "practicalPrinciple"})
             )  # type: ignore
         else:
             return BigUnion(
-                __root__=_BigUnion.PracticalPrinciple(**value.dict(exclude_unset=True), type="practicalPrinciple")
+                __root__=copy_and_update_model(
+                    value, _BigUnion.PracticalPrinciple, update={"type": "practicalPrinciple"}
+                )
             )  # type: ignore
 
     def limping_step(self, value: bigunion_types_limping_step_LimpingStep) -> BigUnion:
         if IS_PYDANTIC_V2:
-            return BigUnion(root=_BigUnion.LimpingStep(**value.dict(exclude_unset=True), type="limpingStep"))  # type: ignore
+            return BigUnion(root=copy_and_update_model(value, _BigUnion.LimpingStep, update={"type": "limpingStep"}))  # type: ignore
         else:
-            return BigUnion(__root__=_BigUnion.LimpingStep(**value.dict(exclude_unset=True), type="limpingStep"))  # type: ignore
+            return BigUnion(
+                __root__=copy_and_update_model(value, _BigUnion.LimpingStep, update={"type": "limpingStep"})
+            )  # type: ignore
 
     def vibrant_excitement(self, value: bigunion_types_vibrant_excitement_VibrantExcitement) -> BigUnion:
         if IS_PYDANTIC_V2:
             return BigUnion(
-                root=_BigUnion.VibrantExcitement(**value.dict(exclude_unset=True), type="vibrantExcitement")
+                root=copy_and_update_model(value, _BigUnion.VibrantExcitement, update={"type": "vibrantExcitement"})
             )  # type: ignore
         else:
             return BigUnion(
-                __root__=_BigUnion.VibrantExcitement(**value.dict(exclude_unset=True), type="vibrantExcitement")
+                __root__=copy_and_update_model(value, _BigUnion.VibrantExcitement, update={"type": "vibrantExcitement"})
             )  # type: ignore
 
     def active_diamond(self, value: bigunion_types_active_diamond_ActiveDiamond) -> BigUnion:
         if IS_PYDANTIC_V2:
-            return BigUnion(root=_BigUnion.ActiveDiamond(**value.dict(exclude_unset=True), type="activeDiamond"))  # type: ignore
+            return BigUnion(
+                root=copy_and_update_model(value, _BigUnion.ActiveDiamond, update={"type": "activeDiamond"})
+            )  # type: ignore
         else:
-            return BigUnion(__root__=_BigUnion.ActiveDiamond(**value.dict(exclude_unset=True), type="activeDiamond"))  # type: ignore
+            return BigUnion(
+                __root__=copy_and_update_model(value, _BigUnion.ActiveDiamond, update={"type": "activeDiamond"})
+            )  # type: ignore
 
     def popular_limit(self, value: bigunion_types_popular_limit_PopularLimit) -> BigUnion:
         if IS_PYDANTIC_V2:
-            return BigUnion(root=_BigUnion.PopularLimit(**value.dict(exclude_unset=True), type="popularLimit"))  # type: ignore
+            return BigUnion(root=copy_and_update_model(value, _BigUnion.PopularLimit, update={"type": "popularLimit"}))  # type: ignore
         else:
-            return BigUnion(__root__=_BigUnion.PopularLimit(**value.dict(exclude_unset=True), type="popularLimit"))  # type: ignore
+            return BigUnion(
+                __root__=copy_and_update_model(value, _BigUnion.PopularLimit, update={"type": "popularLimit"})
+            )  # type: ignore
 
     def false_mirror(self, value: bigunion_types_false_mirror_FalseMirror) -> BigUnion:
         if IS_PYDANTIC_V2:
-            return BigUnion(root=_BigUnion.FalseMirror(**value.dict(exclude_unset=True), type="falseMirror"))  # type: ignore
+            return BigUnion(root=copy_and_update_model(value, _BigUnion.FalseMirror, update={"type": "falseMirror"}))  # type: ignore
         else:
-            return BigUnion(__root__=_BigUnion.FalseMirror(**value.dict(exclude_unset=True), type="falseMirror"))  # type: ignore
+            return BigUnion(
+                __root__=copy_and_update_model(value, _BigUnion.FalseMirror, update={"type": "falseMirror"})
+            )  # type: ignore
 
     def primary_block(self, value: bigunion_types_primary_block_PrimaryBlock) -> BigUnion:
         if IS_PYDANTIC_V2:
-            return BigUnion(root=_BigUnion.PrimaryBlock(**value.dict(exclude_unset=True), type="primaryBlock"))  # type: ignore
+            return BigUnion(root=copy_and_update_model(value, _BigUnion.PrimaryBlock, update={"type": "primaryBlock"}))  # type: ignore
         else:
-            return BigUnion(__root__=_BigUnion.PrimaryBlock(**value.dict(exclude_unset=True), type="primaryBlock"))  # type: ignore
+            return BigUnion(
+                __root__=copy_and_update_model(value, _BigUnion.PrimaryBlock, update={"type": "primaryBlock"})
+            )  # type: ignore
 
     def rotating_ratio(self, value: bigunion_types_rotating_ratio_RotatingRatio) -> BigUnion:
         if IS_PYDANTIC_V2:
-            return BigUnion(root=_BigUnion.RotatingRatio(**value.dict(exclude_unset=True), type="rotatingRatio"))  # type: ignore
+            return BigUnion(
+                root=copy_and_update_model(value, _BigUnion.RotatingRatio, update={"type": "rotatingRatio"})
+            )  # type: ignore
         else:
-            return BigUnion(__root__=_BigUnion.RotatingRatio(**value.dict(exclude_unset=True), type="rotatingRatio"))  # type: ignore
+            return BigUnion(
+                __root__=copy_and_update_model(value, _BigUnion.RotatingRatio, update={"type": "rotatingRatio"})
+            )  # type: ignore
 
     def colorful_cover(self, value: bigunion_types_colorful_cover_ColorfulCover) -> BigUnion:
         if IS_PYDANTIC_V2:
-            return BigUnion(root=_BigUnion.ColorfulCover(**value.dict(exclude_unset=True), type="colorfulCover"))  # type: ignore
+            return BigUnion(
+                root=copy_and_update_model(value, _BigUnion.ColorfulCover, update={"type": "colorfulCover"})
+            )  # type: ignore
         else:
-            return BigUnion(__root__=_BigUnion.ColorfulCover(**value.dict(exclude_unset=True), type="colorfulCover"))  # type: ignore
+            return BigUnion(
+                __root__=copy_and_update_model(value, _BigUnion.ColorfulCover, update={"type": "colorfulCover"})
+            )  # type: ignore
 
     def disloyal_value(self, value: bigunion_types_disloyal_value_DisloyalValue) -> BigUnion:
         if IS_PYDANTIC_V2:
-            return BigUnion(root=_BigUnion.DisloyalValue(**value.dict(exclude_unset=True), type="disloyalValue"))  # type: ignore
+            return BigUnion(
+                root=copy_and_update_model(value, _BigUnion.DisloyalValue, update={"type": "disloyalValue"})
+            )  # type: ignore
         else:
-            return BigUnion(__root__=_BigUnion.DisloyalValue(**value.dict(exclude_unset=True), type="disloyalValue"))  # type: ignore
+            return BigUnion(
+                __root__=copy_and_update_model(value, _BigUnion.DisloyalValue, update={"type": "disloyalValue"})
+            )  # type: ignore
 
     def gruesome_coach(self, value: bigunion_types_gruesome_coach_GruesomeCoach) -> BigUnion:
         if IS_PYDANTIC_V2:
-            return BigUnion(root=_BigUnion.GruesomeCoach(**value.dict(exclude_unset=True), type="gruesomeCoach"))  # type: ignore
+            return BigUnion(
+                root=copy_and_update_model(value, _BigUnion.GruesomeCoach, update={"type": "gruesomeCoach"})
+            )  # type: ignore
         else:
-            return BigUnion(__root__=_BigUnion.GruesomeCoach(**value.dict(exclude_unset=True), type="gruesomeCoach"))  # type: ignore
+            return BigUnion(
+                __root__=copy_and_update_model(value, _BigUnion.GruesomeCoach, update={"type": "gruesomeCoach"})
+            )  # type: ignore
 
     def total_work(self, value: bigunion_types_total_work_TotalWork) -> BigUnion:
         if IS_PYDANTIC_V2:
-            return BigUnion(root=_BigUnion.TotalWork(**value.dict(exclude_unset=True), type="totalWork"))  # type: ignore
+            return BigUnion(root=copy_and_update_model(value, _BigUnion.TotalWork, update={"type": "totalWork"}))  # type: ignore
         else:
-            return BigUnion(__root__=_BigUnion.TotalWork(**value.dict(exclude_unset=True), type="totalWork"))  # type: ignore
+            return BigUnion(__root__=copy_and_update_model(value, _BigUnion.TotalWork, update={"type": "totalWork"}))  # type: ignore
 
     def harmonious_play(self, value: bigunion_types_harmonious_play_HarmoniousPlay) -> BigUnion:
         if IS_PYDANTIC_V2:
-            return BigUnion(root=_BigUnion.HarmoniousPlay(**value.dict(exclude_unset=True), type="harmoniousPlay"))  # type: ignore
+            return BigUnion(
+                root=copy_and_update_model(value, _BigUnion.HarmoniousPlay, update={"type": "harmoniousPlay"})
+            )  # type: ignore
         else:
-            return BigUnion(__root__=_BigUnion.HarmoniousPlay(**value.dict(exclude_unset=True), type="harmoniousPlay"))  # type: ignore
+            return BigUnion(
+                __root__=copy_and_update_model(value, _BigUnion.HarmoniousPlay, update={"type": "harmoniousPlay"})
+            )  # type: ignore
 
     def unique_stress(self, value: bigunion_types_unique_stress_UniqueStress) -> BigUnion:
         if IS_PYDANTIC_V2:
-            return BigUnion(root=_BigUnion.UniqueStress(**value.dict(exclude_unset=True), type="uniqueStress"))  # type: ignore
+            return BigUnion(root=copy_and_update_model(value, _BigUnion.UniqueStress, update={"type": "uniqueStress"}))  # type: ignore
         else:
-            return BigUnion(__root__=_BigUnion.UniqueStress(**value.dict(exclude_unset=True), type="uniqueStress"))  # type: ignore
+            return BigUnion(
+                __root__=copy_and_update_model(value, _BigUnion.UniqueStress, update={"type": "uniqueStress"})
+            )  # type: ignore
 
     def unwilling_smoke(self, value: bigunion_types_unwilling_smoke_UnwillingSmoke) -> BigUnion:
         if IS_PYDANTIC_V2:
-            return BigUnion(root=_BigUnion.UnwillingSmoke(**value.dict(exclude_unset=True), type="unwillingSmoke"))  # type: ignore
+            return BigUnion(
+                root=copy_and_update_model(value, _BigUnion.UnwillingSmoke, update={"type": "unwillingSmoke"})
+            )  # type: ignore
         else:
-            return BigUnion(__root__=_BigUnion.UnwillingSmoke(**value.dict(exclude_unset=True), type="unwillingSmoke"))  # type: ignore
+            return BigUnion(
+                __root__=copy_and_update_model(value, _BigUnion.UnwillingSmoke, update={"type": "unwillingSmoke"})
+            )  # type: ignore
 
     def frozen_sleep(self, value: bigunion_types_frozen_sleep_FrozenSleep) -> BigUnion:
         if IS_PYDANTIC_V2:
-            return BigUnion(root=_BigUnion.FrozenSleep(**value.dict(exclude_unset=True), type="frozenSleep"))  # type: ignore
+            return BigUnion(root=copy_and_update_model(value, _BigUnion.FrozenSleep, update={"type": "frozenSleep"}))  # type: ignore
         else:
-            return BigUnion(__root__=_BigUnion.FrozenSleep(**value.dict(exclude_unset=True), type="frozenSleep"))  # type: ignore
+            return BigUnion(
+                __root__=copy_and_update_model(value, _BigUnion.FrozenSleep, update={"type": "frozenSleep"})
+            )  # type: ignore
 
     def diligent_deal(self, value: bigunion_types_diligent_deal_DiligentDeal) -> BigUnion:
         if IS_PYDANTIC_V2:
-            return BigUnion(root=_BigUnion.DiligentDeal(**value.dict(exclude_unset=True), type="diligentDeal"))  # type: ignore
+            return BigUnion(root=copy_and_update_model(value, _BigUnion.DiligentDeal, update={"type": "diligentDeal"}))  # type: ignore
         else:
-            return BigUnion(__root__=_BigUnion.DiligentDeal(**value.dict(exclude_unset=True), type="diligentDeal"))  # type: ignore
+            return BigUnion(
+                __root__=copy_and_update_model(value, _BigUnion.DiligentDeal, update={"type": "diligentDeal"})
+            )  # type: ignore
 
     def attractive_script(self, value: bigunion_types_attractive_script_AttractiveScript) -> BigUnion:
         if IS_PYDANTIC_V2:
-            return BigUnion(root=_BigUnion.AttractiveScript(**value.dict(exclude_unset=True), type="attractiveScript"))  # type: ignore
+            return BigUnion(
+                root=copy_and_update_model(value, _BigUnion.AttractiveScript, update={"type": "attractiveScript"})
+            )  # type: ignore
         else:
             return BigUnion(
-                __root__=_BigUnion.AttractiveScript(**value.dict(exclude_unset=True), type="attractiveScript")
+                __root__=copy_and_update_model(value, _BigUnion.AttractiveScript, update={"type": "attractiveScript"})
             )  # type: ignore
 
     def hoarse_mouse(self, value: bigunion_types_hoarse_mouse_HoarseMouse) -> BigUnion:
         if IS_PYDANTIC_V2:
-            return BigUnion(root=_BigUnion.HoarseMouse(**value.dict(exclude_unset=True), type="hoarseMouse"))  # type: ignore
+            return BigUnion(root=copy_and_update_model(value, _BigUnion.HoarseMouse, update={"type": "hoarseMouse"}))  # type: ignore
         else:
-            return BigUnion(__root__=_BigUnion.HoarseMouse(**value.dict(exclude_unset=True), type="hoarseMouse"))  # type: ignore
+            return BigUnion(
+                __root__=copy_and_update_model(value, _BigUnion.HoarseMouse, update={"type": "hoarseMouse"})
+            )  # type: ignore
 
     def circular_card(self, value: bigunion_types_circular_card_CircularCard) -> BigUnion:
         if IS_PYDANTIC_V2:
-            return BigUnion(root=_BigUnion.CircularCard(**value.dict(exclude_unset=True), type="circularCard"))  # type: ignore
+            return BigUnion(root=copy_and_update_model(value, _BigUnion.CircularCard, update={"type": "circularCard"}))  # type: ignore
         else:
-            return BigUnion(__root__=_BigUnion.CircularCard(**value.dict(exclude_unset=True), type="circularCard"))  # type: ignore
+            return BigUnion(
+                __root__=copy_and_update_model(value, _BigUnion.CircularCard, update={"type": "circularCard"})
+            )  # type: ignore
 
     def potable_bad(self, value: bigunion_types_potable_bad_PotableBad) -> BigUnion:
         if IS_PYDANTIC_V2:
-            return BigUnion(root=_BigUnion.PotableBad(**value.dict(exclude_unset=True), type="potableBad"))  # type: ignore
+            return BigUnion(root=copy_and_update_model(value, _BigUnion.PotableBad, update={"type": "potableBad"}))  # type: ignore
         else:
-            return BigUnion(__root__=_BigUnion.PotableBad(**value.dict(exclude_unset=True), type="potableBad"))  # type: ignore
+            return BigUnion(__root__=copy_and_update_model(value, _BigUnion.PotableBad, update={"type": "potableBad"}))  # type: ignore
 
     def triangular_repair(self, value: bigunion_types_triangular_repair_TriangularRepair) -> BigUnion:
         if IS_PYDANTIC_V2:
-            return BigUnion(root=_BigUnion.TriangularRepair(**value.dict(exclude_unset=True), type="triangularRepair"))  # type: ignore
+            return BigUnion(
+                root=copy_and_update_model(value, _BigUnion.TriangularRepair, update={"type": "triangularRepair"})
+            )  # type: ignore
         else:
             return BigUnion(
-                __root__=_BigUnion.TriangularRepair(**value.dict(exclude_unset=True), type="triangularRepair")
+                __root__=copy_and_update_model(value, _BigUnion.TriangularRepair, update={"type": "triangularRepair"})
             )  # type: ignore
 
     def gaseous_road(self, value: bigunion_types_gaseous_road_GaseousRoad) -> BigUnion:
         if IS_PYDANTIC_V2:
-            return BigUnion(root=_BigUnion.GaseousRoad(**value.dict(exclude_unset=True), type="gaseousRoad"))  # type: ignore
+            return BigUnion(root=copy_and_update_model(value, _BigUnion.GaseousRoad, update={"type": "gaseousRoad"}))  # type: ignore
         else:
-            return BigUnion(__root__=_BigUnion.GaseousRoad(**value.dict(exclude_unset=True), type="gaseousRoad"))  # type: ignore
+            return BigUnion(
+                __root__=copy_and_update_model(value, _BigUnion.GaseousRoad, update={"type": "gaseousRoad"})
+            )  # type: ignore
 
 
 class BigUnion(UniversalRootModel):
@@ -425,135 +487,125 @@ class BigUnion(UniversalRootModel):
         unioned_value = self.get_as_union()
         if unioned_value.type == "normalSweet":
             return normal_sweet(
-                bigunion_types_normal_sweet_NormalSweet(**unioned_value.dict(exclude_unset=True, exclude={"type"}))
+                copy_and_update_model(unioned_value, bigunion_types_normal_sweet_NormalSweet, exclude={"type"})
             )
         if unioned_value.type == "thankfulFactor":
             return thankful_factor(
-                bigunion_types_thankful_factor_ThankfulFactor(
-                    **unioned_value.dict(exclude_unset=True, exclude={"type"})
-                )
+                copy_and_update_model(unioned_value, bigunion_types_thankful_factor_ThankfulFactor, exclude={"type"})
             )
         if unioned_value.type == "jumboEnd":
-            return jumbo_end(
-                bigunion_types_jumbo_end_JumboEnd(**unioned_value.dict(exclude_unset=True, exclude={"type"}))
-            )
+            return jumbo_end(copy_and_update_model(unioned_value, bigunion_types_jumbo_end_JumboEnd, exclude={"type"}))
         if unioned_value.type == "hastyPain":
             return hasty_pain(
-                bigunion_types_hasty_pain_HastyPain(**unioned_value.dict(exclude_unset=True, exclude={"type"}))
+                copy_and_update_model(unioned_value, bigunion_types_hasty_pain_HastyPain, exclude={"type"})
             )
         if unioned_value.type == "mistySnow":
             return misty_snow(
-                bigunion_types_misty_snow_MistySnow(**unioned_value.dict(exclude_unset=True, exclude={"type"}))
+                copy_and_update_model(unioned_value, bigunion_types_misty_snow_MistySnow, exclude={"type"})
             )
         if unioned_value.type == "distinctFailure":
             return distinct_failure(
-                bigunion_types_distinct_failure_DistinctFailure(
-                    **unioned_value.dict(exclude_unset=True, exclude={"type"})
-                )
+                copy_and_update_model(unioned_value, bigunion_types_distinct_failure_DistinctFailure, exclude={"type"})
             )
         if unioned_value.type == "practicalPrinciple":
             return practical_principle(
-                bigunion_types_practical_principle_PracticalPrinciple(
-                    **unioned_value.dict(exclude_unset=True, exclude={"type"})
+                copy_and_update_model(
+                    unioned_value, bigunion_types_practical_principle_PracticalPrinciple, exclude={"type"}
                 )
             )
         if unioned_value.type == "limpingStep":
             return limping_step(
-                bigunion_types_limping_step_LimpingStep(**unioned_value.dict(exclude_unset=True, exclude={"type"}))
+                copy_and_update_model(unioned_value, bigunion_types_limping_step_LimpingStep, exclude={"type"})
             )
         if unioned_value.type == "vibrantExcitement":
             return vibrant_excitement(
-                bigunion_types_vibrant_excitement_VibrantExcitement(
-                    **unioned_value.dict(exclude_unset=True, exclude={"type"})
+                copy_and_update_model(
+                    unioned_value, bigunion_types_vibrant_excitement_VibrantExcitement, exclude={"type"}
                 )
             )
         if unioned_value.type == "activeDiamond":
             return active_diamond(
-                bigunion_types_active_diamond_ActiveDiamond(**unioned_value.dict(exclude_unset=True, exclude={"type"}))
+                copy_and_update_model(unioned_value, bigunion_types_active_diamond_ActiveDiamond, exclude={"type"})
             )
         if unioned_value.type == "popularLimit":
             return popular_limit(
-                bigunion_types_popular_limit_PopularLimit(**unioned_value.dict(exclude_unset=True, exclude={"type"}))
+                copy_and_update_model(unioned_value, bigunion_types_popular_limit_PopularLimit, exclude={"type"})
             )
         if unioned_value.type == "falseMirror":
             return false_mirror(
-                bigunion_types_false_mirror_FalseMirror(**unioned_value.dict(exclude_unset=True, exclude={"type"}))
+                copy_and_update_model(unioned_value, bigunion_types_false_mirror_FalseMirror, exclude={"type"})
             )
         if unioned_value.type == "primaryBlock":
             return primary_block(
-                bigunion_types_primary_block_PrimaryBlock(**unioned_value.dict(exclude_unset=True, exclude={"type"}))
+                copy_and_update_model(unioned_value, bigunion_types_primary_block_PrimaryBlock, exclude={"type"})
             )
         if unioned_value.type == "rotatingRatio":
             return rotating_ratio(
-                bigunion_types_rotating_ratio_RotatingRatio(**unioned_value.dict(exclude_unset=True, exclude={"type"}))
+                copy_and_update_model(unioned_value, bigunion_types_rotating_ratio_RotatingRatio, exclude={"type"})
             )
         if unioned_value.type == "colorfulCover":
             return colorful_cover(
-                bigunion_types_colorful_cover_ColorfulCover(**unioned_value.dict(exclude_unset=True, exclude={"type"}))
+                copy_and_update_model(unioned_value, bigunion_types_colorful_cover_ColorfulCover, exclude={"type"})
             )
         if unioned_value.type == "disloyalValue":
             return disloyal_value(
-                bigunion_types_disloyal_value_DisloyalValue(**unioned_value.dict(exclude_unset=True, exclude={"type"}))
+                copy_and_update_model(unioned_value, bigunion_types_disloyal_value_DisloyalValue, exclude={"type"})
             )
         if unioned_value.type == "gruesomeCoach":
             return gruesome_coach(
-                bigunion_types_gruesome_coach_GruesomeCoach(**unioned_value.dict(exclude_unset=True, exclude={"type"}))
+                copy_and_update_model(unioned_value, bigunion_types_gruesome_coach_GruesomeCoach, exclude={"type"})
             )
         if unioned_value.type == "totalWork":
             return total_work(
-                bigunion_types_total_work_TotalWork(**unioned_value.dict(exclude_unset=True, exclude={"type"}))
+                copy_and_update_model(unioned_value, bigunion_types_total_work_TotalWork, exclude={"type"})
             )
         if unioned_value.type == "harmoniousPlay":
             return harmonious_play(
-                bigunion_types_harmonious_play_HarmoniousPlay(
-                    **unioned_value.dict(exclude_unset=True, exclude={"type"})
-                )
+                copy_and_update_model(unioned_value, bigunion_types_harmonious_play_HarmoniousPlay, exclude={"type"})
             )
         if unioned_value.type == "uniqueStress":
             return unique_stress(
-                bigunion_types_unique_stress_UniqueStress(**unioned_value.dict(exclude_unset=True, exclude={"type"}))
+                copy_and_update_model(unioned_value, bigunion_types_unique_stress_UniqueStress, exclude={"type"})
             )
         if unioned_value.type == "unwillingSmoke":
             return unwilling_smoke(
-                bigunion_types_unwilling_smoke_UnwillingSmoke(
-                    **unioned_value.dict(exclude_unset=True, exclude={"type"})
-                )
+                copy_and_update_model(unioned_value, bigunion_types_unwilling_smoke_UnwillingSmoke, exclude={"type"})
             )
         if unioned_value.type == "frozenSleep":
             return frozen_sleep(
-                bigunion_types_frozen_sleep_FrozenSleep(**unioned_value.dict(exclude_unset=True, exclude={"type"}))
+                copy_and_update_model(unioned_value, bigunion_types_frozen_sleep_FrozenSleep, exclude={"type"})
             )
         if unioned_value.type == "diligentDeal":
             return diligent_deal(
-                bigunion_types_diligent_deal_DiligentDeal(**unioned_value.dict(exclude_unset=True, exclude={"type"}))
+                copy_and_update_model(unioned_value, bigunion_types_diligent_deal_DiligentDeal, exclude={"type"})
             )
         if unioned_value.type == "attractiveScript":
             return attractive_script(
-                bigunion_types_attractive_script_AttractiveScript(
-                    **unioned_value.dict(exclude_unset=True, exclude={"type"})
+                copy_and_update_model(
+                    unioned_value, bigunion_types_attractive_script_AttractiveScript, exclude={"type"}
                 )
             )
         if unioned_value.type == "hoarseMouse":
             return hoarse_mouse(
-                bigunion_types_hoarse_mouse_HoarseMouse(**unioned_value.dict(exclude_unset=True, exclude={"type"}))
+                copy_and_update_model(unioned_value, bigunion_types_hoarse_mouse_HoarseMouse, exclude={"type"})
             )
         if unioned_value.type == "circularCard":
             return circular_card(
-                bigunion_types_circular_card_CircularCard(**unioned_value.dict(exclude_unset=True, exclude={"type"}))
+                copy_and_update_model(unioned_value, bigunion_types_circular_card_CircularCard, exclude={"type"})
             )
         if unioned_value.type == "potableBad":
             return potable_bad(
-                bigunion_types_potable_bad_PotableBad(**unioned_value.dict(exclude_unset=True, exclude={"type"}))
+                copy_and_update_model(unioned_value, bigunion_types_potable_bad_PotableBad, exclude={"type"})
             )
         if unioned_value.type == "triangularRepair":
             return triangular_repair(
-                bigunion_types_triangular_repair_TriangularRepair(
-                    **unioned_value.dict(exclude_unset=True, exclude={"type"})
+                copy_and_update_model(
+                    unioned_value, bigunion_types_triangular_repair_TriangularRepair, exclude={"type"}
                 )
             )
         if unioned_value.type == "gaseousRoad":
             return gaseous_road(
-                bigunion_types_gaseous_road_GaseousRoad(**unioned_value.dict(exclude_unset=True, exclude={"type"}))
+                copy_and_update_model(unioned_value, bigunion_types_gaseous_road_GaseousRoad, exclude={"type"})
             )
 
     if IS_PYDANTIC_V2:

--- a/seed/python-sdk/unions/union-utils/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/unions/union-utils/src/seed/core/pydantic_utilities.py
@@ -258,3 +258,62 @@ def _get_field_default(field: PydanticField) -> Any:
             return None
         return value
     return value
+
+
+def copy_and_update_model(
+    source: pydantic.BaseModel,
+    target_cls: Type[Model],
+    *,
+    update: Optional[Dict[str, Any]] = None,
+    exclude: Optional[Set[str]] = None,
+) -> Model:
+    """
+    Efficiently copy fields from a source model to a new instance of target_cls
+    without deep serialization (avoiding .dict() overhead).
+
+    This is useful for union type conversions where we need to:
+    - Add fields (e.g., discriminant field in factory methods)
+    - Remove fields (e.g., discriminant field in visit methods)
+
+    Args:
+        source: The source Pydantic model instance
+        target_cls: The target model class to create
+        update: Optional dict of field values to add/override
+        exclude: Optional set of field names to exclude from copying
+
+    Returns:
+        A new instance of target_cls with copied fields
+    """
+    update = update or {}
+    exclude = exclude or set()
+
+    if IS_PYDANTIC_V2:
+        fields_set = source.__pydantic_fields_set__.copy()  # type: ignore[attr-defined]
+        extras = getattr(source, "__pydantic_extra__", None) or {}
+    else:
+        fields_set = source.__fields_set__.copy()
+        extras = {}
+        for key in source.__dict__:
+            if key not in source.__fields__:
+                extras[key] = source.__dict__[key]
+
+    values: Dict[str, Any] = {}
+    for field_name in source.__dict__:
+        if field_name not in exclude:
+            values[field_name] = source.__dict__[field_name]
+
+    for key in extras:
+        if key not in exclude:
+            values[key] = extras[key]
+
+    for key, value in update.items():
+        values[key] = value
+        fields_set.add(key)
+
+    for field_name in exclude:
+        fields_set.discard(field_name)
+
+    if IS_PYDANTIC_V2:
+        return pydantic.BaseModel.model_construct.__func__(target_cls, fields_set, **values)  # type: ignore[attr-defined, return-value]
+    else:
+        return pydantic.BaseModel.construct.__func__(target_cls, fields_set, **values)  # type: ignore[attr-defined, return-value]

--- a/seed/python-sdk/unions/union-utils/src/seed/types/types/union_with_base_properties.py
+++ b/seed/python-sdk/unions/union-utils/src/seed/types/types/union_with_base_properties.py
@@ -6,7 +6,13 @@ import typing
 
 import pydantic
 import typing_extensions
-from ...core.pydantic_utilities import IS_PYDANTIC_V2, UniversalBaseModel, UniversalRootModel, update_forward_refs
+from ...core.pydantic_utilities import (
+    IS_PYDANTIC_V2,
+    UniversalBaseModel,
+    UniversalRootModel,
+    copy_and_update_model,
+    update_forward_refs,
+)
 from .foo import Foo as types_types_foo_Foo
 
 T_Result = typing.TypeVar("T_Result")
@@ -28,11 +34,11 @@ class _Factory:
     def foo(self, value: types_types_foo_Foo) -> UnionWithBaseProperties:
         if IS_PYDANTIC_V2:
             return UnionWithBaseProperties(
-                root=_UnionWithBaseProperties.Foo(**value.dict(exclude_unset=True), type="foo")
+                root=copy_and_update_model(value, _UnionWithBaseProperties.Foo, update={"type": "foo"})
             )  # type: ignore
         else:
             return UnionWithBaseProperties(
-                __root__=_UnionWithBaseProperties.Foo(**value.dict(exclude_unset=True), type="foo")
+                __root__=copy_and_update_model(value, _UnionWithBaseProperties.Foo, update={"type": "foo"})
             )  # type: ignore
 
 
@@ -94,7 +100,7 @@ class UnionWithBaseProperties(UniversalRootModel):
         if unioned_value.type == "string":
             return string(unioned_value.value)
         if unioned_value.type == "foo":
-            return foo(types_types_foo_Foo(**unioned_value.dict(exclude_unset=True, exclude={"type"})))
+            return foo(copy_and_update_model(unioned_value, types_types_foo_Foo, exclude={"type"}))
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/unions/union-utils/src/seed/types/types/union_with_duplicate_types.py
+++ b/seed/python-sdk/unions/union-utils/src/seed/types/types/union_with_duplicate_types.py
@@ -6,7 +6,7 @@ import typing
 
 import pydantic
 import typing_extensions
-from ...core.pydantic_utilities import IS_PYDANTIC_V2, UniversalRootModel, update_forward_refs
+from ...core.pydantic_utilities import IS_PYDANTIC_V2, UniversalRootModel, copy_and_update_model, update_forward_refs
 from .foo import Foo
 
 T_Result = typing.TypeVar("T_Result")
@@ -16,21 +16,21 @@ class _Factory:
     def foo_1(self, value: Foo) -> UnionWithDuplicateTypes:
         if IS_PYDANTIC_V2:
             return UnionWithDuplicateTypes(
-                root=_UnionWithDuplicateTypes.Foo1(**value.dict(exclude_unset=True), type="foo1")
+                root=copy_and_update_model(value, _UnionWithDuplicateTypes.Foo1, update={"type": "foo1"})
             )  # type: ignore
         else:
             return UnionWithDuplicateTypes(
-                __root__=_UnionWithDuplicateTypes.Foo1(**value.dict(exclude_unset=True), type="foo1")
+                __root__=copy_and_update_model(value, _UnionWithDuplicateTypes.Foo1, update={"type": "foo1"})
             )  # type: ignore
 
     def foo_2(self, value: Foo) -> UnionWithDuplicateTypes:
         if IS_PYDANTIC_V2:
             return UnionWithDuplicateTypes(
-                root=_UnionWithDuplicateTypes.Foo2(**value.dict(exclude_unset=True), type="foo2")
+                root=copy_and_update_model(value, _UnionWithDuplicateTypes.Foo2, update={"type": "foo2"})
             )  # type: ignore
         else:
             return UnionWithDuplicateTypes(
-                __root__=_UnionWithDuplicateTypes.Foo2(**value.dict(exclude_unset=True), type="foo2")
+                __root__=copy_and_update_model(value, _UnionWithDuplicateTypes.Foo2, update={"type": "foo2"})
             )  # type: ignore
 
 
@@ -73,9 +73,9 @@ class UnionWithDuplicateTypes(UniversalRootModel):
     def visit(self, foo_1: typing.Callable[[Foo], T_Result], foo_2: typing.Callable[[Foo], T_Result]) -> T_Result:
         unioned_value = self.get_as_union()
         if unioned_value.type == "foo1":
-            return foo_1(Foo(**unioned_value.dict(exclude_unset=True, exclude={"type"})))
+            return foo_1(copy_and_update_model(unioned_value, Foo, exclude={"type"}))
         if unioned_value.type == "foo2":
-            return foo_2(Foo(**unioned_value.dict(exclude_unset=True, exclude={"type"})))
+            return foo_2(copy_and_update_model(unioned_value, Foo, exclude={"type"}))
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/unions/union-utils/src/seed/types/types/union_with_duplicative_discriminants.py
+++ b/seed/python-sdk/unions/union-utils/src/seed/types/types/union_with_duplicative_discriminants.py
@@ -6,7 +6,7 @@ import typing
 
 import pydantic
 import typing_extensions
-from ...core.pydantic_utilities import IS_PYDANTIC_V2, UniversalRootModel, update_forward_refs
+from ...core.pydantic_utilities import IS_PYDANTIC_V2, UniversalRootModel, copy_and_update_model, update_forward_refs
 from .first_item_type import FirstItemType as types_types_first_item_type_FirstItemType
 from .second_item_type import SecondItemType as types_types_second_item_type_SecondItemType
 
@@ -17,28 +17,28 @@ class _Factory:
     def first_item_type(self, value: types_types_first_item_type_FirstItemType) -> UnionWithDuplicativeDiscriminants:
         if IS_PYDANTIC_V2:
             return UnionWithDuplicativeDiscriminants(
-                root=_UnionWithDuplicativeDiscriminants.FirstItemType(
-                    **value.dict(exclude_unset=True), type="firstItemType"
+                root=copy_and_update_model(
+                    value, _UnionWithDuplicativeDiscriminants.FirstItemType, update={"type": "firstItemType"}
                 )
             )  # type: ignore
         else:
             return UnionWithDuplicativeDiscriminants(
-                __root__=_UnionWithDuplicativeDiscriminants.FirstItemType(
-                    **value.dict(exclude_unset=True), type="firstItemType"
+                __root__=copy_and_update_model(
+                    value, _UnionWithDuplicativeDiscriminants.FirstItemType, update={"type": "firstItemType"}
                 )
             )  # type: ignore
 
     def second_item_type(self, value: types_types_second_item_type_SecondItemType) -> UnionWithDuplicativeDiscriminants:
         if IS_PYDANTIC_V2:
             return UnionWithDuplicativeDiscriminants(
-                root=_UnionWithDuplicativeDiscriminants.SecondItemType(
-                    **value.dict(exclude_unset=True), type="secondItemType"
+                root=copy_and_update_model(
+                    value, _UnionWithDuplicativeDiscriminants.SecondItemType, update={"type": "secondItemType"}
                 )
             )  # type: ignore
         else:
             return UnionWithDuplicativeDiscriminants(
-                __root__=_UnionWithDuplicativeDiscriminants.SecondItemType(
-                    **value.dict(exclude_unset=True), type="secondItemType"
+                __root__=copy_and_update_model(
+                    value, _UnionWithDuplicativeDiscriminants.SecondItemType, update={"type": "secondItemType"}
                 )
             )  # type: ignore
 
@@ -89,11 +89,11 @@ class UnionWithDuplicativeDiscriminants(UniversalRootModel):
         unioned_value = self.get_as_union()
         if unioned_value.type == "firstItemType":
             return first_item_type(
-                types_types_first_item_type_FirstItemType(**unioned_value.dict(exclude_unset=True, exclude={"type"}))
+                copy_and_update_model(unioned_value, types_types_first_item_type_FirstItemType, exclude={"type"})
             )
         if unioned_value.type == "secondItemType":
             return second_item_type(
-                types_types_second_item_type_SecondItemType(**unioned_value.dict(exclude_unset=True, exclude={"type"}))
+                copy_and_update_model(unioned_value, types_types_second_item_type_SecondItemType, exclude={"type"})
             )
 
     if IS_PYDANTIC_V2:

--- a/seed/python-sdk/unions/union-utils/src/seed/types/types/union_with_multiple_no_properties.py
+++ b/seed/python-sdk/unions/union-utils/src/seed/types/types/union_with_multiple_no_properties.py
@@ -6,7 +6,13 @@ import typing
 
 import pydantic
 import typing_extensions
-from ...core.pydantic_utilities import IS_PYDANTIC_V2, UniversalBaseModel, UniversalRootModel, update_forward_refs
+from ...core.pydantic_utilities import (
+    IS_PYDANTIC_V2,
+    UniversalBaseModel,
+    UniversalRootModel,
+    copy_and_update_model,
+    update_forward_refs,
+)
 from .foo import Foo as types_types_foo_Foo
 
 T_Result = typing.TypeVar("T_Result")
@@ -16,11 +22,11 @@ class _Factory:
     def foo(self, value: types_types_foo_Foo) -> UnionWithMultipleNoProperties:
         if IS_PYDANTIC_V2:
             return UnionWithMultipleNoProperties(
-                root=_UnionWithMultipleNoProperties.Foo(**value.dict(exclude_unset=True), type="foo")
+                root=copy_and_update_model(value, _UnionWithMultipleNoProperties.Foo, update={"type": "foo"})
             )  # type: ignore
         else:
             return UnionWithMultipleNoProperties(
-                __root__=_UnionWithMultipleNoProperties.Foo(**value.dict(exclude_unset=True), type="foo")
+                __root__=copy_and_update_model(value, _UnionWithMultipleNoProperties.Foo, update={"type": "foo"})
             )  # type: ignore
 
     def empty_1(self) -> UnionWithMultipleNoProperties:
@@ -100,7 +106,7 @@ class UnionWithMultipleNoProperties(UniversalRootModel):
     ) -> T_Result:
         unioned_value = self.get_as_union()
         if unioned_value.type == "foo":
-            return foo(types_types_foo_Foo(**unioned_value.dict(exclude_unset=True, exclude={"type"})))
+            return foo(copy_and_update_model(unioned_value, types_types_foo_Foo, exclude={"type"}))
         if unioned_value.type == "empty1":
             return empty_1()
         if unioned_value.type == "empty2":

--- a/seed/python-sdk/unions/union-utils/src/seed/types/types/union_with_no_properties.py
+++ b/seed/python-sdk/unions/union-utils/src/seed/types/types/union_with_no_properties.py
@@ -6,7 +6,13 @@ import typing
 
 import pydantic
 import typing_extensions
-from ...core.pydantic_utilities import IS_PYDANTIC_V2, UniversalBaseModel, UniversalRootModel, update_forward_refs
+from ...core.pydantic_utilities import (
+    IS_PYDANTIC_V2,
+    UniversalBaseModel,
+    UniversalRootModel,
+    copy_and_update_model,
+    update_forward_refs,
+)
 from .foo import Foo as types_types_foo_Foo
 
 T_Result = typing.TypeVar("T_Result")
@@ -15,10 +21,12 @@ T_Result = typing.TypeVar("T_Result")
 class _Factory:
     def foo(self, value: types_types_foo_Foo) -> UnionWithNoProperties:
         if IS_PYDANTIC_V2:
-            return UnionWithNoProperties(root=_UnionWithNoProperties.Foo(**value.dict(exclude_unset=True), type="foo"))  # type: ignore
+            return UnionWithNoProperties(
+                root=copy_and_update_model(value, _UnionWithNoProperties.Foo, update={"type": "foo"})
+            )  # type: ignore
         else:
             return UnionWithNoProperties(
-                __root__=_UnionWithNoProperties.Foo(**value.dict(exclude_unset=True), type="foo")
+                __root__=copy_and_update_model(value, _UnionWithNoProperties.Foo, update={"type": "foo"})
             )  # type: ignore
 
     def empty(self) -> UnionWithNoProperties:
@@ -67,7 +75,7 @@ class UnionWithNoProperties(UniversalRootModel):
     ) -> T_Result:
         unioned_value = self.get_as_union()
         if unioned_value.type == "foo":
-            return foo(types_types_foo_Foo(**unioned_value.dict(exclude_unset=True, exclude={"type"})))
+            return foo(copy_and_update_model(unioned_value, types_types_foo_Foo, exclude={"type"}))
         if unioned_value.type == "empty":
             return empty()
 

--- a/seed/python-sdk/unions/union-utils/src/seed/types/types/union_with_single_element.py
+++ b/seed/python-sdk/unions/union-utils/src/seed/types/types/union_with_single_element.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import typing
 
 import pydantic
-from ...core.pydantic_utilities import IS_PYDANTIC_V2, UniversalRootModel, update_forward_refs
+from ...core.pydantic_utilities import IS_PYDANTIC_V2, UniversalRootModel, copy_and_update_model, update_forward_refs
 from .foo import Foo as types_types_foo_Foo
 
 T_Result = typing.TypeVar("T_Result")
@@ -15,11 +15,11 @@ class _Factory:
     def foo(self, value: types_types_foo_Foo) -> UnionWithSingleElement:
         if IS_PYDANTIC_V2:
             return UnionWithSingleElement(
-                root=_UnionWithSingleElement.Foo(**value.dict(exclude_unset=True), type="foo")
+                root=copy_and_update_model(value, _UnionWithSingleElement.Foo, update={"type": "foo"})
             )  # type: ignore
         else:
             return UnionWithSingleElement(
-                __root__=_UnionWithSingleElement.Foo(**value.dict(exclude_unset=True), type="foo")
+                __root__=copy_and_update_model(value, _UnionWithSingleElement.Foo, update={"type": "foo"})
             )  # type: ignore
 
 
@@ -56,7 +56,7 @@ class UnionWithSingleElement(UniversalRootModel):
     def visit(self, foo: typing.Callable[[types_types_foo_Foo], T_Result]) -> T_Result:
         unioned_value = self.get_as_union()
         if unioned_value.type == "foo":
-            return foo(types_types_foo_Foo(**unioned_value.dict(exclude_unset=True, exclude={"type"})))
+            return foo(copy_and_update_model(unioned_value, types_types_foo_Foo, exclude={"type"}))
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/unions/union-utils/src/seed/types/types/union_with_sub_types.py
+++ b/seed/python-sdk/unions/union-utils/src/seed/types/types/union_with_sub_types.py
@@ -6,7 +6,7 @@ import typing
 
 import pydantic
 import typing_extensions
-from ...core.pydantic_utilities import IS_PYDANTIC_V2, UniversalRootModel, update_forward_refs
+from ...core.pydantic_utilities import IS_PYDANTIC_V2, UniversalRootModel, copy_and_update_model, update_forward_refs
 from .foo import Foo as types_types_foo_Foo
 from .foo_extended import FooExtended as types_types_foo_extended_FooExtended
 
@@ -16,18 +16,20 @@ T_Result = typing.TypeVar("T_Result")
 class _Factory:
     def foo(self, value: types_types_foo_Foo) -> UnionWithSubTypes:
         if IS_PYDANTIC_V2:
-            return UnionWithSubTypes(root=_UnionWithSubTypes.Foo(**value.dict(exclude_unset=True), type="foo"))  # type: ignore
+            return UnionWithSubTypes(root=copy_and_update_model(value, _UnionWithSubTypes.Foo, update={"type": "foo"}))  # type: ignore
         else:
-            return UnionWithSubTypes(__root__=_UnionWithSubTypes.Foo(**value.dict(exclude_unset=True), type="foo"))  # type: ignore
+            return UnionWithSubTypes(
+                __root__=copy_and_update_model(value, _UnionWithSubTypes.Foo, update={"type": "foo"})
+            )  # type: ignore
 
     def foo_extended(self, value: types_types_foo_extended_FooExtended) -> UnionWithSubTypes:
         if IS_PYDANTIC_V2:
             return UnionWithSubTypes(
-                root=_UnionWithSubTypes.FooExtended(**value.dict(exclude_unset=True), type="fooExtended")
+                root=copy_and_update_model(value, _UnionWithSubTypes.FooExtended, update={"type": "fooExtended"})
             )  # type: ignore
         else:
             return UnionWithSubTypes(
-                __root__=_UnionWithSubTypes.FooExtended(**value.dict(exclude_unset=True), type="fooExtended")
+                __root__=copy_and_update_model(value, _UnionWithSubTypes.FooExtended, update={"type": "fooExtended"})
             )  # type: ignore
 
 
@@ -72,10 +74,10 @@ class UnionWithSubTypes(UniversalRootModel):
     ) -> T_Result:
         unioned_value = self.get_as_union()
         if unioned_value.type == "foo":
-            return foo(types_types_foo_Foo(**unioned_value.dict(exclude_unset=True, exclude={"type"})))
+            return foo(copy_and_update_model(unioned_value, types_types_foo_Foo, exclude={"type"}))
         if unioned_value.type == "fooExtended":
             return foo_extended(
-                types_types_foo_extended_FooExtended(**unioned_value.dict(exclude_unset=True, exclude={"type"}))
+                copy_and_update_model(unioned_value, types_types_foo_extended_FooExtended, exclude={"type"})
             )
 
     if IS_PYDANTIC_V2:

--- a/seed/python-sdk/unions/union-utils/src/seed/types/types/union_without_key.py
+++ b/seed/python-sdk/unions/union-utils/src/seed/types/types/union_without_key.py
@@ -6,7 +6,7 @@ import typing
 
 import pydantic
 import typing_extensions
-from ...core.pydantic_utilities import IS_PYDANTIC_V2, UniversalRootModel, update_forward_refs
+from ...core.pydantic_utilities import IS_PYDANTIC_V2, UniversalRootModel, copy_and_update_model, update_forward_refs
 from .bar import Bar as types_types_bar_Bar
 from .foo import Foo as types_types_foo_Foo
 
@@ -16,15 +16,15 @@ T_Result = typing.TypeVar("T_Result")
 class _Factory:
     def foo(self, value: types_types_foo_Foo) -> UnionWithoutKey:
         if IS_PYDANTIC_V2:
-            return UnionWithoutKey(root=_UnionWithoutKey.Foo(**value.dict(exclude_unset=True), type="foo"))  # type: ignore
+            return UnionWithoutKey(root=copy_and_update_model(value, _UnionWithoutKey.Foo, update={"type": "foo"}))  # type: ignore
         else:
-            return UnionWithoutKey(__root__=_UnionWithoutKey.Foo(**value.dict(exclude_unset=True), type="foo"))  # type: ignore
+            return UnionWithoutKey(__root__=copy_and_update_model(value, _UnionWithoutKey.Foo, update={"type": "foo"}))  # type: ignore
 
     def bar(self, value: types_types_bar_Bar) -> UnionWithoutKey:
         if IS_PYDANTIC_V2:
-            return UnionWithoutKey(root=_UnionWithoutKey.Bar(**value.dict(exclude_unset=True), type="bar"))  # type: ignore
+            return UnionWithoutKey(root=copy_and_update_model(value, _UnionWithoutKey.Bar, update={"type": "bar"}))  # type: ignore
         else:
-            return UnionWithoutKey(__root__=_UnionWithoutKey.Bar(**value.dict(exclude_unset=True), type="bar"))  # type: ignore
+            return UnionWithoutKey(__root__=copy_and_update_model(value, _UnionWithoutKey.Bar, update={"type": "bar"}))  # type: ignore
 
 
 class UnionWithoutKey(UniversalRootModel):
@@ -68,9 +68,9 @@ class UnionWithoutKey(UniversalRootModel):
     ) -> T_Result:
         unioned_value = self.get_as_union()
         if unioned_value.type == "foo":
-            return foo(types_types_foo_Foo(**unioned_value.dict(exclude_unset=True, exclude={"type"})))
+            return foo(copy_and_update_model(unioned_value, types_types_foo_Foo, exclude={"type"}))
         if unioned_value.type == "bar":
-            return bar(types_types_bar_Bar(**unioned_value.dict(exclude_unset=True, exclude={"type"})))
+            return bar(copy_and_update_model(unioned_value, types_types_bar_Bar, exclude={"type"}))
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/unions/union-utils/src/seed/union/types/shape.py
+++ b/seed/python-sdk/unions/union-utils/src/seed/union/types/shape.py
@@ -6,7 +6,7 @@ import typing
 
 import pydantic
 import typing_extensions
-from ...core.pydantic_utilities import IS_PYDANTIC_V2, UniversalRootModel, update_forward_refs
+from ...core.pydantic_utilities import IS_PYDANTIC_V2, UniversalRootModel, copy_and_update_model, update_forward_refs
 from .circle import Circle as union_types_circle_Circle
 from .square import Square as union_types_square_Square
 
@@ -16,15 +16,15 @@ T_Result = typing.TypeVar("T_Result")
 class _Factory:
     def circle(self, value: union_types_circle_Circle) -> Shape:
         if IS_PYDANTIC_V2:
-            return Shape(root=_Shape.Circle(**value.dict(exclude_unset=True), type="circle"))  # type: ignore
+            return Shape(root=copy_and_update_model(value, _Shape.Circle, update={"type": "circle"}))  # type: ignore
         else:
-            return Shape(__root__=_Shape.Circle(**value.dict(exclude_unset=True), type="circle"))  # type: ignore
+            return Shape(__root__=copy_and_update_model(value, _Shape.Circle, update={"type": "circle"}))  # type: ignore
 
     def square(self, value: union_types_square_Square) -> Shape:
         if IS_PYDANTIC_V2:
-            return Shape(root=_Shape.Square(**value.dict(exclude_unset=True), type="square"))  # type: ignore
+            return Shape(root=copy_and_update_model(value, _Shape.Square, update={"type": "square"}))  # type: ignore
         else:
-            return Shape(__root__=_Shape.Square(**value.dict(exclude_unset=True), type="square"))  # type: ignore
+            return Shape(__root__=copy_and_update_model(value, _Shape.Square, update={"type": "square"}))  # type: ignore
 
 
 class Shape(UniversalRootModel):
@@ -68,9 +68,9 @@ class Shape(UniversalRootModel):
     ) -> T_Result:
         unioned_value = self.get_as_union()
         if unioned_value.type == "circle":
-            return circle(union_types_circle_Circle(**unioned_value.dict(exclude_unset=True, exclude={"type"})))
+            return circle(copy_and_update_model(unioned_value, union_types_circle_Circle, exclude={"type"}))
         if unioned_value.type == "square":
-            return square(union_types_square_Square(**unioned_value.dict(exclude_unset=True, exclude={"type"})))
+            return square(copy_and_update_model(unioned_value, union_types_square_Square, exclude={"type"}))
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(frozen=True)  # type: ignore # Pydantic v2


### PR DESCRIPTION
## Description

Refs customer feedback about performance bottlenecks in discriminated union `factory` and `visit` methods.

Link to Devin run: https://app.devin.ai/sessions/ac18896281bc4c41a46e21d637ce328f
Requested by: thomas@buildwithfern.com (@tjb9dc)

## Changes Made

This PR optimizes the `factory` and `visit` methods for discriminated unions to avoid expensive `.dict()` serialization/deserialization. Previously, these methods would:
1. Call `.dict(exclude_unset=True)` on the source model (deep serialization)
2. Spread the dict into a new model constructor (re-validation)

The new implementation uses shallow field copying via `copy_and_update_model`, which:
- Directly copies field values from `source.__dict__`
- Preserves `fields_set` / `__pydantic_fields_set__` for `exclude_unset` semantics
- Handles extra fields (fields not in schema)
- Uses `construct`/`model_construct` to bypass validation (matching original behavior)

**Files changed:**
- Added `copy_and_update_model` utility to all 4 pydantic utility variants
- Updated `discriminated_union_with_utils_generator.py` to emit optimized code
- Added export and getter in `core_utilities.py`
- Updated seed test outputs for `unions` fixture

## Updates since last revision

- Fixed mypy `no-any-return` errors by wrapping return values with `typing.cast(Model, ...)` in all 4 pydantic utility variants

## Human Review Checklist

- [ ] Verify `copy_and_update_model` correctly handles `fields_set` tracking (lines 288-323 in `pydantic_utilities.py`)
- [ ] Verify Pydantic v1 vs v2 code paths are correct (the v1_on_v2 variants use `pydantic.v1.BaseModel`)
- [ ] Check the generator changes in `discriminated_union_with_utils_generator.py` - especially the `make_visitor_argument_for_same_properties` function and `write_copy_and_update` closure
- [ ] Review generated code in seed tests (e.g., `union_with_base_properties.py`) to confirm the optimization is applied correctly
- [ ] **Note:** The diff includes unrelated `_build_url` test additions in `test_http_client.py` - these appear to be from a merge/rebase and may need to be reviewed separately

## Testing

- [x] Seed tests pass for `unions` fixture (all 3 configurations: `no-custom-config`, `union-utils`, `union-naming-v1`)
- [x] Lint checks pass (`pnpm run check`)
- [x] Mypy type checking passes
- [ ] May want to run additional seed tests for other fixtures with discriminated unions