### PR TITLE
chore(cli): add auth scheme example selection test fixture

### DIFF
--- a/packages/cli/register/src/ir-to-fdr-converter/__test__/__snapshots__/auth-scheme-example-selection-fdr.snap
+++ b/packages/cli/register/src/ir-to-fdr-converter/__test__/__snapshots__/auth-scheme-example-selection-fdr.snap
@@ -1,0 +1,352 @@
+{
+  "auth": {
+    "description": "User authentication token",
+    "headerWireValue": "x-user-token",
+    "nameOverride": "apiKey",
+    "prefix": undefined,
+    "type": "header",
+  },
+  "authSchemes": {
+    "admin": {
+      "description": "Admin API key",
+      "headerWireValue": "Authorization",
+      "nameOverride": "apiKey",
+      "prefix": undefined,
+      "type": "header",
+    },
+    "operator": {
+      "description": "Operator API key",
+      "headerWireValue": "Authorization",
+      "nameOverride": "apiKey",
+      "prefix": undefined,
+      "type": "header",
+    },
+    "user": {
+      "description": "User authentication token",
+      "headerWireValue": "x-user-token",
+      "nameOverride": "apiKey",
+      "prefix": undefined,
+      "type": "header",
+    },
+  },
+  "globalHeaders": [],
+  "navigation": undefined,
+  "rootPackage": {
+    "endpoints": [
+      {
+        "auth": true,
+        "authV2": [
+          "admin",
+          "operator",
+        ],
+        "availability": undefined,
+        "defaultEnvironment": "https://api.example.com/v1",
+        "description": "This endpoint accepts either admin auth OR operator auth.
+Examples should use the first available auth scheme (admin).
+",
+        "environments": [
+          {
+            "baseUrl": "https://api.example.com/v1",
+            "id": "https://api.example.com/v1",
+          },
+        ],
+        "errors": undefined,
+        "errorsV2": [],
+        "examples": [
+          {
+            "codeSamples": undefined,
+            "description": "",
+            "headers": {},
+            "name": undefined,
+            "path": "/resource",
+            "pathParameters": {},
+            "queryParameters": {},
+            "requestBody": {
+              "amount": {
+                "value": 1.1,
+              },
+              "target": "string",
+              "type": "typeA",
+            },
+            "requestBodyV3": {
+              "type": "json",
+              "value": {
+                "amount": {
+                  "value": 1.1,
+                },
+                "target": "string",
+                "type": "typeA",
+              },
+            },
+            "responseBody": {
+              "id": "string",
+            },
+            "responseBodyV3": {
+              "type": "json",
+              "value": {
+                "id": "string",
+              },
+            },
+            "responseStatusCode": 200,
+          },
+        ],
+        "headers": [],
+        "id": "createResource",
+        "includeInApiExplorer": undefined,
+        "method": "POST",
+        "multiAuth": [
+          {
+            "schemes": [
+              "admin",
+            ],
+          },
+          {
+            "schemes": [
+              "operator",
+            ],
+          },
+        ],
+        "name": "Create a resource with multiple auth options",
+        "originalEndpointId": "endpoint_.createResource",
+        "path": {
+          "parts": [
+            {
+              "type": "literal",
+              "value": "",
+            },
+            {
+              "type": "literal",
+              "value": "/resource",
+            },
+          ],
+          "pathParameters": [],
+        },
+        "protocol": {
+          "type": "rest",
+        },
+        "queryParameters": [],
+        "request": {
+          "description": undefined,
+          "type": {
+            "contentType": "application/json",
+            "description": undefined,
+            "shape": {
+              "type": "reference",
+              "value": {
+                "default": undefined,
+                "type": "id",
+                "value": "ResourceRequest",
+              },
+            },
+            "type": "json",
+          },
+        },
+        "requestsV2": {
+          "requests": [
+            {
+              "description": undefined,
+              "type": {
+                "contentType": "application/json",
+                "description": undefined,
+                "shape": {
+                  "type": "reference",
+                  "value": {
+                    "default": undefined,
+                    "type": "id",
+                    "value": "ResourceRequest",
+                  },
+                },
+                "type": "json",
+              },
+            },
+          ],
+        },
+        "response": {
+          "description": "Resource created successfully",
+          "isWildcard": undefined,
+          "statusCode": 200,
+          "type": {
+            "type": "reference",
+            "value": {
+              "default": undefined,
+              "type": "id",
+              "value": "ResourceResponse",
+            },
+          },
+        },
+        "responsesV2": {
+          "responses": [
+            {
+              "description": "Resource created successfully",
+              "isWildcard": undefined,
+              "statusCode": 200,
+              "type": {
+                "type": "reference",
+                "value": {
+                  "default": undefined,
+                  "type": "id",
+                  "value": "ResourceResponse",
+                },
+              },
+            },
+          ],
+        },
+        "slug": undefined,
+      },
+    ],
+    "pointsTo": undefined,
+    "subpackages": [],
+    "types": [
+      "ResourceRequest",
+      "ResourceResponse",
+    ],
+    "webhooks": [],
+    "websockets": [],
+  },
+  "snippetsConfiguration": {
+    "csharpSdk": undefined,
+    "goSdk": undefined,
+    "javaSdk": undefined,
+    "phpSdk": undefined,
+    "pythonSdk": undefined,
+    "rubySdk": undefined,
+    "rustSdk": undefined,
+    "swiftSdk": undefined,
+    "typescriptSdk": undefined,
+  },
+  "subpackages": {},
+  "types": {
+    "ResourceRequest": {
+      "availability": undefined,
+      "description": undefined,
+      "displayName": undefined,
+      "name": "ResourceRequest",
+      "shape": {
+        "extends": [],
+        "extraProperties": undefined,
+        "properties": [
+          {
+            "availability": undefined,
+            "description": "Resource type",
+            "key": "type",
+            "propertyAccess": undefined,
+            "valueType": {
+              "default": undefined,
+              "type": "id",
+              "value": "ResourceRequestType",
+            },
+          },
+          {
+            "availability": undefined,
+            "description": undefined,
+            "key": "amount",
+            "propertyAccess": undefined,
+            "valueType": {
+              "default": undefined,
+              "type": "id",
+              "value": "ResourceRequestAmount",
+            },
+          },
+          {
+            "availability": undefined,
+            "description": "Target identifier",
+            "key": "target",
+            "propertyAccess": undefined,
+            "valueType": {
+              "type": "primitive",
+              "value": {
+                "default": undefined,
+                "format": undefined,
+                "maxLength": undefined,
+                "minLength": undefined,
+                "regex": undefined,
+                "type": "string",
+              },
+            },
+          },
+        ],
+        "type": "object",
+      },
+    },
+    "ResourceRequestAmount": {
+      "availability": undefined,
+      "description": undefined,
+      "displayName": undefined,
+      "name": "ResourceRequestAmount",
+      "shape": {
+        "extends": [],
+        "extraProperties": undefined,
+        "properties": [
+          {
+            "availability": undefined,
+            "description": "Amount value",
+            "key": "value",
+            "propertyAccess": undefined,
+            "valueType": {
+              "type": "primitive",
+              "value": {
+                "default": undefined,
+                "maximum": undefined,
+                "minimum": 1,
+                "type": "double",
+              },
+            },
+          },
+        ],
+        "type": "object",
+      },
+    },
+    "ResourceRequestType": {
+      "availability": undefined,
+      "description": "Resource type",
+      "displayName": undefined,
+      "name": "ResourceRequestType",
+      "shape": {
+        "default": undefined,
+        "type": "enum",
+        "values": [
+          {
+            "availability": undefined,
+            "description": undefined,
+            "value": "typeA",
+          },
+          {
+            "availability": undefined,
+            "description": undefined,
+            "value": "typeB",
+          },
+        ],
+      },
+    },
+    "ResourceResponse": {
+      "availability": undefined,
+      "description": undefined,
+      "displayName": undefined,
+      "name": "ResourceResponse",
+      "shape": {
+        "extends": [],
+        "extraProperties": undefined,
+        "properties": [
+          {
+            "availability": undefined,
+            "description": "Resource identifier",
+            "key": "id",
+            "propertyAccess": undefined,
+            "valueType": {
+              "type": "primitive",
+              "value": {
+                "default": undefined,
+                "format": undefined,
+                "maxLength": undefined,
+                "minLength": undefined,
+                "regex": undefined,
+                "type": "string",
+              },
+            },
+          },
+        ],
+        "type": "object",
+      },
+    },
+  },
+}

