### PR TITLE
fix(python): support `x-fern-sdk-method-name` on AsyncAPI operations

### DIFF
--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -4,7 +4,7 @@
   changelogEntry:
     - summary: |
         Support custom `x-fern-sdk-method-name` on AsyncAPI operations.
-      type: feat
+      type: fix
   createdAt: "2025-12-19"
   irVersion: 62
 

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 4.46.6
+  changelogEntry:
+    - summary: |
+        Support custom `x-fern-sdk-method-name` on AsyncAPI operations.
+      type: feat
+  createdAt: "2025-12-19"
+  irVersion: 62
+
 - version: 4.46.5
   changelogEntry:
     - summary: |

--- a/generators/python/src/fern_python/generators/sdk/client_generator/socket_client_generator.py
+++ b/generators/python/src/fern_python/generators/sdk/client_generator/socket_client_generator.py
@@ -238,9 +238,7 @@ class SocketClientGenerator:
 
     def _get_send_message_method(self, message: ir_types.WebSocketMessage, is_async: bool) -> AST.FunctionDeclaration:
         # Use custom method_name if provided, otherwise default to send_{message_type}
-        method_name = (
-            snake_case(message.method_name) if message.method_name else f"send_{snake_case(message.type)}"
-        )
+        method_name = snake_case(message.method_name) if message.method_name else f"send_{snake_case(message.type)}"
 
         union = message.body.get_as_union()
         if not hasattr(union, "body_type"):

--- a/generators/python/src/fern_python/generators/sdk/client_generator/socket_client_generator.py
+++ b/generators/python/src/fern_python/generators/sdk/client_generator/socket_client_generator.py
@@ -237,11 +237,16 @@ class SocketClientGenerator:
         return _get_start_listening_method_body
 
     def _get_send_message_method(self, message: ir_types.WebSocketMessage, is_async: bool) -> AST.FunctionDeclaration:
+        # Use custom method_name if provided, otherwise default to send_{message_type}
+        method_name = (
+            snake_case(message.method_name) if message.method_name else f"send_{snake_case(message.type)}"
+        )
+
         union = message.body.get_as_union()
         if not hasattr(union, "body_type"):
             # Create a fallback for non-reference messages
             return AST.FunctionDeclaration(
-                name=f"send_{snake_case(message.type)}",
+                name=method_name,
                 is_async=is_async,
                 signature=AST.FunctionSignature(
                     parameters=[
@@ -259,7 +264,7 @@ class SocketClientGenerator:
         message_type = union.body_type
         message_type_hint = self._context.pydantic_generator_context.get_type_hint_for_type_reference(message_type)
         return AST.FunctionDeclaration(
-            name=f"send_{snake_case(message.type)}",
+            name=method_name,
             is_async=is_async,
             signature=AST.FunctionSignature(
                 parameters=[

--- a/generators/python/tests/utils/test_http_client.py
+++ b/generators/python/tests/utils/test_http_client.py
@@ -106,16 +106,12 @@ def test_explicit_empty_json_body_is_preserved() -> None:
     unrelated_request_options: RequestOptions = {"max_retries": 3}
 
     # Explicit json={} should be preserved
-    json_body, data_body = get_request_body(
-        json={}, data=None, request_options=unrelated_request_options, omit=None
-    )
+    json_body, data_body = get_request_body(json={}, data=None, request_options=unrelated_request_options, omit=None)
     assert json_body == {}
     assert data_body is None
 
     # Explicit data={} should also be preserved
-    json_body2, data_body2 = get_request_body(
-        json=None, data={}, request_options=unrelated_request_options, omit=None
-    )
+    json_body2, data_body2 = get_request_body(json=None, data={}, request_options=unrelated_request_options, omit=None)
     assert json_body2 is None
     assert data_body2 == {}
 

--- a/seed/python-sdk/seed.yml
+++ b/seed/python-sdk/seed.yml
@@ -1,4 +1,4 @@
-irVersion: v61
+irVersion: v62
 displayName: Python SDK
 image: fernapi/fern-python-sdk
 changelogLocation: ../../generators/python/sdk/versions.yml

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/realtime/socket_client.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/realtime/socket_client.py
@@ -68,7 +68,7 @@ class AsyncRealtimeSocketClient(EventEmitterMixin):
         """
         await self._send_model(message)
 
-    async def send_send_2(self, message: SendEvent2) -> None:
+    async def custom_send(self, message: SendEvent2) -> None:
         """
         Send a message to the websocket connection.
         The message will be sent as a SendEvent2.
@@ -142,7 +142,7 @@ class RealtimeSocketClient(EventEmitterMixin):
         """
         self._send_model(message)
 
-    def send_send_2(self, message: SendEvent2) -> None:
+    def custom_send(self, message: SendEvent2) -> None:
         """
         Send a message to the websocket connection.
         The message will be sent as a SendEvent2.

--- a/test-definitions/fern/apis/websocket/definition/realtime.yml
+++ b/test-definitions/fern/apis/websocket/definition/realtime.yml
@@ -20,6 +20,7 @@ channel:
       body: send_snake_case
     send2:
       display-name: Send2
+      method-name: custom_send
       origin: client
       body: SendEvent2
     receive:


### PR DESCRIPTION
## Description
Use `WebsocketMessage.methodName` from the IR to specify custom names for websocket methods when provided.

## Changes Made
Small change to websocket client generator.

## Testing
Change to `websocket` fixture that reflects in the output.
- [X] Unit tests added/updated
- [X] Manual testing completed
