### PR TITLE
feat(cli): restart docs server on file changes in fern docs dev

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.27.1
+  changelogEntry:
+    - summary: |
+        Fix `fern docs dev` hot reload to properly restart the docs server when files change.
+      type: fix
+  createdAt: "2025-12-19"
+  irVersion: 62
+
 - version: 3.27.0
   changelogEntry:
     - summary: |

--- a/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
+++ b/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
@@ -12,6 +12,10 @@ import xml2js from "xml2js";
 const PLATFORM_IS_WINDOWS = process.platform === "win32";
 const DOCS_PREFIX = chalk.cyan("[docs]:");
 const ETAG_FILENAME = "etag";
+
+// Progress bar label alignment - pad labels to the longest one for consistent bar positioning
+const PROGRESS_LABEL_WIDTH = "Downloading docs bundle".length;
+const formatProgressLabel = (label: string): string => label.padEnd(PROGRESS_LABEL_WIDTH, " ");
 const PREVIEW_FOLDER_NAME = "preview";
 const APP_PREVIEW_FOLDER_NAME = "app-preview";
 const BUNDLE_FOLDER_NAME = "bundle";
@@ -180,7 +184,7 @@ export async function downloadBundle({
         let progressBar: cliProgress.SingleBar | undefined;
         if (app && totalBytes > 0) {
             progressBar = new cliProgress.SingleBar({
-                format: `${DOCS_PREFIX} Downloading docs bundle [{bar}] {percentage}% | {value}/{total} MB`,
+                format: `${DOCS_PREFIX} ${formatProgressLabel("Downloading docs bundle")} [{bar}] {percentage}% | {value}/{total} MB`,
                 barCompleteChar: "\u2588",
                 barIncompleteChar: "\u2591",
                 hideCursor: true
@@ -235,7 +239,7 @@ export async function downloadBundle({
 
         if (app) {
             unzipProgressBar = new cliProgress.SingleBar({
-                format: `${DOCS_PREFIX} Unzipping docs bundle [{bar}] {percentage}%`,
+                format: `${DOCS_PREFIX} ${formatProgressLabel("Unzipping docs bundle")} [{bar}] {percentage}%`,
                 barCompleteChar: "\u2588",
                 barIncompleteChar: "\u2591",
                 hideCursor: true

--- a/packages/cli/docs-preview/src/runAppPreviewServer.ts
+++ b/packages/cli/docs-preview/src/runAppPreviewServer.ts
@@ -860,8 +860,10 @@ export async function runAppPreviewServer({
                 context.logger.info("Restarting docs server...");
                 await restartNextJsServer();
 
-                // Wait 500ms for the server to be ready
-                await new Promise((resolve) => setTimeout(resolve, 500));
+                // Wait 1 second for the server to be ready
+                await new Promise((resolve) => setTimeout(resolve, 1000));
+
+                context.logger.info("Refreshing page. Please refresh manually if you don't see changes.");
 
                 sendData({
                     version: 1,

--- a/packages/cli/docs-preview/src/runAppPreviewServer.ts
+++ b/packages/cli/docs-preview/src/runAppPreviewServer.ts
@@ -860,6 +860,9 @@ export async function runAppPreviewServer({
                 context.logger.info("Restarting docs server...");
                 await restartNextJsServer();
 
+                // Wait 500ms for the server to be ready
+                await new Promise((resolve) => setTimeout(resolve, 500));
+
                 sendData({
                     version: 1,
                     type: "finishReload"

--- a/packages/cli/docs-preview/src/runAppPreviewServer.ts
+++ b/packages/cli/docs-preview/src/runAppPreviewServer.ts
@@ -856,19 +856,14 @@ export async function runAppPreviewServer({
 
                 editedAbsoluteFilepaths.length = 0;
 
-                // Restart the Next.js server
-                context.logger.info("Restarting Next.js server...");
+                // Restart the docs server
+                context.logger.info("Restarting docs server...");
                 await restartNextJsServer();
-
-                // Wait 3 seconds for the server to be fully ready before triggering refresh
-                context.logger.info("Waiting 3 seconds for server to be ready...");
-                await new Promise((resolve) => setTimeout(resolve, 3000));
 
                 sendData({
                     version: 1,
                     type: "finishReload"
                 });
-                context.logger.info("Reload complete. Refreshing browser...");
                 isReloading = false;
 
                 if (reloadedDocsDefinition != null) {


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of the changes made in this PR -->
Modifies `fern docs dev` to restart the docs server when file changes are detected, instead of just sending WebSocket messages to trigger a refresh. After restarting, waits 500ms before triggering the browser refresh.

Also fixes progress bar alignment in the docs bundle download output.

**Link to Devin run:** https://app.devin.ai/sessions/9c95c98f81aa4ebf9ac13ee8a3f68935
**Requested by:** Sandeep Dinesh (sandeep@buildwithfern.com) / @thesandlord

## Changes Made
- Refactored server startup logic into reusable `startNextJsServer()` function
- Added `stopNextJsServer()` function to gracefully terminate the server process (with force kill fallback after 1 second)
- Added `restartNextJsServer()` function that stops and starts the server
- Modified file watcher to call `restartNextJsServer()` when changes are detected
- Added 500ms delay after server restart before sending browser refresh signal
- Moved watcher event handler registration to after `restartNextJsServer` is defined (fixes race condition)
- Updated `serverProcess` to be nullable and added null checks in cleanup function
- Added visible info-level logging: "Restarting docs server..."
- Added `formatProgressLabel()` helper to align progress bars for "Downloading docs bundle" and "Unzipping docs bundle"
- Added changelog entry (v3.27.1) for the hot reload fix
- [ ] Updated README.md generator (if applicable)

## Testing
- [ ] Unit tests added/updated
- [ ] Manual testing completed

**Note:** This change requires manual testing by running `fern docs dev` and making file changes to verify the server restarts correctly.

## Human Review Checklist
- [ ] Check that rapid file changes don't cause issues (the `isReloading` flag should prevent this)
- [ ] Confirm process cleanup handles edge cases (server already killed, startup failures)
- [ ] Verify progress bars now align correctly in terminal output
- [ ] Confirm the watcher event handler placement after function definitions prevents the race condition
- [ ] Verify the 10-second fallback timeout in `startNextJsServer` is appropriate if "Ready" message is missed
- [ ] Verify 500ms delay is sufficient for server to be ready before browser refresh

https://www.loom.com/share/df3fd2415174425aade7c0bdbd63e51c