--- a/packages/cli/register/src/ir-to-fdr-converter/__test__/__snapshots__/auth-scheme-example-selection-ir.snap
+++ b/packages/cli/register/src/ir-to-fdr-converter/__test__/__snapshots__/auth-scheme-example-selection-ir.snap
@@ -1,0 +1,1208 @@
+{
+  "apiDisplayName": undefined,
+  "apiDocs": undefined,
+  "apiName": {
+    "camelCase": {
+      "safeName": "",
+      "unsafeName": "",
+    },
+    "originalName": "",
+    "pascalCase": {
+      "safeName": "",
+      "unsafeName": "",
+    },
+    "screamingSnakeCase": {
+      "safeName": "",
+      "unsafeName": "",
+    },
+    "snakeCase": {
+      "safeName": "",
+      "unsafeName": "",
+    },
+  },
+  "apiPlayground": undefined,
+  "apiVersion": undefined,
+  "audiences": undefined,
+  "auth": {
+    "docs": undefined,
+    "requirement": "ANY",
+    "schemes": [
+      {
+        "_visit": [Function],
+        "docs": "User authentication token",
+        "headerEnvVar": undefined,
+        "key": "user",
+        "name": {
+          "name": {
+            "camelCase": {
+              "safeName": "apiKey",
+              "unsafeName": "apiKey",
+            },
+            "originalName": "apiKey",
+            "pascalCase": {
+              "safeName": "ApiKey",
+              "unsafeName": "ApiKey",
+            },
+            "screamingSnakeCase": {
+              "safeName": "API_KEY",
+              "unsafeName": "API_KEY",
+            },
+            "snakeCase": {
+              "safeName": "api_key",
+              "unsafeName": "api_key",
+            },
+          },
+          "wireValue": "x-user-token",
+        },
+        "prefix": undefined,
+        "type": "header",
+        "valueType": {
+          "_visit": [Function],
+          "container": {
+            "_visit": [Function],
+            "optional": {
+              "_visit": [Function],
+              "primitive": {
+                "v1": "STRING",
+                "v2": {
+                  "_visit": [Function],
+                  "default": undefined,
+                  "type": "string",
+                  "validation": undefined,
+                },
+              },
+              "type": "primitive",
+            },
+            "type": "optional",
+          },
+          "type": "container",
+        },
+      },
+      {
+        "_visit": [Function],
+        "docs": "Operator API key",
+        "headerEnvVar": undefined,
+        "key": "operator",
+        "name": {
+          "name": {
+            "camelCase": {
+              "safeName": "apiKey",
+              "unsafeName": "apiKey",
+            },
+            "originalName": "apiKey",
+            "pascalCase": {
+              "safeName": "ApiKey",
+              "unsafeName": "ApiKey",
+            },
+            "screamingSnakeCase": {
+              "safeName": "API_KEY",
+              "unsafeName": "API_KEY",
+            },
+            "snakeCase": {
+              "safeName": "api_key",
+              "unsafeName": "api_key",
+            },
+          },
+          "wireValue": "Authorization",
+        },
+        "prefix": undefined,
+        "type": "header",
+        "valueType": {
+          "_visit": [Function],
+          "container": {
+            "_visit": [Function],
+            "optional": {
+              "_visit": [Function],
+              "primitive": {
+                "v1": "STRING",
+                "v2": {
+                  "_visit": [Function],
+                  "default": undefined,
+                  "type": "string",
+                  "validation": undefined,
+                },
+              },
+              "type": "primitive",
+            },
+            "type": "optional",
+          },
+          "type": "container",
+        },
+      },
+      {
+        "_visit": [Function],
+        "docs": "Admin API key",
+        "headerEnvVar": undefined,
+        "key": "admin",
+        "name": {
+          "name": {
+            "camelCase": {
+              "safeName": "apiKey",
+              "unsafeName": "apiKey",
+            },
+            "originalName": "apiKey",
+            "pascalCase": {
+              "safeName": "ApiKey",
+              "unsafeName": "ApiKey",
+            },
+            "screamingSnakeCase": {
+              "safeName": "API_KEY",
+              "unsafeName": "API_KEY",
+            },
+            "snakeCase": {
+              "safeName": "api_key",
+              "unsafeName": "api_key",
+            },
+          },
+          "wireValue": "Authorization",
+        },
+        "prefix": undefined,
+        "type": "header",
+        "valueType": {
+          "_visit": [Function],
+          "container": {
+            "_visit": [Function],
+            "optional": {
+              "_visit": [Function],
+              "primitive": {
+                "v1": "STRING",
+                "v2": {
+                  "_visit": [Function],
+                  "default": undefined,
+                  "type": "string",
+                  "validation": undefined,
+                },
+              },
+              "type": "primitive",
+            },
+            "type": "optional",
+          },
+          "type": "container",
+        },
+      },
+    ],
+  },
+  "basePath": undefined,
+  "constants": {
+    "errorInstanceIdKey": {
+      "name": {
+        "camelCase": {
+          "safeName": "errorInstanceId",
+          "unsafeName": "errorInstanceId",
+        },
+        "originalName": "errorInstanceId",
+        "pascalCase": {
+          "safeName": "ErrorInstanceId",
+          "unsafeName": "ErrorInstanceId",
+        },
+        "screamingSnakeCase": {
+          "safeName": "ERROR_INSTANCE_ID",
+          "unsafeName": "ERROR_INSTANCE_ID",
+        },
+        "snakeCase": {
+          "safeName": "error_instance_id",
+          "unsafeName": "error_instance_id",
+        },
+      },
+      "wireValue": "errorInstanceId",
+    },
+  },
+  "dynamic": undefined,
+  "environments": {
+    "defaultEnvironment": "https://api.example.com/v1",
+    "environments": {
+      "_visit": [Function],
+      "environments": [
+        {
+          "docs": undefined,
+          "id": "https://api.example.com/v1",
+          "name": {
+            "camelCase": {
+              "safeName": "httpsApiExampleComV1",
+              "unsafeName": "httpsApiExampleComV1",
+            },
+            "originalName": "https://api.example.com/v1",
+            "pascalCase": {
+              "safeName": "HttpsApiExampleComV1",
+              "unsafeName": "HttpsApiExampleComV1",
+            },
+            "screamingSnakeCase": {
+              "safeName": "HTTPS_API_EXAMPLE_COM_V_1",
+              "unsafeName": "HTTPS_API_EXAMPLE_COM_V_1",
+            },
+            "snakeCase": {
+              "safeName": "https_api_example_com_v_1",
+              "unsafeName": "https_api_example_com_v_1",
+            },
+          },
+          "url": "https://api.example.com/v1",
+        },
+      ],
+      "type": "singleBaseUrl",
+    },
+  },
+  "errorDiscriminationStrategy": {
+    "_visit": [Function],
+    "type": "statusCode",
+  },
+  "errors": {},
+  "fdrApiDefinitionId": undefined,
+  "generationMetadata": undefined,
+  "headers": [],
+  "idempotencyHeaders": [],
+  "pathParameters": [],
+  "publishConfig": undefined,
+  "readmeConfig": undefined,
+  "rootPackage": {
+    "docs": undefined,
+    "errors": [],
+    "fernFilepath": {
+      "allParts": [],
+      "file": undefined,
+      "packagePath": [],
+    },
+    "hasEndpointsInTree": false,
+    "navigationConfig": undefined,
+    "service": "service_",
+    "subpackages": [],
+    "types": [
+      "ResourceRequest",
+      "ResourceResponse",
+    ],
+    "webhooks": undefined,
+    "websocket": undefined,
+  },
+  "sdkConfig": {
+    "hasFileDownloadEndpoints": false,
+    "hasPaginatedEndpoints": false,
+    "hasStreamingEndpoints": false,
+    "isAuthMandatory": true,
+    "platformHeaders": {
+      "language": "",
+      "sdkName": "",
+      "sdkVersion": "",
+      "userAgent": undefined,
+    },
+  },
+  "selfHosted": false,
+  "serviceTypeReferenceInfo": {
+    "sharedTypes": [],
+    "typesReferencedOnlyByService": {},
+  },
+  "services": {
+    "service_": {
+      "audiences": undefined,
+      "availability": undefined,
+      "basePath": {
+        "head": "",
+        "parts": [],
+      },
+      "displayName": undefined,
+      "encoding": undefined,
+      "endpoints": [
+        {
+          "allPathParameters": [],
+          "apiPlayground": undefined,
+          "audiences": [],
+          "auth": true,
+          "autogeneratedExamples": [],
+          "availability": undefined,
+          "basePath": undefined,
+          "baseUrl": "https://api.example.com/v1",
+          "displayName": "Create a resource with multiple auth options",
+          "docs": "This endpoint accepts either admin auth OR operator auth.
+Examples should use the first available auth scheme (admin).
+",
+          "errors": [],
+          "fullPath": {
+            "head": "/resource",
+            "parts": [],
+          },
+          "headers": [],
+          "id": "endpoint_.createResource",
+          "idempotent": false,
+          "method": "POST",
+          "name": {
+            "camelCase": {
+              "safeName": "createResource",
+              "unsafeName": "createResource",
+            },
+            "originalName": "createResource",
+            "pascalCase": {
+              "safeName": "CreateResource",
+              "unsafeName": "CreateResource",
+            },
+            "screamingSnakeCase": {
+              "safeName": "CREATE_RESOURCE",
+              "unsafeName": "CREATE_RESOURCE",
+            },
+            "snakeCase": {
+              "safeName": "create_resource",
+              "unsafeName": "create_resource",
+            },
+          },
+          "pagination": undefined,
+          "path": {
+            "head": "/resource",
+            "parts": [],
+          },
+          "pathParameters": [],
+          "queryParameters": [],
+          "requestBody": {
+            "_visit": [Function],
+            "contentType": "application/json",
+            "docs": undefined,
+            "requestBodyType": {
+              "_visit": [Function],
+              "default": undefined,
+              "displayName": undefined,
+              "fernFilepath": {
+                "allParts": [],
+                "file": undefined,
+                "packagePath": [],
+              },
+              "inline": false,
+              "name": {
+                "camelCase": {
+                  "safeName": "resourceRequest",
+                  "unsafeName": "resourceRequest",
+                },
+                "originalName": "ResourceRequest",
+                "pascalCase": {
+                  "safeName": "ResourceRequest",
+                  "unsafeName": "ResourceRequest",
+                },
+                "screamingSnakeCase": {
+                  "safeName": "RESOURCE_REQUEST",
+                  "unsafeName": "RESOURCE_REQUEST",
+                },
+                "snakeCase": {
+                  "safeName": "resource_request",
+                  "unsafeName": "resource_request",
+                },
+              },
+              "type": "named",
+              "typeId": "ResourceRequest",
+            },
+            "type": "reference",
+            "v2Examples": {
+              "autogeneratedExamples": {
+                "createResourceExample": {
+                  "amount": {
+                    "value": 1.1,
+                  },
+                  "target": "string",
+                  "type": "typeA",
+                },
+              },
+              "userSpecifiedExamples": {},
+            },
+          },
+          "response": {
+            "body": {
+              "_visit": [Function],
+              "type": "json",
+              "value": {
+                "_visit": [Function],
+                "docs": "Resource created successfully",
+                "responseBodyType": {
+                  "_visit": [Function],
+                  "default": undefined,
+                  "displayName": undefined,
+                  "fernFilepath": {
+                    "allParts": [],
+                    "file": undefined,
+                    "packagePath": [],
+                  },
+                  "inline": false,
+                  "name": {
+                    "camelCase": {
+                      "safeName": "resourceResponse",
+                      "unsafeName": "resourceResponse",
+                    },
+                    "originalName": "ResourceResponse",
+                    "pascalCase": {
+                      "safeName": "ResourceResponse",
+                      "unsafeName": "ResourceResponse",
+                    },
+                    "screamingSnakeCase": {
+                      "safeName": "RESOURCE_RESPONSE",
+                      "unsafeName": "RESOURCE_RESPONSE",
+                    },
+                    "snakeCase": {
+                      "safeName": "resource_response",
+                      "unsafeName": "resource_response",
+                    },
+                  },
+                  "type": "named",
+                  "typeId": "ResourceResponse",
+                },
+                "type": "response",
+                "v2Examples": {
+                  "autogeneratedExamples": {
+                    "createResourceExample": {
+                      "id": "string",
+                    },
+                  },
+                  "userSpecifiedExamples": {},
+                },
+              },
+            },
+            "docs": "Resource created successfully",
+            "isWildcardStatusCode": undefined,
+            "statusCode": 200,
+          },
+          "retries": undefined,
+          "sdkRequest": undefined,
+          "security": [
+            {
+              "admin": [],
+            },
+            {
+              "operator": [],
+            },
+          ],
+          "source": {
+            "_visit": [Function],
+            "type": "openapi",
+          },
+          "transport": undefined,
+          "userSpecifiedExamples": [],
+          "v2BaseUrls": undefined,
+          "v2Examples": {
+            "autogeneratedExamples": {
+              "createResourceExample_200": {
+                "codeSamples": undefined,
+                "displayName": "createResourceExample",
+                "request": {
+                  "auth": undefined,
+                  "baseUrl": undefined,
+                  "docs": undefined,
+                  "endpoint": {
+                    "method": "POST",
+                    "path": "/resource",
+                  },
+                  "environment": "https://api.example.com/v1",
+                  "headers": {},
+                  "pathParameters": {},
+                  "queryParameters": {},
+                  "requestBody": {
+                    "amount": {
+                      "value": 1.1,
+                    },
+                    "target": "string",
+                    "type": "typeA",
+                  },
+                },
+                "response": {
+                  "body": {
+                    "_visit": [Function],
+                    "type": "json",
+                    "value": {
+                      "id": "string",
+                    },
+                  },
+                  "docs": undefined,
+                  "statusCode": 200,
+                },
+              },
+            },
+            "userSpecifiedExamples": {},
+          },
+          "v2RequestBodies": {
+            "requestBodies": [
+              {
+                "_visit": [Function],
+                "contentType": "application/json",
+                "docs": undefined,
+                "requestBodyType": {
+                  "_visit": [Function],
+                  "default": undefined,
+                  "displayName": undefined,
+                  "fernFilepath": {
+                    "allParts": [],
+                    "file": undefined,
+                    "packagePath": [],
+                  },
+                  "inline": false,
+                  "name": {
+                    "camelCase": {
+                      "safeName": "resourceRequest",
+                      "unsafeName": "resourceRequest",
+                    },
+                    "originalName": "ResourceRequest",
+                    "pascalCase": {
+                      "safeName": "ResourceRequest",
+                      "unsafeName": "ResourceRequest",
+                    },
+                    "screamingSnakeCase": {
+                      "safeName": "RESOURCE_REQUEST",
+                      "unsafeName": "RESOURCE_REQUEST",
+                    },
+                    "snakeCase": {
+                      "safeName": "resource_request",
+                      "unsafeName": "resource_request",
+                    },
+                  },
+                  "type": "named",
+                  "typeId": "ResourceRequest",
+                },
+                "type": "reference",
+                "v2Examples": {
+                  "autogeneratedExamples": {
+                    "createResourceExample": {
+                      "amount": {
+                        "value": 1.1,
+                      },
+                      "target": "string",
+                      "type": "typeA",
+                    },
+                  },
+                  "userSpecifiedExamples": {},
+                },
+              },
+            ],
+          },
+          "v2Responses": {
+            "responses": [
+              {
+                "body": {
+                  "_visit": [Function],
+                  "type": "json",
+                  "value": {
+                    "_visit": [Function],
+                    "docs": "Resource created successfully",
+                    "responseBodyType": {
+                      "_visit": [Function],
+                      "default": undefined,
+                      "displayName": undefined,
+                      "fernFilepath": {
+                        "allParts": [],
+                        "file": undefined,
+                        "packagePath": [],
+                      },
+                      "inline": false,
+                      "name": {
+                        "camelCase": {
+                          "safeName": "resourceResponse",
+                          "unsafeName": "resourceResponse",
+                        },
+                        "originalName": "ResourceResponse",
+                        "pascalCase": {
+                          "safeName": "ResourceResponse",
+                          "unsafeName": "ResourceResponse",
+                        },
+                        "screamingSnakeCase": {
+                          "safeName": "RESOURCE_RESPONSE",
+                          "unsafeName": "RESOURCE_RESPONSE",
+                        },
+                        "snakeCase": {
+                          "safeName": "resource_response",
+                          "unsafeName": "resource_response",
+                        },
+                      },
+                      "type": "named",
+                      "typeId": "ResourceResponse",
+                    },
+                    "type": "response",
+                    "v2Examples": {
+                      "autogeneratedExamples": {
+                        "createResourceExample": {
+                          "id": "string",
+                        },
+                      },
+                      "userSpecifiedExamples": {},
+                    },
+                  },
+                },
+                "docs": "Resource created successfully",
+                "isWildcardStatusCode": undefined,
+                "statusCode": 200,
+              },
+            ],
+          },
+        },
+      ],
+      "headers": [],
+      "name": {
+        "fernFilepath": {
+          "allParts": [],
+          "file": undefined,
+          "packagePath": [],
+        },
+      },
+      "pathParameters": [],
+      "transport": undefined,
+    },
+  },
+  "sourceConfig": undefined,
+  "subpackages": {},
+  "types": {
+    "ResourceRequest": {
+      "autogeneratedExamples": [],
+      "availability": undefined,
+      "docs": undefined,
+      "encoding": undefined,
+      "inline": false,
+      "name": {
+        "displayName": undefined,
+        "fernFilepath": {
+          "allParts": [],
+          "file": undefined,
+          "packagePath": [],
+        },
+        "name": {
+          "camelCase": {
+            "safeName": "resourceRequest",
+            "unsafeName": "resourceRequest",
+          },
+          "originalName": "ResourceRequest",
+          "pascalCase": {
+            "safeName": "ResourceRequest",
+            "unsafeName": "ResourceRequest",
+          },
+          "screamingSnakeCase": {
+            "safeName": "RESOURCE_REQUEST",
+            "unsafeName": "RESOURCE_REQUEST",
+          },
+          "snakeCase": {
+            "safeName": "resource_request",
+            "unsafeName": "resource_request",
+          },
+        },
+        "typeId": "ResourceRequest",
+      },
+      "referencedTypes": Set {
+        "ResourceRequestType",
+        "ResourceRequestAmount",
+      },
+      "shape": {
+        "_visit": [Function],
+        "extendedProperties": [],
+        "extends": [],
+        "extraProperties": false,
+        "properties": [
+          {
+            "availability": undefined,
+            "docs": "Resource type",
+            "name": {
+              "name": {
+                "camelCase": {
+                  "safeName": "type_",
+                  "unsafeName": "type",
+                },
+                "originalName": "type",
+                "pascalCase": {
+                  "safeName": "Type",
+                  "unsafeName": "Type",
+                },
+                "screamingSnakeCase": {
+                  "safeName": "TYPE",
+                  "unsafeName": "TYPE",
+                },
+                "snakeCase": {
+                  "safeName": "type_",
+                  "unsafeName": "type",
+                },
+              },
+              "wireValue": "type",
+            },
+            "propertyAccess": undefined,
+            "v2Examples": {
+              "autogeneratedExamples": {
+                "ResourceRequestType_example_autogenerated": "typeA",
+              },
+              "userSpecifiedExamples": {},
+            },
+            "valueType": {
+              "_visit": [Function],
+              "default": undefined,
+              "displayName": undefined,
+              "fernFilepath": {
+                "allParts": [],
+                "file": undefined,
+                "packagePath": [],
+              },
+              "inline": false,
+              "name": {
+                "camelCase": {
+                  "safeName": "resourceRequestType",
+                  "unsafeName": "resourceRequestType",
+                },
+                "originalName": "ResourceRequestType",
+                "pascalCase": {
+                  "safeName": "ResourceRequestType",
+                  "unsafeName": "ResourceRequestType",
+                },
+                "screamingSnakeCase": {
+                  "safeName": "RESOURCE_REQUEST_TYPE",
+                  "unsafeName": "RESOURCE_REQUEST_TYPE",
+                },
+                "snakeCase": {
+                  "safeName": "resource_request_type",
+                  "unsafeName": "resource_request_type",
+                },
+              },
+              "type": "named",
+              "typeId": "ResourceRequestType",
+            },
+          },
+          {
+            "availability": undefined,
+            "docs": undefined,
+            "name": {
+              "name": {
+                "camelCase": {
+                  "safeName": "amount",
+                  "unsafeName": "amount",
+                },
+                "originalName": "amount",
+                "pascalCase": {
+                  "safeName": "Amount",
+                  "unsafeName": "Amount",
+                },
+                "screamingSnakeCase": {
+                  "safeName": "AMOUNT",
+                  "unsafeName": "AMOUNT",
+                },
+                "snakeCase": {
+                  "safeName": "amount",
+                  "unsafeName": "amount",
+                },
+              },
+              "wireValue": "amount",
+            },
+            "propertyAccess": undefined,
+            "v2Examples": {
+              "autogeneratedExamples": {
+                "ResourceRequestAmount_example_autogenerated": {
+                  "value": 1.1,
+                },
+              },
+              "userSpecifiedExamples": {},
+            },
+            "valueType": {
+              "_visit": [Function],
+              "default": undefined,
+              "displayName": undefined,
+              "fernFilepath": {
+                "allParts": [],
+                "file": undefined,
+                "packagePath": [],
+              },
+              "inline": false,
+              "name": {
+                "camelCase": {
+                  "safeName": "resourceRequestAmount",
+                  "unsafeName": "resourceRequestAmount",
+                },
+                "originalName": "ResourceRequestAmount",
+                "pascalCase": {
+                  "safeName": "ResourceRequestAmount",
+                  "unsafeName": "ResourceRequestAmount",
+                },
+                "screamingSnakeCase": {
+                  "safeName": "RESOURCE_REQUEST_AMOUNT",
+                  "unsafeName": "RESOURCE_REQUEST_AMOUNT",
+                },
+                "snakeCase": {
+                  "safeName": "resource_request_amount",
+                  "unsafeName": "resource_request_amount",
+                },
+              },
+              "type": "named",
+              "typeId": "ResourceRequestAmount",
+            },
+          },
+          {
+            "availability": undefined,
+            "docs": "Target identifier",
+            "name": {
+              "name": {
+                "camelCase": {
+                  "safeName": "target",
+                  "unsafeName": "target",
+                },
+                "originalName": "target",
+                "pascalCase": {
+                  "safeName": "Target",
+                  "unsafeName": "Target",
+                },
+                "screamingSnakeCase": {
+                  "safeName": "TARGET",
+                  "unsafeName": "TARGET",
+                },
+                "snakeCase": {
+                  "safeName": "target",
+                  "unsafeName": "target",
+                },
+              },
+              "wireValue": "target",
+            },
+            "propertyAccess": undefined,
+            "v2Examples": {
+              "autogeneratedExamples": {
+                "ResourceRequestTarget_example_autogenerated": "string",
+              },
+              "userSpecifiedExamples": {},
+            },
+            "valueType": {
+              "_visit": [Function],
+              "primitive": {
+                "v1": "STRING",
+                "v2": {
+                  "_visit": [Function],
+                  "default": undefined,
+                  "type": "string",
+                  "validation": {
+                    "format": undefined,
+                    "maxLength": undefined,
+                    "minLength": undefined,
+                    "pattern": undefined,
+                  },
+                },
+              },
+              "type": "primitive",
+            },
+          },
+        ],
+        "type": "object",
+      },
+      "source": undefined,
+      "userProvidedExamples": [],
+      "v2Examples": {
+        "autogeneratedExamples": {
+          "ResourceRequest_example_autogenerated": {
+            "amount": {
+              "value": 1.1,
+            },
+            "target": "string",
+            "type": "typeA",
+          },
+        },
+        "userSpecifiedExamples": {},
+      },
+    },
+    "ResourceRequestAmount": {
+      "autogeneratedExamples": [],
+      "availability": undefined,
+      "docs": undefined,
+      "encoding": undefined,
+      "inline": false,
+      "name": {
+        "displayName": undefined,
+        "fernFilepath": {
+          "allParts": [],
+          "file": undefined,
+          "packagePath": [],
+        },
+        "name": {
+          "camelCase": {
+            "safeName": "resourceRequestAmount",
+            "unsafeName": "resourceRequestAmount",
+          },
+          "originalName": "ResourceRequestAmount",
+          "pascalCase": {
+            "safeName": "ResourceRequestAmount",
+            "unsafeName": "ResourceRequestAmount",
+          },
+          "screamingSnakeCase": {
+            "safeName": "RESOURCE_REQUEST_AMOUNT",
+            "unsafeName": "RESOURCE_REQUEST_AMOUNT",
+          },
+          "snakeCase": {
+            "safeName": "resource_request_amount",
+            "unsafeName": "resource_request_amount",
+          },
+        },
+        "typeId": "ResourceRequestAmount",
+      },
+      "referencedTypes": Set {},
+      "shape": {
+        "_visit": [Function],
+        "extendedProperties": [],
+        "extends": [],
+        "extraProperties": false,
+        "properties": [
+          {
+            "availability": undefined,
+            "docs": "Amount value",
+            "name": {
+              "name": {
+                "camelCase": {
+                  "safeName": "value",
+                  "unsafeName": "value",
+                },
+                "originalName": "value",
+                "pascalCase": {
+                  "safeName": "Value",
+                  "unsafeName": "Value",
+                },
+                "screamingSnakeCase": {
+                  "safeName": "VALUE",
+                  "unsafeName": "VALUE",
+                },
+                "snakeCase": {
+                  "safeName": "value",
+                  "unsafeName": "value",
+                },
+              },
+              "wireValue": "value",
+            },
+            "propertyAccess": undefined,
+            "v2Examples": {
+              "autogeneratedExamples": {
+                "ResourceRequestAmountValue_example_autogenerated": 1.1,
+              },
+              "userSpecifiedExamples": {},
+            },
+            "valueType": {
+              "_visit": [Function],
+              "primitive": {
+                "v1": "DOUBLE",
+                "v2": {
+                  "_visit": [Function],
+                  "default": undefined,
+                  "type": "double",
+                  "validation": {
+                    "exclusiveMax": undefined,
+                    "exclusiveMin": undefined,
+                    "max": undefined,
+                    "min": 1,
+                    "multipleOf": undefined,
+                  },
+                },
+              },
+              "type": "primitive",
+            },
+          },
+        ],
+        "type": "object",
+      },
+      "source": undefined,
+      "userProvidedExamples": [],
+      "v2Examples": {
+        "autogeneratedExamples": {
+          "ResourceRequestAmount_example_autogenerated": {
+            "value": 1.1,
+          },
+        },
+        "userSpecifiedExamples": {},
+      },
+    },
+    "ResourceRequestType": {
+      "autogeneratedExamples": [],
+      "availability": undefined,
+      "docs": "Resource type",
+      "encoding": undefined,
+      "inline": false,
+      "name": {
+        "displayName": undefined,
+        "fernFilepath": {
+          "allParts": [],
+          "file": undefined,
+          "packagePath": [],
+        },
+        "name": {
+          "camelCase": {
+            "safeName": "resourceRequestType",
+            "unsafeName": "resourceRequestType",
+          },
+          "originalName": "ResourceRequestType",
+          "pascalCase": {
+            "safeName": "ResourceRequestType",
+            "unsafeName": "ResourceRequestType",
+          },
+          "screamingSnakeCase": {
+            "safeName": "RESOURCE_REQUEST_TYPE",
+            "unsafeName": "RESOURCE_REQUEST_TYPE",
+          },
+          "snakeCase": {
+            "safeName": "resource_request_type",
+            "unsafeName": "resource_request_type",
+          },
+        },
+        "typeId": "ResourceRequestType",
+      },
+      "referencedTypes": Set {},
+      "shape": {
+        "_visit": [Function],
+        "default": undefined,
+        "type": "enum",
+        "values": [
+          {
+            "availability": undefined,
+            "casing": undefined,
+            "docs": undefined,
+            "name": {
+              "name": {
+                "camelCase": {
+                  "safeName": "typeA",
+                  "unsafeName": "typeA",
+                },
+                "originalName": "typeA",
+                "pascalCase": {
+                  "safeName": "TypeA",
+                  "unsafeName": "TypeA",
+                },
+                "screamingSnakeCase": {
+                  "safeName": "TYPE_A",
+                  "unsafeName": "TYPE_A",
+                },
+                "snakeCase": {
+                  "safeName": "type_a",
+                  "unsafeName": "type_a",
+                },
+              },
+              "wireValue": "typeA",
+            },
+          },
+          {
+            "availability": undefined,
+            "casing": undefined,
+            "docs": undefined,
+            "name": {
+              "name": {
+                "camelCase": {
+                  "safeName": "typeB",
+                  "unsafeName": "typeB",
+                },
+                "originalName": "typeB",
+                "pascalCase": {
+                  "safeName": "TypeB",
+                  "unsafeName": "TypeB",
+                },
+                "screamingSnakeCase": {
+                  "safeName": "TYPE_B",
+                  "unsafeName": "TYPE_B",
+                },
+                "snakeCase": {
+                  "safeName": "type_b",
+                  "unsafeName": "type_b",
+                },
+              },
+              "wireValue": "typeB",
+            },
+          },
+        ],
+      },
+      "source": undefined,
+      "userProvidedExamples": [],
+      "v2Examples": {
+        "autogeneratedExamples": {
+          "ResourceRequestType_example_autogenerated": "typeA",
+        },
+        "userSpecifiedExamples": {},
+      },
+    },
+    "ResourceResponse": {
+      "autogeneratedExamples": [],
+      "availability": undefined,
+      "docs": undefined,
+      "encoding": undefined,
+      "inline": false,
+      "name": {
+        "displayName": undefined,
+        "fernFilepath": {
+          "allParts": [],
+          "file": undefined,
+          "packagePath": [],
+        },
+        "name": {
+          "camelCase": {
+            "safeName": "resourceResponse",
+            "unsafeName": "resourceResponse",
+          },
+          "originalName": "ResourceResponse",
+          "pascalCase": {
+            "safeName": "ResourceResponse",
+            "unsafeName": "ResourceResponse",
+          },
+          "screamingSnakeCase": {
+            "safeName": "RESOURCE_RESPONSE",
+            "unsafeName": "RESOURCE_RESPONSE",
+          },
+          "snakeCase": {
+            "safeName": "resource_response",
+            "unsafeName": "resource_response",
+          },
+        },
+        "typeId": "ResourceResponse",
+      },
+      "referencedTypes": Set {},
+      "shape": {
+        "_visit": [Function],
+        "extendedProperties": [],
+        "extends": [],
+        "extraProperties": false,
+        "properties": [
+          {
+            "availability": undefined,
+            "docs": "Resource identifier",
+            "name": {
+              "name": {
+                "camelCase": {
+                  "safeName": "id",
+                  "unsafeName": "id",
+                },
+                "originalName": "id",
+                "pascalCase": {
+                  "safeName": "Id",
+                  "unsafeName": "Id",
+                },
+                "screamingSnakeCase": {
+                  "safeName": "ID",
+                  "unsafeName": "ID",
+                },
+                "snakeCase": {
+                  "safeName": "id",
+                  "unsafeName": "id",
+                },
+              },
+              "wireValue": "id",
+            },
+            "propertyAccess": undefined,
+            "v2Examples": {
+              "autogeneratedExamples": {
+                "ResourceResponseId_example_autogenerated": "string",
+              },
+              "userSpecifiedExamples": {},
+            },
+            "valueType": {
+              "_visit": [Function],
+              "primitive": {
+                "v1": "STRING",
+                "v2": {
+                  "_visit": [Function],
+                  "default": undefined,
+                  "type": "string",
+                  "validation": {
+                    "format": undefined,
+                    "maxLength": undefined,
+                    "minLength": undefined,
+                    "pattern": undefined,
+                  },
+                },
+              },
+              "type": "primitive",
+            },
+          },
+        ],
+        "type": "object",
+      },
+      "source": undefined,
+      "userProvidedExamples": [],
+      "v2Examples": {
+        "autogeneratedExamples": {
+          "ResourceResponse_example_autogenerated": {
+            "id": "string",
+          },
+        },
+        "userSpecifiedExamples": {},
+      },
+    },
+  },
+  "variables": [],
+  "webhookGroups": {},
+  "websocketChannels": undefined,
+}

