### PR TITLE
chore(deps): upgrade posthog-node to v5.14.0

### DIFF
--- a/packages/cli/posthog-manager/package.json
+++ b/packages/cli/posthog-manager/package.json
@@ -36,7 +36,7 @@
     "@fern-api/core": "workspace:*",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/task-context": "workspace:*",
-    "posthog-node": "^4.2.1",
+    "posthog-node": "^5.14.0",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6641,8 +6641,8 @@ importers:
         specifier: workspace:*
         version: link:../task-context
       posthog-node:
-        specifier: ^4.2.1
-        version: 4.18.0
+        specifier: ^5.14.0
+        version: 5.17.4
       uuid:
         specifier: ^9.0.1
         version: 9.0.1
@@ -10371,6 +10371,9 @@ packages:
     resolution: {integrity: sha512-c83qWb22rNRuB0UaVCI0uRPNRr8Z0FWnEIvT47jiHAmOIUHbBOg5XvV7pM5x+rKn9HRpjxquDbXYSXr3fAKFcw==}
     engines: {node: '>=12'}
 
+  '@posthog/core@1.8.1':
+    resolution: {integrity: sha512-jfzBtQIk9auRi/biO+G/gumK5KxqsD5wOr7XpYMROE/I3pazjP4zIziinp21iQuIQJMXrDvwt9Af3njgOGwtew==}
+
   '@puppeteer/browsers@2.10.10':
     resolution: {integrity: sha512-3ZG500+ZeLql8rE0hjfhkycJjDj0pI/btEh3L9IkWUYcOrgP0xCNRq3HbtbqOPbvDhFaAWD88pDFtlLv8ns8gA==}
     engines: {node: '>=18'}
@@ -14093,9 +14096,9 @@ packages:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
-  posthog-node@4.18.0:
-    resolution: {integrity: sha512-XROs1h+DNatgKh/AlIlCtDxWzwrKdYDb2mOs58n4yN8BkGN9ewqeQwG5ApS4/IzwCb7HPttUkOVulkYatd2PIw==}
-    engines: {node: '>=15.0.0'}
+  posthog-node@5.17.4:
+    resolution: {integrity: sha512-hrd+Do/DMt40By12ESIDUfD81V9OASjq9XHjycZrGiD8cX/ZwCIVSJLUb7nQmvSCWcKII+u+nnPVuc4LjTDl9g==}
+    engines: {node: '>=20'}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -18424,6 +18427,10 @@ snapshots:
       '@pnpm/config.env-replace': 1.1.0
       '@pnpm/network.ca-file': 1.0.2
       config-chain: 1.1.13
+
+  '@posthog/core@1.8.1':
+    dependencies:
+      cross-spawn: 7.0.5
 
   '@puppeteer/browsers@2.10.10':
     dependencies:
@@ -23162,11 +23169,9 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  posthog-node@4.18.0:
+  posthog-node@5.17.4:
     dependencies:
-      axios: 1.12.2
-    transitivePeerDependencies:
-      - debug
+      '@posthog/core': 1.8.1
 
   prelude-ls@1.2.1: {}
 


### PR DESCRIPTION
## Description

Refs: Requested by @dannysheridan

Upgrades the `posthog-node` dependency from v4.x to v5.x to use the latest PostHog SDK version.

## Changes Made

- Updated `posthog-node` from `^4.2.1` to `^5.14.0` in `packages/cli/posthog-manager/package.json`
- Updated `pnpm-lock.yaml` (resolved version: 5.17.4)

## Testing

- [x] Lint checks pass (`pnpm run check`)
- [ ] Manual testing of PostHog analytics events

## Human Review Checklist

- [ ] Verify the posthog-node v5 API is backward compatible with current usage in `packages/cli/posthog-manager/src/`
- [ ] Confirm Node.js >=20 requirement (new in v5) aligns with project requirements
- [ ] Note: v5 replaces `axios` dependency with `@posthog/core`

---

Link to Devin run: https://app.devin.ai/sessions/a095347c811342689aaa0a97bf14db6f
Requested by: @dannysheridan