### PR TITLE
fix(java): Ensure custom headers are included in getToken requests for Oauth2 clients

### DIFF
--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/ClientOptionsGenerator.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/ClientOptionsGenerator.java
@@ -895,13 +895,15 @@ public final class ClientOptionsGenerator extends AbstractFileGenerator {
                 .addJavadoc("Create a new Builder initialized with values from an existing ClientOptions")
                 .addStatement("$T builder = new $T()", builderClassName, builderClassName)
                 .addStatement("builder.$L = clientOptions.$L()", environmentField.name, environmentField.name)
-                // We can only copy what's accessible via public methods so we can't get headers directly
                 .addStatement(
                         "builder.$L = $T.of(clientOptions.$L(null))",
                         TIMEOUT_FIELD.name,
                         Optional.class,
                         TIMEOUT_FIELD.name)
-                .addStatement("builder.$L = clientOptions.$L()", OKHTTP_CLIENT_FIELD.name, OKHTTP_CLIENT_FIELD.name);
+                .addStatement("builder.$L = clientOptions.$L()", OKHTTP_CLIENT_FIELD.name, OKHTTP_CLIENT_FIELD.name)
+                .addStatement("builder.$L.putAll(clientOptions.$L)", HEADERS_FIELD.name, HEADERS_FIELD.name)
+                .addStatement("builder.$L.putAll(clientOptions.$L)", HEADER_SUPPLIERS_FIELD.name, HEADER_SUPPLIERS_FIELD.name)
+                .addStatement("builder.$L = clientOptions.$L()", MAX_RETRIES_FIELD.name, MAX_RETRIES_FIELD.name);
 
         for (Map.Entry<VariableId, FieldSpec> entry : variableFields.entrySet()) {
             MethodSpec getter = variableGetters.get(entry.getKey());

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/ClientOptionsGenerator.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/ClientOptionsGenerator.java
@@ -902,7 +902,8 @@ public final class ClientOptionsGenerator extends AbstractFileGenerator {
                         TIMEOUT_FIELD.name)
                 .addStatement("builder.$L = clientOptions.$L()", OKHTTP_CLIENT_FIELD.name, OKHTTP_CLIENT_FIELD.name)
                 .addStatement("builder.$L.putAll(clientOptions.$L)", HEADERS_FIELD.name, HEADERS_FIELD.name)
-                .addStatement("builder.$L.putAll(clientOptions.$L)", HEADER_SUPPLIERS_FIELD.name, HEADER_SUPPLIERS_FIELD.name)
+                .addStatement(
+                        "builder.$L.putAll(clientOptions.$L)", HEADER_SUPPLIERS_FIELD.name, HEADER_SUPPLIERS_FIELD.name)
                 .addStatement("builder.$L = clientOptions.$L()", MAX_RETRIES_FIELD.name, MAX_RETRIES_FIELD.name);
 
         for (Map.Entry<VariableId, FieldSpec> entry : variableFields.entrySet()) {

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/OAuthTokenSupplierGenerator.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/OAuthTokenSupplierGenerator.java
@@ -302,18 +302,18 @@ public class OAuthTokenSupplierGenerator extends AbstractFileGenerator {
             String clientSecretPropertyName,
             List<Map.Entry<String, String>> customPropertiesWithNames,
             HttpEndpoint httpEndpoint) {
-        // Custom properties (headers) must come BEFORE clientId/clientSecret for staged builders
+        // Required properties (clientId/clientSecret) must come first for staged builders,
+        // followed by optional custom properties (like scope) which are in _FinalStage
         CodeBlock.Builder requestBuilderCode = CodeBlock.builder()
-                .add("$T $L = $T.builder()", fetchTokenRequestType, GET_TOKEN_REQUEST_NAME, fetchTokenRequestType);
+                .add("$T $L = $T.builder()", fetchTokenRequestType, GET_TOKEN_REQUEST_NAME, fetchTokenRequestType)
+                .add(".$L($L)", clientIdPropertyName, CLIENT_ID_FIELD_NAME)
+                .add(".$L($L)", clientSecretPropertyName, CLIENT_SECRET_FIELD_NAME);
 
         for (Map.Entry<String, String> customProp : customPropertiesWithNames) {
             requestBuilderCode.add(".$L($L)", customProp.getValue(), customProp.getKey());
         }
 
-        requestBuilderCode
-                .add(".$L($L)", clientIdPropertyName, CLIENT_ID_FIELD_NAME)
-                .add(".$L($L)", clientSecretPropertyName, CLIENT_SECRET_FIELD_NAME)
-                .add(".build()");
+        requestBuilderCode.add(".build()");
 
         return MethodSpec.methodBuilder(FETCH_TOKEN_METHOD_NAME)
                 .addModifiers(Modifier.PUBLIC)

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 3.27.4
+  changelogEntry:
+    - summary: |
+        Fix OAuth client credentials flow to include custom headers, timeouts, and retries in token requests by using ClientOptions.Builder.from() pattern.
+      type: fix
+  createdAt: "2025-12-18"
+  irVersion: 61
+
 - version: 3.27.3
   changelogEntry:
     - summary: |

--- a/seed/java-sdk/oauth-client-credentials/oauth-client-credentials/src/main/java/com/seed/oauthClientCredentials/AsyncSeedOauthClientCredentialsClientBuilder.java
+++ b/seed/java-sdk/oauth-client-credentials/oauth-client-credentials/src/main/java/com/seed/oauthClientCredentials/AsyncSeedOauthClientCredentialsClientBuilder.java
@@ -238,13 +238,16 @@ public class AsyncSeedOauthClientCredentialsClientBuilder {
         }
 
         @Override
-        protected void setAuthentication(ClientOptions.Builder builder) {
-            ClientOptions.Builder authClientOptionsBuilder =
-                    ClientOptions.builder().environment(this.environment);
-            AuthClient authClient = new AuthClient(authClientOptionsBuilder.build());
+        public AsyncSeedOauthClientCredentialsClient build() {
+            validateConfiguration();
+            ClientOptions baseOptions = buildClientOptions();
+            AuthClient authClient = new AuthClient(baseOptions);
             OAuthTokenSupplier oAuthTokenSupplier =
                     new OAuthTokenSupplier(this.clientId, this.clientSecret, this.scope, authClient);
-            builder.addHeader("Authorization", oAuthTokenSupplier);
+            ClientOptions finalOptions = ClientOptions.Builder.from(baseOptions)
+                    .addHeader("Authorization", oAuthTokenSupplier)
+                    .build();
+            return new AsyncSeedOauthClientCredentialsClient(finalOptions);
         }
     }
 }

--- a/seed/java-sdk/oauth-client-credentials/oauth-client-credentials/src/main/java/com/seed/oauthClientCredentials/SeedOauthClientCredentialsClientBuilder.java
+++ b/seed/java-sdk/oauth-client-credentials/oauth-client-credentials/src/main/java/com/seed/oauthClientCredentials/SeedOauthClientCredentialsClientBuilder.java
@@ -238,13 +238,16 @@ public class SeedOauthClientCredentialsClientBuilder {
         }
 
         @Override
-        protected void setAuthentication(ClientOptions.Builder builder) {
-            ClientOptions.Builder authClientOptionsBuilder =
-                    ClientOptions.builder().environment(this.environment);
-            AuthClient authClient = new AuthClient(authClientOptionsBuilder.build());
+        public SeedOauthClientCredentialsClient build() {
+            validateConfiguration();
+            ClientOptions baseOptions = buildClientOptions();
+            AuthClient authClient = new AuthClient(baseOptions);
             OAuthTokenSupplier oAuthTokenSupplier =
                     new OAuthTokenSupplier(this.clientId, this.clientSecret, this.scope, authClient);
-            builder.addHeader("Authorization", oAuthTokenSupplier);
+            ClientOptions finalOptions = ClientOptions.Builder.from(baseOptions)
+                    .addHeader("Authorization", oAuthTokenSupplier)
+                    .build();
+            return new SeedOauthClientCredentialsClient(finalOptions);
         }
     }
 }

--- a/seed/java-sdk/oauth-client-credentials/oauth-client-credentials/src/main/java/com/seed/oauthClientCredentials/core/ClientOptions.java
+++ b/seed/java-sdk/oauth-client-credentials/oauth-client-credentials/src/main/java/com/seed/oauthClientCredentials/core/ClientOptions.java
@@ -183,6 +183,9 @@ public final class ClientOptions {
             builder.environment = clientOptions.environment();
             builder.timeout = Optional.of(clientOptions.timeout(null));
             builder.httpClient = clientOptions.httpClient();
+            builder.headers.putAll(clientOptions.headers);
+            builder.headerSuppliers.putAll(clientOptions.headerSuppliers);
+            builder.maxRetries = clientOptions.maxRetries();
             return builder;
         }
     }

--- a/seed/java-sdk/oauth-client-credentials/oauth-client-credentials/src/main/java/com/seed/oauthClientCredentials/core/OAuthTokenSupplier.java
+++ b/seed/java-sdk/oauth-client-credentials/oauth-client-credentials/src/main/java/com/seed/oauthClientCredentials/core/OAuthTokenSupplier.java
@@ -35,9 +35,9 @@ public final class OAuthTokenSupplier implements Supplier<String> {
 
     public TokenResponse fetchToken() {
         GetTokenRequest getTokenRequest = GetTokenRequest.builder()
-                .scope(scope)
                 .clientId(clientId)
                 .clientSecret(clientSecret)
+                .scope(scope)
                 .build();
         return authClient.getTokenWithClientCredentials(getTokenRequest);
     }


### PR DESCRIPTION
## Description
When using OAuth client credentials authentication, custom headers and configuration options (like timeouts and retries) were not being passed to the AuthClient used for token requests. This meant that getToken requests would fail if the API required custom headers for authentication.

## Changes Made
- **OAuthTokenSupplier**: Fixed staged builder method call order so `clientId`/`clientSecret` come before optional properties like `scope` (required by the staged builder pattern)
- **ClientOptions.Builder.from()**: Added missing property copying for `headers`, `headerSuppliers`, and `maxRetries` so the full configuration is preserved when creating derived options
- **_CredentialsAuth.build()**: Changed from overriding `setAuthentication()` to overriding `build()` - now builds full ClientOptions first, creates AuthClient with those options, then uses `Builder.from()` to add the Authorization header while preserving all configuration

## Testing
- [x] Seed test `oauth-client-credentials` fixture passes
- [x] Generated code compiles and matches expected output