--- a/packages/cli/register/src/ir-to-fdr-converter/__test__/fixtures/auth-scheme-example-selection/generators.yml
+++ b/packages/cli/register/src/ir-to-fdr-converter/__test__/fixtures/auth-scheme-example-selection/generators.yml
@@ -1,0 +1,3 @@
+api:
+  specs:
+    - openapi: openapi.yml

--- a/packages/cli/register/src/ir-to-fdr-converter/__test__/fixtures/auth-scheme-example-selection/openapi.yml
+++ b/packages/cli/register/src/ir-to-fdr-converter/__test__/fixtures/auth-scheme-example-selection/openapi.yml
@@ -1,0 +1,90 @@
+openapi: 3.0.3
+info:
+  title: Auth Scheme Example Selection Test API
+  version: 1.0.0
+  description: |
+    Test fixture to verify that examples populate with the first available auth scheme
+    from the endpoint's security requirements, not the first globally defined auth scheme.
+
+servers:
+  - url: https://api.example.com/v1
+
+paths:
+  /resource:
+    post:
+      operationId: createResource
+      summary: Create a resource with multiple auth options
+      description: |
+        This endpoint accepts either admin auth OR operator auth.
+        Examples should use the first available auth scheme (admin).
+      security:
+        - admin: []
+        - operator: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ResourceRequest"
+      responses:
+        "200":
+          description: Resource created successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResourceResponse"
+
+components:
+  securitySchemes:
+    user:
+      type: apiKey
+      name: x-user-token
+      in: header
+      description: User authentication token
+    operator:
+      type: apiKey
+      name: Authorization
+      in: header
+      description: Operator API key
+    admin:
+      type: apiKey
+      name: Authorization
+      in: header
+      description: Admin API key
+
+  schemas:
+    ResourceRequest:
+      type: object
+      required:
+        - type
+        - amount
+        - target
+      properties:
+        type:
+          type: string
+          enum:
+            - typeA
+            - typeB
+          description: Resource type
+        amount:
+          type: object
+          required:
+            - value
+          properties:
+            value:
+              type: number
+              format: double
+              minimum: 1
+              description: Amount value
+        target:
+          type: string
+          description: Target identifier
+
+    ResourceResponse:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+          description: Resource identifier

