### PR TITLE
feat(go): add request scoping to wire tests using X-Test-Id header

### DIFF
--- a/generators/go-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/go-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -299,7 +299,7 @@ export class EndpointSnippetGenerator {
     }
 
     private getWiremockTestConstructorArgs(): go.AstNode[] {
-        const args: go.AstNode[] = [
+        return [
             go.codeblock((writer) => {
                 writer.writeNode(
                     go.invokeFunc({
@@ -310,11 +310,7 @@ export class EndpointSnippetGenerator {
                         arguments_: [go.codeblock(WIREMOCK_BASE_URL)]
                     })
                 );
-            })
-        ];
-
-        // Add X-Test-Id header for request scoping in concurrent test execution
-        args.push(
+            }),
             go.codeblock((writer) => {
                 writer.writeNode(
                     go.invokeFunc({
@@ -322,15 +318,11 @@ export class EndpointSnippetGenerator {
                             name: "WithHTTPHeader",
                             importPath: this.context.getOptionImportPath()
                         }),
-                        arguments_: [
-                            go.codeblock(`http.Header{"X-Test-Id": []string{"TEST-ID-PLACEHOLDER"}}`)
-                        ]
+                        arguments_: [go.codeblock(`http.Header{"X-Test-Id": []string{"TEST-ID-PLACEHOLDER"}}`)]
                     })
                 );
             })
-        );
-
-        return args;
+        ];
     }
 
     private getConstructorAuthArg({

--- a/generators/go-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/go-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -150,7 +150,9 @@ export class EndpointSnippetGenerator {
                         writer.writeLine();
                         writer.writeNode(this.constructWiremockTestClient({ endpoint, snippet }));
                         writer.writeLine();
-                        writer.writeNode(this.callClientMethodAndAssert({ endpoint, snippet }));
+                        writer.writeNode(
+                            this.callClientMethodAndAssert({ endpoint, snippet, includeTestIdHeader: true })
+                        );
                     })
                 })
             );
@@ -211,13 +213,30 @@ export class EndpointSnippetGenerator {
     private writeMethodInvocation({
         writer,
         endpoint,
-        snippet
+        snippet,
+        includeTestIdHeader
     }: {
         writer: go.Writer;
         endpoint: FernIr.dynamic.Endpoint;
         snippet: FernIr.dynamic.EndpointSnippetRequest;
+        includeTestIdHeader?: boolean;
     }): void {
         const { otherArgs, requestArg } = this.getMethodArgs({ endpoint, snippet });
+        const optionArgsInvocation = includeTestIdHeader
+            ? [
+                  go.codeblock((writer) => {
+                      writer.writeNode(
+                          go.invokeFunc({
+                              func: go.typeReference({
+                                  name: "WithHTTPHeader",
+                                  importPath: this.context.getOptionImportPath()
+                              }),
+                              arguments_: [go.codeblock(`http.Header{"X-Test-Id": []string{"TEST-ID-PLACEHOLDER"}}`)]
+                          })
+                      );
+                  })
+              ]
+            : [];
 
         if (requestArg != null) {
             if (requestArg instanceof go.TypeInstantiation && go.TypeInstantiation.isNop(requestArg)) {
@@ -238,7 +257,12 @@ export class EndpointSnippetGenerator {
                     go.invokeMethod({
                         on: go.codeblock(CLIENT_VAR_NAME),
                         method: this.getMethod({ endpoint }),
-                        arguments_: [this.context.getContextTodoFunctionInvocation(), ...otherArgs, requestRef]
+                        arguments_: [
+                            this.context.getContextTodoFunctionInvocation(),
+                            ...otherArgs,
+                            requestRef,
+                            ...optionArgsInvocation
+                        ]
                     })
                 );
             }
@@ -247,7 +271,7 @@ export class EndpointSnippetGenerator {
                 go.invokeMethod({
                     on: go.codeblock(CLIENT_VAR_NAME),
                     method: this.getMethod({ endpoint }),
-                    arguments_: [this.context.getContextTodoFunctionInvocation(), ...otherArgs]
+                    arguments_: [this.context.getContextTodoFunctionInvocation(), ...otherArgs, ...optionArgsInvocation]
                 })
             );
         }
@@ -308,17 +332,6 @@ export class EndpointSnippetGenerator {
                             importPath: this.context.getOptionImportPath()
                         }),
                         arguments_: [go.codeblock(WIREMOCK_BASE_URL)]
-                    })
-                );
-            }),
-            go.codeblock((writer) => {
-                writer.writeNode(
-                    go.invokeFunc({
-                        func: go.typeReference({
-                            name: "WithHTTPHeader",
-                            importPath: this.context.getOptionImportPath()
-                        }),
-                        arguments_: [go.codeblock(`http.Header{"X-Test-Id": []string{"TEST-ID-PLACEHOLDER"}}`)]
                     })
                 );
             })
