### PR TITLE
fix(cli): normalize instance URL for matching in fern generate --docs --instance

### DIFF
--- a/packages/cli/cli/src/commands/generate/generateDocsWorkspace.ts
+++ b/packages/cli/cli/src/commands/generate/generateDocsWorkspace.ts
@@ -1,5 +1,5 @@
 import { createOrganizationIfDoesNotExist, FernToken, FernUserToken } from "@fern-api/auth";
-import { filterOssWorkspaces } from "@fern-api/docs-resolver";
+import { filterOssWorkspaces, wrapWithHttps } from "@fern-api/docs-resolver";
 import { Rules } from "@fern-api/docs-validator";
 import { askToLogin } from "@fern-api/login";
 import { Project } from "@fern-api/project-loader";
@@ -40,7 +40,7 @@ export async function generateDocsWorkspace({
 
     if (!preview && !isCI() && !noPrompt) {
         const productionUrl = instance ?? docsWorkspace.config.instances[0]?.url;
-        const urlDisplay = productionUrl ? ` (${chalk.cyan(`https://${productionUrl}`)})` : "";
+        const urlDisplay = productionUrl ? ` (${chalk.cyan(wrapWithHttps(productionUrl))})` : "";
 
         const shouldContinue = await cliContext.confirmPrompt(
             `This will affect a production site${urlDisplay}. Run with --preview to generate docs for a preview instance.\n${chalk.yellow("?")} Are you sure you want to continue?`,

--- a/packages/cli/docs-resolver/src/index.ts
+++ b/packages/cli/docs-resolver/src/index.ts
@@ -1,4 +1,5 @@
 export { DocsDefinitionResolver, type UploadedFile } from "./DocsDefinitionResolver";
+export { normalizeInstanceUrl } from "./normalizeInstanceUrl";
 export { convertIrToApiDefinition } from "./utils/convertIrToApiDefinition";
 export { filterOssWorkspaces } from "./utils/filterOssWorkspaces";
 export { generateFdrFromOpenApiWorkspaceV3 } from "./utils/generateFdrFromOpenAPIWorkspaceV3";

--- a/packages/cli/docs-resolver/src/normalizeInstanceUrl.ts
+++ b/packages/cli/docs-resolver/src/normalizeInstanceUrl.ts
@@ -1,0 +1,61 @@
+/**
+ * Normalizes an instance URL for comparison by:
+ * - Stripping https:// and http:// prefixes (case-insensitive)
+ * - Lowercasing the host portion (domains are case-insensitive)
+ * - Preserving the path portion (paths can be case-sensitive)
+ * - Removing trailing slash (except for root path)
+ * - Trimming whitespace
+ *
+ * Examples:
+ * - "https://docs.example.com" -> "docs.example.com"
+ * - "HTTPS://Docs.Example.Com/path" -> "docs.example.com/path"
+ * - "docs.example.com/" -> "docs.example.com"
+ * - "docs.example.com/de/" -> "docs.example.com/de"
+ */
+export function normalizeInstanceUrl(url: string): string {
+    const trimmed = url.trim();
+
+    // Check if URL has a scheme (case-insensitive)
+    const schemeMatch = trimmed.match(/^(https?:\/\/)/i);
+
+    let urlWithoutScheme: string;
+    if (schemeMatch) {
+        urlWithoutScheme = trimmed.slice(schemeMatch[0].length);
+    } else {
+        urlWithoutScheme = trimmed;
+    }
+
+    // Split into host and path
+    const slashIndex = urlWithoutScheme.indexOf("/");
+    let host: string;
+    let path: string;
+
+    if (slashIndex === -1) {
+        host = urlWithoutScheme;
+        path = "";
+    } else {
+        host = urlWithoutScheme.slice(0, slashIndex);
+        path = urlWithoutScheme.slice(slashIndex);
+    }
+
+    // Lowercase the host (domains are case-insensitive)
+    const normalizedHost = host.toLowerCase();
+
+    // Remove trailing slash from path (except for root path "/")
+    let normalizedPath = path;
+    if (normalizedPath.length > 1 && normalizedPath.endsWith("/")) {
+        normalizedPath = normalizedPath.slice(0, -1);
+    }
+
+    // Remove query string and hash if present
+    const queryIndex = normalizedPath.indexOf("?");
+    if (queryIndex !== -1) {
+        normalizedPath = normalizedPath.slice(0, queryIndex);
+    }
+    const hashIndex = normalizedPath.indexOf("#");
+    if (hashIndex !== -1) {
+        normalizedPath = normalizedPath.slice(0, hashIndex);
+    }
+
+    return normalizedHost + normalizedPath;
+}


### PR DESCRIPTION
## Description

Refs: Customer support thread about docs generation confusion

Requested by: danny@buildwithfern.com (@dannysheridan)

[Link to Devin run](https://app.devin.ai/sessions/1ea0a6fa5f7f43f184d5a56236979e1b)

Fixes two issues with the `--instance` flag in `fern generate --docs`:

1. **https:// prefix requirement**: The CLI help says `--instance acme.docs.buildwithfern.com` (without https://), but if a user passed `--instance https://docs.example.com`, it wouldn't match because the comparison was an exact string match.

2. **Silent fallback to first instance**: When no match was found, the CLI silently fell back to the first instance without warning, potentially publishing to the wrong site.

## Changes Made

- Added `normalizeInstanceUrl` utility that strips scheme prefixes (case-insensitive), lowercases hosts, preserves paths, and removes trailing slashes
- Updated instance matching to use normalized URL comparison
- Added support for matching against `customDomain` entries (string or array)
- Removed silent fallback - now shows clear error with available instances when no match found
- Fixed display issue where `https://` was unconditionally prepended (would show `https://https://...` if user passed URL with scheme)
- [ ] Updated README.md generator (if applicable) - N/A

## Testing

- [ ] Unit tests added/updated
- [x] Manual lint check passed (`pnpm run check`)

## Human Review Checklist

- [ ] Verify `normalizeInstanceUrl` handles expected URL formats (with/without scheme, with paths like `/de`, trailing slashes, query strings)
- [ ] Confirm the behavior change (error instead of silent fallback) is acceptable - this is a breaking change for users who were relying on the fallback behavior
- [ ] Check that single-instance case (no `--instance` flag) still works correctly
- [ ] Verify custom domain matching works as expected (both string and array formats)