--- a/packages/cli/register/src/ir-to-fdr-converter/__test__/openapi-from-flag.test.ts
+++ b/packages/cli/register/src/ir-to-fdr-converter/__test__/openapi-from-flag.test.ts
@@ -2413,9 +2413,10 @@ describe("OpenAPI v3 Parser Pipeline (--from-openapi flag)", () => {
     });
 
     it("should populate examples with the first available auth scheme from endpoint security", async () => {
-        // Test that when an endpoint has multiple auth options (e.g., admin OR operator),
-        // the generated examples should use the first available auth scheme (admin),
-        // not the first globally defined auth scheme or an incorrect scheme.
+        // Bug reproduction test: When an endpoint has multiple auth options (e.g., admin OR operator),
+        // the generated examples should use the first available auth scheme from the endpoint's
+        // security requirements (admin), not the first globally defined auth scheme or an incorrect scheme.
+        // See: https://app.devin.ai/sessions/9cf9fa77087045cda6bbf83fa5859f52
         const context = createMockTaskContext();
         const workspace = await loadAPIWorkspace({
             absolutePathToWorkspace: join(


### PR DESCRIPTION
## Description

Refs: N/A

Adds a test fixture to capture the current behavior of auth scheme selection in generated examples. This test demonstrates a bug where examples may not populate with the first available auth scheme from the endpoint's security requirements.

**Link to Devin run:** https://app.devin.ai/sessions/9cf9fa77087045cda6bbf83fa5859f52
**Requested by:** Sarah Bawabe (@sbawabe)

## Changes Made

- Added new test fixture `auth-scheme-example-selection` with an OpenAPI spec containing:
  - 3 security schemes: `user`, `operator`, `admin` (defined in that order)
  - An endpoint with security `[{admin: []}, {operator: []}]` (admin first, operator second)
- Added test case validating that `multiAuth` correctly reflects the endpoint's security order
- Generated FDR and IR snapshots for regression testing

## Testing

- [x] Unit tests added/updated
- [x] Test passes and generates expected snapshots

## Human Review Checklist

- [ ] **Verify bug demonstration**: The FDR snapshot shows `auth.headerWireValue: "x-user-token"` (the `user` scheme) at the top level, even though the endpoint only uses `admin` and `operator`. This may be the bug being captured - confirm this is the intended behavior to document.
- [ ] **Confirm test assertions match intent**: The test validates `multiAuth` order but doesn't explicitly assert that examples use the correct auth scheme. Verify this captures the bug sufficiently.
- [ ] **Obfuscation check**: Data has been obfuscated from the original swagger file (faucet → resource, coinflow → example.com, etc.)