@@ -999,10 +1012,12 @@ export class EndpointSnippetGenerator {
 
     private callClientMethodAndAssert({
         endpoint,
-        snippet
+        snippet,
+        includeTestIdHeader
     }: {
         endpoint: FernIr.dynamic.Endpoint;
         snippet: FernIr.dynamic.EndpointSnippetRequest;
+        includeTestIdHeader?: boolean;
     }): go.CodeBlock {
         return go.codeblock((writer) => {
             // IMPORTANT: currently not capturing the response/error values since its not trivial to determine
@@ -1010,7 +1025,7 @@ export class EndpointSnippetGenerator {
 
             // Call the method and capture response and error
             // writer.write("_, invocationErr := ");
-            this.writeMethodInvocation({ writer, endpoint, snippet });
+            this.writeMethodInvocation({ writer, endpoint, snippet, includeTestIdHeader: true });
             writer.writeLine();
             writer.writeLine();
 

--- a/generators/go-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/go-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -299,7 +299,7 @@ export class EndpointSnippetGenerator {
     }
 
     private getWiremockTestConstructorArgs(): go.AstNode[] {
-        return [
+        const args: go.AstNode[] = [
             go.codeblock((writer) => {
                 writer.writeNode(
                     go.invokeFunc({
@@ -312,6 +312,25 @@ export class EndpointSnippetGenerator {
                 );
             })
         ];
+
+        // Add X-Test-Id header for request scoping in concurrent test execution
+        args.push(
+            go.codeblock((writer) => {
+                writer.writeNode(
+                    go.invokeFunc({
+                        func: go.typeReference({
+                            name: "WithHTTPHeader",
+                            importPath: this.context.getOptionImportPath()
+                        }),
+                        arguments_: [
+                            go.codeblock(`http.Header{"X-Test-Id": []string{"TEST-ID-PLACEHOLDER"}}`)
+                        ]
+                    })
+                );
+            })
+        );
+
+        return args;
     }
 
     private getConstructorAuthArg({

--- a/generators/go-v2/sdk/src/wire-tests/WireTestGenerator.ts
+++ b/generators/go-v2/sdk/src/wire-tests/WireTestGenerator.ts
@@ -160,35 +160,10 @@ export class WireTestGenerator {
             }
             writer.writeNewLineIfLastLineNot();
             writer.newLine();
-            writer.write(
-                go.func({
-                    name: "ResetWireMockRequests",
-                    parameters: [
-                        go.parameter({
-                            name: "t",
-                            type: go.Type.pointer(go.Type.reference(this.context.getTestingTypeReference()))
-                        })
-                    ],
-                    return_: [],
-                    body: go.codeblock((writer) => {
-                        writer.writeNode(go.codeblock('WiremockAdminURL := "http://localhost:8080/__admin"'));
-                        writer.newLine();
-                        writer.writeNode(
-                            go.codeblock(
-                                '_, err := http.Post(WiremockAdminURL+"/requests/reset", "application/json", nil)'
-                            )
-                        );
-                        writer.newLine();
-                        writer.writeNode(go.codeblock("require.NoError(t, err)"));
-                        writer.newLine();
-                    })
-                })
-            );
 
             // Uses the requests/find endpoint for more flexible matching based on query parameters and base URL
             // This allows proper matching even when SDKs reorder query parameters alphabetically
-            writer.writeNewLineIfLastLineNot();
-            writer.newLine();
+            // Filters by X-Test-Id header to scope assertions to specific tests for concurrency safety
             this.writeVerifyRequestCount(writer);
             writer.writeNewLineIfLastLineNot();
             writer.newLine();
@@ -226,6 +201,10 @@ export class WireTestGenerator {
                         type: go.Type.pointer(go.Type.reference(this.context.getTestingTypeReference()))
                     }),
                     go.parameter({
+                        name: "testId",
+                        type: go.Type.string()
+                    }),
+                    go.parameter({
                         name: "method",
                         type: go.Type.string()
                     }),
@@ -245,6 +224,7 @@ export class WireTestGenerator {
                 return_: [],
                 body: go.codeblock((writer) => {
                     // Build the request body for WireMock's requests/find endpoint
+                    // Includes X-Test-Id header filtering for concurrency safety
                     writer.writeNode(go.codeblock('WiremockAdminURL := "http://localhost:8080/__admin"'));
                     writer.newLine();
                     writer.writeNode(go.codeblock("var reqBody bytes.Buffer"));
@@ -257,7 +237,11 @@ export class WireTestGenerator {
                     writer.newLine();
                     writer.writeNode(go.codeblock("reqBody.WriteString(urlPath)"));
                     writer.newLine();
-                    writer.writeNode(go.codeblock('reqBody.WriteString(`"}`)'));
+                    writer.writeNode(go.codeblock('reqBody.WriteString(`","headers":{"X-Test-Id":{"equalTo":"`)'));
+                    writer.newLine();
+                    writer.writeNode(go.codeblock("reqBody.WriteString(testId)"));
+                    writer.newLine();
+                    writer.writeNode(go.codeblock('reqBody.WriteString(`"}}`)'));
                     writer.newLine();
                     writer.writeNode(go.codeblock("if len(queryParams) > 0 {"));
                     writer.newLine();
@@ -290,6 +274,8 @@ export class WireTestGenerator {
                     writer.writeNode(go.codeblock('    reqBody.WriteString("}")'));
                     writer.newLine();
                     writer.writeNode(go.codeblock("}"));
+                    writer.newLine();
+                    writer.writeNode(go.codeblock('reqBody.WriteString("}")'));
                     writer.newLine();
                     writer.writeNode(
                         go.codeblock(
@@ -339,13 +325,11 @@ export class WireTestGenerator {
                     ],
                     return_: [],
                     body: go.codeblock((writer) => {
-                        writer.writeNode(go.codeblock(`ResetWireMockRequests(t)`));
-                        writer.newLine();
                         writer.writeNode(go.codeblock('WireMockBaseURL := "http://localhost:8080"'));
                         writer.newLine();
-                        writer.writeNode(this.constructWiremockTestClient({ endpoint, snippet }));
+                        writer.writeNode(this.constructWiremockTestClient({ endpoint, snippet, testFunctionName }));
                         writer.newLine();
-                        writer.writeNode(this.callClientMethodAndAssert({ endpoint, snippet }));
+                        writer.writeNode(this.callClientMethodAndAssert({ endpoint, snippet, testFunctionName }));
                     })
                 })
             );
@@ -567,13 +551,16 @@ export class WireTestGenerator {
 
     private constructWiremockTestClient({
         endpoint,
-        snippet
+        snippet,
+        testFunctionName
     }: {
         endpoint: HttpEndpoint;
         snippet: string;
+        testFunctionName: string;
     }): go.CodeBlock {
-        const clientConstructor = this.parseClientConstructor(snippet);
-
+        // The dynamic snippets generator includes the X-Test-Id header with a placeholder.
+        // Replace the placeholder with the actual unique test function name.
+        const clientConstructor = this.parseClientConstructor(snippet).replace(`"X-Test-Id": []string{"TEST-ID-PLACEHOLDER"}`, `"X-Test-Id": []string{"${testFunctionName}"}`);
         return go.codeblock((writer) => {
             writer.write(clientConstructor);
         });
@@ -581,10 +568,12 @@ export class WireTestGenerator {
 
     private callClientMethodAndAssert({
         endpoint,
-        snippet
+        snippet,
+        testFunctionName
     }: {
         endpoint: HttpEndpoint;
         snippet: string;
+        testFunctionName: string;
     }): go.CodeBlock {
         const requestBodyInstantiation = this.parseRequestBodyInstantiation(snippet);
         const clientCall = this.parseClientCallFromSnippet(snippet);
@@ -628,7 +617,9 @@ export class WireTestGenerator {
             const queryParamsMap = this.buildQueryParamsMap(endpoint);
 
             writer.writeNode(
-                go.codeblock(`VerifyRequestCount(t, "${endpoint.method}", "${basePath}", ${queryParamsMap}, 1)`)
+                go.codeblock(
+                    `VerifyRequestCount(t, "${testFunctionName}", "${endpoint.method}", "${basePath}", ${queryParamsMap}, 1)`
+                )
             );
 
             writer.writeLine();

--- a/generators/go-v2/sdk/src/wire-tests/WireTestGenerator.ts
+++ b/generators/go-v2/sdk/src/wire-tests/WireTestGenerator.ts
@@ -560,7 +560,10 @@ export class WireTestGenerator {
     }): go.CodeBlock {
         // The dynamic snippets generator includes the X-Test-Id header with a placeholder.
         // Replace the placeholder with the actual unique test function name.
-        const clientConstructor = this.parseClientConstructor(snippet).replace(`"X-Test-Id": []string{"TEST-ID-PLACEHOLDER"}`, `"X-Test-Id": []string{"${testFunctionName}"}`);
+        const clientConstructor = this.parseClientConstructor(snippet).replace(
+            `"X-Test-Id": []string{"TEST-ID-PLACEHOLDER"}`,
+            `"X-Test-Id": []string{"${testFunctionName}"}`
+        );
         return go.codeblock((writer) => {
             writer.write(clientConstructor);
         });

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,5 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.21.8
+  changelogEntry:
+    - summary: |
+        Add request scoping to wire tests using X-Test-Id header. Each test now sends a unique
+        header that is used to filter WireMock request verification, enabling safe concurrent
+        test execution without interference between tests.
+      type: feat
+  createdAt: "2025-12-18"
+  irVersion: 60
+
 - version: 1.21.7
   changelogEntry:
     - summary: Fix nil check in caller

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -6,7 +6,7 @@
         Add request scoping to wire tests using X-Test-Id header. Each test now sends a unique
         header that is used to filter WireMock request verification, enabling safe concurrent
         test execution without interference between tests.
-      type: feat
+      type: fix
   createdAt: "2025-12-18"
   irVersion: 60
 

--- a/seed/go-sdk/imdb/with-wiremock-tests/imdb/imdb_test/imdb_test.go
+++ b/seed/go-sdk/imdb/with-wiremock-tests/imdb/imdb_test/imdb_test.go
@@ -65,9 +65,6 @@ func TestImdbCreateMovieWithWireMock(
 		option.WithBaseURL(
 			WireMockBaseURL,
 		),
-		option.WithHTTPHeader(
-			http.Header{"X-Test-Id": []string{"TestImdbCreateMovieWithWireMock"}},
-		),
 	)
 	request := &testPackageName.CreateMovieRequest{
 		Title:  "title",
@@ -76,6 +73,9 @@ func TestImdbCreateMovieWithWireMock(
 	_, invocationErr := client.Imdb.CreateMovie(
 		context.TODO(),
 		request,
+		option.WithHTTPHeader(
+			http.Header{"X-Test-Id": []string{"TestImdbCreateMovieWithWireMock"}},
+		),
 	)
 
 	require.NoError(t, invocationErr, "Client method call should succeed")
@@ -90,13 +90,13 @@ func TestImdbGetMovieWithWireMock(
 		option.WithBaseURL(
 			WireMockBaseURL,
 		),
-		option.WithHTTPHeader(
-			http.Header{"X-Test-Id": []string{"TestImdbGetMovieWithWireMock"}},
-		),
 	)
 	_, invocationErr := client.Imdb.GetMovie(
 		context.TODO(),
 		"movieId",
+		option.WithHTTPHeader(
+			http.Header{"X-Test-Id": []string{"TestImdbGetMovieWithWireMock"}},
+		),
 	)
 
 	require.NoError(t, invocationErr, "Client method call should succeed")


### PR DESCRIPTION
Each wire test now sends a unique X-Test-Id header that is used to filter WireMock request verification, enabling safe concurrent test execution without interference between tests.

Changes:
- Add X-Test-Id header to client constructor in dynamic snippets
- Update VerifyRequestCount to filter by test ID header
- Remove ResetWireMockRequests which is no longer needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)